### PR TITLE
responsive without overflow hidden

### DIFF
--- a/src/components/ResponsiveList/ResponsiveList.scss
+++ b/src/components/ResponsiveList/ResponsiveList.scss
@@ -2,7 +2,6 @@
 @import "../../styles/typography.scss";
 
 .responsive-list--wrapper {
-  overflow: hidden;
   display: flex;
   .responsive-list-menu-button {
     margin-inline-start: auto;

--- a/src/components/ResponsiveList/__stories__/responsiveList.stories.js
+++ b/src/components/ResponsiveList/__stories__/responsiveList.stories.js
@@ -35,7 +35,7 @@ export const Sandbox = () => (
   <div style={{ width: "100%" }}>
     <DescriptionLabel>
       Use this component when you want to collapse elements into a menu button which appends to the end of the row. The
-      list wraps the element with <code>display: flex;</code> property and <code>overflow: hidden</code> in order to
+      list wraps the element with <code>display: flex;</code> property in order to
       calculate the
     </DescriptionLabel>
     <br />

--- a/src/hooks/useElementsOverflowingIndex.js
+++ b/src/hooks/useElementsOverflowingIndex.js
@@ -7,8 +7,8 @@ function useElementsOverflowingIndex({ ref, children, paddingSize, resizeDebounc
   const [size, setSize] = useState(null);
 
   const onResize = useCallback(
-    ({ borderBoxSize }) => {
-      setSize(borderBoxSize.inlineSize);
+    () => {
+      setSize(ref.current.scrollWidth);
     },
     [setSize]
   );


### PR DESCRIPTION
Had a dropdown, and it didn't work with the responsive component, cause it has overflow hidden:
![image](https://user-images.githubusercontent.com/2057934/124607528-9d35fb80-de76-11eb-921e-46d09d810489.png)

Changed it to work without overflow hidden