### PR TITLE
Tooltip inverted color instead of mud

### DIFF
--- a/src/components/Tooltip/Tooltip.scss
+++ b/src/components/Tooltip/Tooltip.scss
@@ -37,8 +37,8 @@ $arrow-size-md: 16px;
 
 .monday-style-tooltip-dark,
 .monday-style-arrow-dark {
-  @include theme-prop(background-color, dark-color);
-  @include theme-prop(color, text-color-on-primary);
+  @include theme-prop(background-color, inverted-color-background);
+  @include theme-prop(color, text-color-on-inverted);
 }
 
 .monday-style-tooltip-white,


### PR DESCRIPTION
This is a change of the tooltip color to support dark theme.
It will know have the inverted-color-background instead of the mud background, So in dark theme the background can be light

#### Basic
- [V] PR has description
- [V] Changes to the component are backward compatible (including selectors structure). If not - add to the title of the PR "BREAKABLE_CHANGE""
- [V] All changes to the component are reflected in the ReadMe
- [V] If component is old and was not compliant with the latest guidelines - it was fixed (optional) 
#### Style
- [V] CSS selectors are named using [BEM convention](http://getbem.com/naming/) 
- [V] Design is compatible with [Monday Design System](https://design.monday.com/)
#### Storybook
- [V] All the changes to the component should be reflected in the Storybook.
- [V] Component passed Accessibility Plugin checks
#### Tests
- [V] All current tests are passing
- [V] New functionality is covered with tests
- [V] Tests are compliant with TESTING_README.md instructions


