### PR TITLE
fix: remove pointer-events: none, because it causes cursor: not-allow…

### DIFF
--- a/src/components/Button/Button.scss
+++ b/src/components/Button/Button.scss
@@ -139,7 +139,6 @@
           @include theme-prop(background-color, disabled-background-color);
           @include theme-prop(color, disabled-text-color);
           cursor: not-allowed;
-          pointer-events: none;
         }
       }
     }
@@ -209,7 +208,6 @@
         @include theme-prop(border-color, disabled-background-color);
         @include theme-prop(color, disabled-text-color);
         cursor: not-allowed;
-        pointer-events: none;
         &:hover {
           background-color: transparent;
         }
@@ -260,7 +258,6 @@
       &:disabled {
         @include theme-prop(color, disabled-text-color);
         cursor: not-allowed;
-        pointer-events: none;
         &:hover {
           background-color: transparent;
         }


### PR DESCRIPTION
Removing the pointer-events: none for disabled button, because with it the cursor: not-allowed doesn't really work and all disabled button have default cursor instead of the not allowed one.

### Updating existing component
#### Basic
- [x] PR has description
- [x] Changes to the component are backward compatible (including selectors structure). If not - add to the title of the PR "BREAKABLE_CHANGE""
- [x] All changes to the component are reflected in the ReadMe
- [ ] If component is old and was not compliant with the latest guidelines - it was fixed (optional) 
#### Style
- [x] CSS selectors are named using [BEM convention](http://getbem.com/naming/) 
- [x] Design is compatible with [Monday Design System](https://design.monday.com/)
#### Storybook
- [x] All the changes to the component should be reflected in the Storybook.
- [x] Component passed Accessibility Plugin checks
#### Tests
- [x] All current tests are passing
- [x] New functionality is covered with tests
- [x] Tests are compliant with TESTING_README.md instructions


