### PR TITLE
Feature/omer/menu document event listeners

### DIFF
--- a/src/components/Menu/Menu/Menu.jsx
+++ b/src/components/Menu/Menu/Menu.jsx
@@ -26,7 +26,8 @@ const Menu = forwardRef(
       onClose,
       focusOnMount,
       focusItemIndex,
-      isSubMenu
+      isSubMenu,
+      useDocumentEventListeners
     },
     forwardedRef
   ) => {
@@ -57,7 +58,7 @@ const Menu = forwardRef(
     const onCloseMenu = useOnCloseMenu(setActiveItemIndex, setOpenSubMenuIndex, onClose);
 
     useClickOutside({ ref, callback: onCloseMenu });
-    useCloseMenuOnKeyEvent(hasOpenSubMenu, onCloseMenu, ref, onClose, isSubMenu);
+    useCloseMenuOnKeyEvent(hasOpenSubMenu, onCloseMenu, ref, onClose, isSubMenu, useDocumentEventListeners);
     useMenuKeyboardNavigation(
       hasOpenSubMenu,
       children,
@@ -65,25 +66,26 @@ const Menu = forwardRef(
       setActiveItemIndex,
       isVisible,
       ref,
-      resetOpenSubMenuIndex
+      resetOpenSubMenuIndex,
+      useDocumentEventListeners
     );
     useMouseLeave(resetOpenSubMenuIndex, hasOpenSubMenu, ref, setActiveItemIndex);
 
     useLayoutEffect(() => {
-      if (hasOpenSubMenu) return;
+      if (hasOpenSubMenu || useDocumentEventListeners) return;
       if (activeItemIndex > -1) {
         requestAnimationFrame(() => {
           ref && ref.current && ref.current.focus();
         });
       }
-    }, [activeItemIndex, hasOpenSubMenu]);
+    }, [activeItemIndex, hasOpenSubMenu, useDocumentEventListeners]);
 
     useLayoutEffect(() => {
-      if (!focusOnMount) return;
+      if (!focusOnMount || useDocumentEventListeners) return;
       requestAnimationFrame(() => {
         ref && ref.current && ref.current.focus();
       });
-    }, [ref, focusOnMount]);
+    }, [ref, focusOnMount, useDocumentEventListeners]);
 
     const mergedRef = useMergeRefs({ refs: [ref, forwardedRef] });
 
@@ -119,7 +121,8 @@ const Menu = forwardRef(
               setSubMenuIsOpenByIndex,
               hasOpenSubMenu: index === openSubMenuIndex,
               closeMenu: onCloseMenu,
-              menuId: id
+              menuId: id,
+              useDocumentEventListeners
             });
           })}
       </ul>
@@ -142,7 +145,8 @@ Menu.defaultProps = {
   isVisible: true,
   onClose: undefined,
   focusItemIndex: -1,
-  isSubMenu: false
+  isSubMenu: false,
+  useDocumentEventListeners: false
 };
 
 Menu.propTypes = {
@@ -156,7 +160,8 @@ Menu.propTypes = {
   isVisible: PropTypes.bool,
   onClose: PropTypes.func,
   focusItemIndex: PropTypes.number,
-  isSubMenu: PropTypes.bool
+  isSubMenu: PropTypes.bool,
+  useDocumentEventListeners: PropTypes.bool
 };
 
 export default Menu;

--- a/src/components/Menu/Menu/__stories__/menu.stories.js
+++ b/src/components/Menu/Menu/__stories__/menu.stories.js
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect, useRef } from "react";
 import Menu from "../Menu";
 import { FlexLayout } from "../../../storybook-helpers";
 import { text, boolean, number, select } from "@storybook/addon-knobs";
@@ -192,6 +192,26 @@ export const Sizes = () => {
             {renderMenuItems()}
           </Menu>
         </StoryLine>
+      </FlexLayout>
+    </div>
+  );
+};
+
+export const menuKeyboardNavigationWithoutFocus = () => {
+  const inputRef = useRef();
+  useEffect(() => {
+    inputRef.current.focus();
+  }, [inputRef]);
+
+  return (
+    <div style={{ width: 700 }}>
+      <FlexLayout>
+        <form>
+          <input ref={inputRef} tabIndex={0} />
+        </form>
+        <Menu useDocumentEventListeners={true} id="menu" size={Menu.sizes.SMALL} tabIndex={0}>
+          {renderMenuItems()}
+        </Menu>
       </FlexLayout>
     </div>
   );

--- a/src/components/Menu/Menu/hooks/useCloseMenuOnKeyEvent.jsx
+++ b/src/components/Menu/Menu/hooks/useCloseMenuOnKeyEvent.jsx
@@ -3,7 +3,14 @@ import useKeyEvent from "../../../../hooks/useKeyEvent";
 
 const KEYS = ["Escape", "ArrowLeft"];
 
-export default function useCloseMenuOnKeyEvent(hasOpenSubMenu, onCloseMenu, ref, onClose, isSubMenu) {
+export default function useCloseMenuOnKeyEvent(
+  hasOpenSubMenu,
+  onCloseMenu,
+  ref,
+  onClose,
+  isSubMenu,
+  useDocumentEventListeners
+) {
   const onEscapeOrLeftArrowClick = useCallback(
     event => {
       const isArrowLeftClick = event.key === "ArrowLeft";
@@ -20,12 +27,12 @@ export default function useCloseMenuOnKeyEvent(hasOpenSubMenu, onCloseMenu, ref,
         event.stopPropagation();
       }
     },
-    [onClose, hasOpenSubMenu, onCloseMenu]
+    [onClose, hasOpenSubMenu, onCloseMenu, isSubMenu]
   );
 
   useKeyEvent({
     keys: KEYS,
     callback: onEscapeOrLeftArrowClick,
-    ref
+    ref: useDocumentEventListeners ? undefined : ref
   });
 }

--- a/src/components/Menu/Menu/hooks/useMenuKeyboardNavigation.jsx
+++ b/src/components/Menu/Menu/hooks/useMenuKeyboardNavigation.jsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect } from "react";
+import { useCallback, useMemo } from "react";
 import useKeyEvent from "../../../../hooks/useKeyEvent";
 
 const ARROW_DIRECTIONS = {
@@ -22,16 +22,13 @@ export default function useMenuKeyboardNavigation(
   setActiveItemIndex,
   isVisible,
   ref,
-  resetOpenSubMenuIndex
+  resetOpenSubMenuIndex,
+  useDocumentEventListeners
 ) {
   const onArrowKeyEvent = useCallback(
     direction => {
       let newIndex;
-      const refElement = ref && ref.current;
-      if (document.activeElement === refElement && hasOpenSubMenu) {
-        resetOpenSubMenuIndex(); // as a fallback for blur from sub menu and sub menu not closing
-        return;
-      }
+
       if (hasOpenSubMenu) return false;
 
       if (direction === ARROW_DIRECTIONS.DOWN) {
@@ -52,7 +49,7 @@ export default function useMenuKeyboardNavigation(
 
       if (newIndex || newIndex === 0) setActiveItemIndex(newIndex);
     },
-    [ref, activeItemIndex, children, hasOpenSubMenu, setActiveItemIndex, resetOpenSubMenuIndex]
+    [activeItemIndex, children, hasOpenSubMenu, setActiveItemIndex]
   );
   const onArrowUp = useCallback(() => {
     onArrowKeyEvent(ARROW_DIRECTIONS.UP);
@@ -73,27 +70,31 @@ export default function useMenuKeyboardNavigation(
     [setActiveItemIndex, activeItemIndex, isVisible]
   );
 
+  const listenerOptions = useMemo(() => {
+    if (useDocumentEventListeners) return undefined;
+
+    return {
+      ref,
+      preventDefault: true,
+      stopPropagation: true
+    };
+  }, [useDocumentEventListeners, ref]);
+
   useKeyEvent({
     keys: ARROW_DOWN_KEYS,
     callback: onArrowDown,
-    ref,
-    preventDefault: true,
-    stopPropagation: true
+    ...listenerOptions
   });
 
   useKeyEvent({
     keys: ARROW_UP_KEYS,
     callback: onArrowUp,
-    ref,
-    preventDefault: true,
-    stopPropagation: true
+    ...listenerOptions
   });
 
   useKeyEvent({
     keys: ENTER_KEYS,
     callback: onEnterClickCallback,
-    ref,
-    preventDefault: true,
-    stopPropagation: true
+    ...listenerOptions
   });
 }

--- a/src/components/Menu/MenuItem/MenuItem.jsx
+++ b/src/components/Menu/MenuItem/MenuItem.jsx
@@ -38,7 +38,8 @@ const MenuItem = ({
   resetOpenSubMenuIndex,
   hasOpenSubMenu,
   setSubMenuIsOpenByIndex,
-  closeMenu
+  closeMenu,
+  useDocumentEventListeners
 }) => {
   const isActive = activeItemIndex === index;
   const isSubMenuOpen = !!children && isActive && hasOpenSubMenu;
@@ -92,16 +93,19 @@ const MenuItem = ({
     setSubMenuIsOpenByIndex,
     menuRef,
     isMouseEnter,
-    closeMenu
+    closeMenu,
+    useDocumentEventListeners
   );
 
   useLayoutEffect(() => {
+    if (useDocumentEventListeners) return;
+
     if (shouldShowSubMenu && childElement) {
       requestAnimationFrame(() => {
         childElement.focus();
       });
     }
-  }, [shouldShowSubMenu, childElement]);
+  }, [shouldShowSubMenu, childElement, useDocumentEventListeners]);
 
   const closeSubMenu = useCallback(
     (options = {}) => {
@@ -229,7 +233,8 @@ MenuItem.defaultProps = {
   isParentMenuVisible: false,
   hasOpenSubMenu: false,
   setSubMenuIsOpenByIndex: undefined,
-  resetOpenSubMenuIndex: undefined
+  resetOpenSubMenuIndex: undefined,
+  useDocumentEventListeners: false
 };
 
 MenuItem.propTypes = {
@@ -246,7 +251,8 @@ MenuItem.propTypes = {
   isParentMenuVisible: PropTypes.bool,
   resetOpenSubMenuIndex: PropTypes.func,
   hasOpenSubMenu: PropTypes.bool,
-  setSubMenuIsOpenByIndex: PropTypes.func
+  setSubMenuIsOpenByIndex: PropTypes.func,
+  useDocumentEventListeners: PropTypes.bool
 };
 
 MenuItem.isSelectable = true;

--- a/src/components/Menu/MenuItem/hooks/useMenuItemKeyboardEvents.js
+++ b/src/components/Menu/MenuItem/hooks/useMenuItemKeyboardEvents.js
@@ -15,13 +15,11 @@ export default function useMenuItemKeyboardEvents(
   setSubMenuIsOpenByIndex,
   menuRef,
   isMouseEnter,
-  closeMenu
+  closeMenu,
+  useDocumentEventListeners
 ) {
   const onClickCallback = useCallback(
     event => {
-      event.preventDefault();
-      event.stopPropagation();
-
       if (!isActive && !isMouseEnter) return;
 
       if (!setActiveItemIndex || !setSubMenuIsOpenByIndex) {
@@ -75,14 +73,15 @@ export default function useMenuItemKeyboardEvents(
       hasChildren,
       shouldShowSubMenu,
       setSubMenuIsOpenByIndex,
-      isMouseEnter
+      isMouseEnter,
+      closeMenu
     ]
   );
 
   useKeyEvent({
     keys: KEYS,
     callback: onClickCallback,
-    ref: menuRef,
+    ref: useDocumentEventListeners ? undefined : menuRef,
     preventDefault: true
   });
 

--- a/src/components/Menu/MenuItem/hooks/useMenuItemKeyboardEvents.js
+++ b/src/components/Menu/MenuItem/hooks/useMenuItemKeyboardEvents.js
@@ -38,11 +38,15 @@ export default function useMenuItemKeyboardEvents(
       const isKeyEvent = !!event.key;
 
       const clickCallback = () => {
+        event.preventDefault();
         onClick(event);
         closeMenu({ propagate: true });
       };
 
       if (isKeyEvent && onClick && !disabled && isActive) {
+        if (event.key === "ArrowRight") {
+          return;
+        }
         clickCallback();
       }
 
@@ -81,8 +85,7 @@ export default function useMenuItemKeyboardEvents(
   useKeyEvent({
     keys: KEYS,
     callback: onClickCallback,
-    ref: useDocumentEventListeners ? undefined : menuRef,
-    preventDefault: true
+    ref: useDocumentEventListeners ? undefined : menuRef
   });
 
   return { onClickCallback };


### PR DESCRIPTION
new menu prop: useDocumentEventListeners, this will do two changes:
- Menu will never acquire focus, even during keyboard navigation
- All keyboard listeners will be on the document and not on the menu and on the menu item refs

Right arrow click will be used only for keyboard navigation (until now it was handled the same as enter click)