### PR TITLE
Bug/hadasfa/toggle focus

### DIFF
--- a/src/components/Checkbox/Checkbox.scss
+++ b/src/components/Checkbox/Checkbox.scss
@@ -77,10 +77,7 @@ $checkbox-size: 16px;
   // In order to allow accessibility, all operations will be performed on the hidden checkbox and be reflected
   // in the new checkbox we drew.
   &__input {
-    opacity: 0;
-    width: 0;
-    height: 0;
-    position: absolute;
+    @include hidden-element();
 
     // For any active attribute in the hidden checkbox, we will change the appearance of the checkbox we drew in its place.
     &:focus {

--- a/src/components/Toggle/Toggle.jsx
+++ b/src/components/Toggle/Toggle.jsx
@@ -2,11 +2,13 @@ import React from "react";
 import PropTypes from "prop-types";
 import classNames from "classnames";
 import NOOP from "lodash/noop";
-import { VisuallyHidden } from "@react-aria/visually-hidden";
 import { BASE_TOGGLE_CLASS_NAME } from "./ToggleConstants";
 import ToggleText from "./ToggleText";
 import "./Toggle.scss";
 import { useToggle } from "../../hooks/useToggle";
+import { BEMClass } from "../../helpers/bem-helper";
+
+const bemHelper = BEMClass(BASE_TOGGLE_CLASS_NAME);
 
 const Toggle = ({
   id,
@@ -23,7 +25,7 @@ const Toggle = ({
   onOverrideText,
   offOverrideText
 }) => {
-  const { inputProps, isChecked, isFocusVisible } = useToggle({
+  const { inputProps, isChecked } = useToggle({
     id,
     isDefaultSelected,
     isSelected,
@@ -35,19 +37,16 @@ const Toggle = ({
     ariaControls
   });
 
-  const className = classNames(`${BASE_TOGGLE_CLASS_NAME}__toggle`, componentClassName, {
-    [`${BASE_TOGGLE_CLASS_NAME}__toggle--selected`]: isChecked,
-    [`${BASE_TOGGLE_CLASS_NAME}__toggle--not-selected`]: !isChecked,
-    [`${BASE_TOGGLE_CLASS_NAME}__toggle--disabled`]: isDisabled,
-    [`${BASE_TOGGLE_CLASS_NAME}__toggle--focused`]: isFocusVisible
+  const className = classNames(bemHelper({ element: "toggle" }), componentClassName, {
+    [bemHelper({ element: "toggle", state: "selected" })]: isChecked,
+    [bemHelper({ element: "toggle", state: "not-selected" })]: !isChecked,
+    [bemHelper({ element: "toggle", state: "disabled" })]: isDisabled
   });
 
   return (
-    <label htmlFor={id} className={`${BASE_TOGGLE_CLASS_NAME}__wrapper`}>
-      <VisuallyHidden>
-        <input {...inputProps} />
-      </VisuallyHidden>
+    <label htmlFor={id} className={bemHelper({ element: "wrapper" })}>
       {areLabelsHidden ? null : <ToggleText>{offOverrideText}</ToggleText>}
+      <input {...inputProps} className={bemHelper({ element: "input" })} />
       <div className={className} aria-hidden="true" />
       {areLabelsHidden ? null : <ToggleText>{onOverrideText}</ToggleText>}
     </label>

--- a/src/components/Toggle/Toggle.scss
+++ b/src/components/Toggle/Toggle.scss
@@ -1,19 +1,31 @@
 @import "../../styles/states.scss";
 @import "../../styles/global-css-settings.scss";
 
-@mixin toggle-animation {
-  transition: 100ms $expand-animation-timing;
-}
-
 .monday-style-toggle{
-  &__wrapper {
+  &_wrapper {
     display: flex;
     align-items: center;
   }
 
-  &__toggle {
+  // Since it is not possible to change the design of the checkbox according to the storybook toggle requirements using css,
+  // we hide the checkbox and draw a new one instead.
+  // In order to allow accessibility, all operations will be performed on the hidden checkbox and be reflected
+  // in the new toggle we drew.
+  &_input {
+    @include hidden-element;
+
+    // When the hidden checkbox will be focused by keyboard navigation events, the toggle appearance will reflect it
+    &:focus-visible,
+    &.focus-visible {
+      & + .monday-style-toggle_toggle {
+        @include focus-style-css();
+      }
+    }
+  }
+
+  &_toggle {
     @include reset-button();
-    @include toggle-animation;
+    transition: background-color 100ms $expand-animation-timing;
     margin: 0 $spacing-small;
     position: relative;
     height: 24px;
@@ -29,7 +41,7 @@
       height: 18px;
       border-radius: 50%;
       top: calc(50% - 18px/2);
-      @include toggle-animation;
+      transition: left 100ms $expand-animation-timing;
     }
 
     &--selected {
@@ -49,13 +61,9 @@
     &--disabled {
       @include theme-prop(background-color, primary-background-hover-color);
     }
-
-    &--focused {
-      @include focus-style-css();
-    }
   }
 
-  &__text {
+  &_text {
     @include theme-prop(color, primary-text-color);
     font-style: normal;
     font-weight: normal;

--- a/src/components/Toggle/__tests__/__snapshots__/toggle.jest.js.snap
+++ b/src/components/Toggle/__tests__/__snapshots__/toggle.jest.js.snap
@@ -2,55 +2,39 @@
 
 exports[`Toggle Tests Snapshot Tests renders correctly when disabled 1`] = `
 <label
-  className="monday-style-toggle__wrapper"
+  className="monday-style-toggle_wrapper"
 >
-  <div
-    style={
-      Object {
-        "border": 0,
-        "clip": "rect(0 0 0 0)",
-        "clipPath": "inset(50%)",
-        "height": 1,
-        "margin": "0 -1px -1px 0",
-        "overflow": "hidden",
-        "padding": 0,
-        "position": "absolute",
-        "whiteSpace": "nowrap",
-        "width": 1,
-      }
-    }
-  >
-    <input
-      aria-checked={true}
-      checked={true}
-      disabled={true}
-      onBlur={[Function]}
-      onChange={[Function]}
-      onClick={[Function]}
-      onDragStart={[Function]}
-      onFocus={[Function]}
-      onKeyDown={[Function]}
-      onKeyUp={[Function]}
-      onMouseDown={[Function]}
-      onMouseEnter={[Function]}
-      onMouseLeave={[Function]}
-      onMouseUp={[Function]}
-      onTouchCancel={[Function]}
-      onTouchEnd={[Function]}
-      onTouchMove={[Function]}
-      onTouchStart={[Function]}
-      role="switch"
-      type="checkbox"
-    />
-  </div>
   <span
     className="monday-style-toggle__text"
   >
     Off
   </span>
+  <input
+    aria-checked={true}
+    checked={true}
+    className="monday-style-toggle_input"
+    disabled={true}
+    onBlur={[Function]}
+    onChange={[Function]}
+    onClick={[Function]}
+    onDragStart={[Function]}
+    onFocus={[Function]}
+    onKeyDown={[Function]}
+    onKeyUp={[Function]}
+    onMouseDown={[Function]}
+    onMouseEnter={[Function]}
+    onMouseLeave={[Function]}
+    onMouseUp={[Function]}
+    onTouchCancel={[Function]}
+    onTouchEnd={[Function]}
+    onTouchMove={[Function]}
+    onTouchStart={[Function]}
+    role="switch"
+    type="checkbox"
+  />
   <div
     aria-hidden="true"
-    className="monday-style-toggle__toggle monday-style-toggle__toggle--selected monday-style-toggle__toggle--disabled"
+    className="monday-style-toggle_toggle monday-style-toggle_toggle--selected monday-style-toggle_toggle--disabled"
   />
   <span
     className="monday-style-toggle__text"
@@ -62,55 +46,39 @@ exports[`Toggle Tests Snapshot Tests renders correctly when disabled 1`] = `
 
 exports[`Toggle Tests Snapshot Tests renders correctly when selection defined by default selected (off)  1`] = `
 <label
-  className="monday-style-toggle__wrapper"
+  className="monday-style-toggle_wrapper"
 >
-  <div
-    style={
-      Object {
-        "border": 0,
-        "clip": "rect(0 0 0 0)",
-        "clipPath": "inset(50%)",
-        "height": 1,
-        "margin": "0 -1px -1px 0",
-        "overflow": "hidden",
-        "padding": 0,
-        "position": "absolute",
-        "whiteSpace": "nowrap",
-        "width": 1,
-      }
-    }
-  >
-    <input
-      aria-checked={false}
-      checked={false}
-      disabled={false}
-      onBlur={[Function]}
-      onChange={[Function]}
-      onClick={[Function]}
-      onDragStart={[Function]}
-      onFocus={[Function]}
-      onKeyDown={[Function]}
-      onKeyUp={[Function]}
-      onMouseDown={[Function]}
-      onMouseEnter={[Function]}
-      onMouseLeave={[Function]}
-      onMouseUp={[Function]}
-      onTouchCancel={[Function]}
-      onTouchEnd={[Function]}
-      onTouchMove={[Function]}
-      onTouchStart={[Function]}
-      role="switch"
-      type="checkbox"
-    />
-  </div>
   <span
     className="monday-style-toggle__text"
   >
     Off
   </span>
+  <input
+    aria-checked={false}
+    checked={false}
+    className="monday-style-toggle_input"
+    disabled={false}
+    onBlur={[Function]}
+    onChange={[Function]}
+    onClick={[Function]}
+    onDragStart={[Function]}
+    onFocus={[Function]}
+    onKeyDown={[Function]}
+    onKeyUp={[Function]}
+    onMouseDown={[Function]}
+    onMouseEnter={[Function]}
+    onMouseLeave={[Function]}
+    onMouseUp={[Function]}
+    onTouchCancel={[Function]}
+    onTouchEnd={[Function]}
+    onTouchMove={[Function]}
+    onTouchStart={[Function]}
+    role="switch"
+    type="checkbox"
+  />
   <div
     aria-hidden="true"
-    className="monday-style-toggle__toggle dummy-class-name monday-style-toggle__toggle--not-selected"
+    className="monday-style-toggle_toggle dummy-class-name monday-style-toggle_toggle--not-selected"
   />
   <span
     className="monday-style-toggle__text"
@@ -122,55 +90,39 @@ exports[`Toggle Tests Snapshot Tests renders correctly when selection defined by
 
 exports[`Toggle Tests Snapshot Tests renders correctly when selection defined by default selected (on)  1`] = `
 <label
-  className="monday-style-toggle__wrapper"
+  className="monday-style-toggle_wrapper"
 >
-  <div
-    style={
-      Object {
-        "border": 0,
-        "clip": "rect(0 0 0 0)",
-        "clipPath": "inset(50%)",
-        "height": 1,
-        "margin": "0 -1px -1px 0",
-        "overflow": "hidden",
-        "padding": 0,
-        "position": "absolute",
-        "whiteSpace": "nowrap",
-        "width": 1,
-      }
-    }
-  >
-    <input
-      aria-checked={true}
-      checked={true}
-      disabled={false}
-      onBlur={[Function]}
-      onChange={[Function]}
-      onClick={[Function]}
-      onDragStart={[Function]}
-      onFocus={[Function]}
-      onKeyDown={[Function]}
-      onKeyUp={[Function]}
-      onMouseDown={[Function]}
-      onMouseEnter={[Function]}
-      onMouseLeave={[Function]}
-      onMouseUp={[Function]}
-      onTouchCancel={[Function]}
-      onTouchEnd={[Function]}
-      onTouchMove={[Function]}
-      onTouchStart={[Function]}
-      role="switch"
-      type="checkbox"
-    />
-  </div>
   <span
     className="monday-style-toggle__text"
   >
     Off
   </span>
+  <input
+    aria-checked={true}
+    checked={true}
+    className="monday-style-toggle_input"
+    disabled={false}
+    onBlur={[Function]}
+    onChange={[Function]}
+    onClick={[Function]}
+    onDragStart={[Function]}
+    onFocus={[Function]}
+    onKeyDown={[Function]}
+    onKeyUp={[Function]}
+    onMouseDown={[Function]}
+    onMouseEnter={[Function]}
+    onMouseLeave={[Function]}
+    onMouseUp={[Function]}
+    onTouchCancel={[Function]}
+    onTouchEnd={[Function]}
+    onTouchMove={[Function]}
+    onTouchStart={[Function]}
+    role="switch"
+    type="checkbox"
+  />
   <div
     aria-hidden="true"
-    className="monday-style-toggle__toggle dummy-class-name monday-style-toggle__toggle--selected"
+    className="monday-style-toggle_toggle dummy-class-name monday-style-toggle_toggle--selected"
   />
   <span
     className="monday-style-toggle__text"
@@ -182,55 +134,39 @@ exports[`Toggle Tests Snapshot Tests renders correctly when selection defined by
 
 exports[`Toggle Tests Snapshot Tests renders correctly when selection defined by isSelected (off) 1`] = `
 <label
-  className="monday-style-toggle__wrapper"
+  className="monday-style-toggle_wrapper"
 >
-  <div
-    style={
-      Object {
-        "border": 0,
-        "clip": "rect(0 0 0 0)",
-        "clipPath": "inset(50%)",
-        "height": 1,
-        "margin": "0 -1px -1px 0",
-        "overflow": "hidden",
-        "padding": 0,
-        "position": "absolute",
-        "whiteSpace": "nowrap",
-        "width": 1,
-      }
-    }
-  >
-    <input
-      aria-checked={false}
-      checked={false}
-      disabled={false}
-      onBlur={[Function]}
-      onChange={[Function]}
-      onClick={[Function]}
-      onDragStart={[Function]}
-      onFocus={[Function]}
-      onKeyDown={[Function]}
-      onKeyUp={[Function]}
-      onMouseDown={[Function]}
-      onMouseEnter={[Function]}
-      onMouseLeave={[Function]}
-      onMouseUp={[Function]}
-      onTouchCancel={[Function]}
-      onTouchEnd={[Function]}
-      onTouchMove={[Function]}
-      onTouchStart={[Function]}
-      role="switch"
-      type="checkbox"
-    />
-  </div>
   <span
     className="monday-style-toggle__text"
   >
     Off
   </span>
+  <input
+    aria-checked={false}
+    checked={false}
+    className="monday-style-toggle_input"
+    disabled={false}
+    onBlur={[Function]}
+    onChange={[Function]}
+    onClick={[Function]}
+    onDragStart={[Function]}
+    onFocus={[Function]}
+    onKeyDown={[Function]}
+    onKeyUp={[Function]}
+    onMouseDown={[Function]}
+    onMouseEnter={[Function]}
+    onMouseLeave={[Function]}
+    onMouseUp={[Function]}
+    onTouchCancel={[Function]}
+    onTouchEnd={[Function]}
+    onTouchMove={[Function]}
+    onTouchStart={[Function]}
+    role="switch"
+    type="checkbox"
+  />
   <div
     aria-hidden="true"
-    className="monday-style-toggle__toggle dummy-class-name monday-style-toggle__toggle--not-selected"
+    className="monday-style-toggle_toggle dummy-class-name monday-style-toggle_toggle--not-selected"
   />
   <span
     className="monday-style-toggle__text"
@@ -242,55 +178,39 @@ exports[`Toggle Tests Snapshot Tests renders correctly when selection defined by
 
 exports[`Toggle Tests Snapshot Tests renders correctly when selection defined by isSelected (on) 1`] = `
 <label
-  className="monday-style-toggle__wrapper"
+  className="monday-style-toggle_wrapper"
 >
-  <div
-    style={
-      Object {
-        "border": 0,
-        "clip": "rect(0 0 0 0)",
-        "clipPath": "inset(50%)",
-        "height": 1,
-        "margin": "0 -1px -1px 0",
-        "overflow": "hidden",
-        "padding": 0,
-        "position": "absolute",
-        "whiteSpace": "nowrap",
-        "width": 1,
-      }
-    }
-  >
-    <input
-      aria-checked={true}
-      checked={true}
-      disabled={false}
-      onBlur={[Function]}
-      onChange={[Function]}
-      onClick={[Function]}
-      onDragStart={[Function]}
-      onFocus={[Function]}
-      onKeyDown={[Function]}
-      onKeyUp={[Function]}
-      onMouseDown={[Function]}
-      onMouseEnter={[Function]}
-      onMouseLeave={[Function]}
-      onMouseUp={[Function]}
-      onTouchCancel={[Function]}
-      onTouchEnd={[Function]}
-      onTouchMove={[Function]}
-      onTouchStart={[Function]}
-      role="switch"
-      type="checkbox"
-    />
-  </div>
   <span
     className="monday-style-toggle__text"
   >
     Off
   </span>
+  <input
+    aria-checked={true}
+    checked={true}
+    className="monday-style-toggle_input"
+    disabled={false}
+    onBlur={[Function]}
+    onChange={[Function]}
+    onClick={[Function]}
+    onDragStart={[Function]}
+    onFocus={[Function]}
+    onKeyDown={[Function]}
+    onKeyUp={[Function]}
+    onMouseDown={[Function]}
+    onMouseEnter={[Function]}
+    onMouseLeave={[Function]}
+    onMouseUp={[Function]}
+    onTouchCancel={[Function]}
+    onTouchEnd={[Function]}
+    onTouchMove={[Function]}
+    onTouchStart={[Function]}
+    role="switch"
+    type="checkbox"
+  />
   <div
     aria-hidden="true"
-    className="monday-style-toggle__toggle dummy-class-name monday-style-toggle__toggle--selected"
+    className="monday-style-toggle_toggle dummy-class-name monday-style-toggle_toggle--selected"
   />
   <span
     className="monday-style-toggle__text"
@@ -302,55 +222,39 @@ exports[`Toggle Tests Snapshot Tests renders correctly when selection defined by
 
 exports[`Toggle Tests Snapshot Tests renders correctly with empty props 1`] = `
 <label
-  className="monday-style-toggle__wrapper"
+  className="monday-style-toggle_wrapper"
 >
-  <div
-    style={
-      Object {
-        "border": 0,
-        "clip": "rect(0 0 0 0)",
-        "clipPath": "inset(50%)",
-        "height": 1,
-        "margin": "0 -1px -1px 0",
-        "overflow": "hidden",
-        "padding": 0,
-        "position": "absolute",
-        "whiteSpace": "nowrap",
-        "width": 1,
-      }
-    }
-  >
-    <input
-      aria-checked={true}
-      checked={true}
-      disabled={false}
-      onBlur={[Function]}
-      onChange={[Function]}
-      onClick={[Function]}
-      onDragStart={[Function]}
-      onFocus={[Function]}
-      onKeyDown={[Function]}
-      onKeyUp={[Function]}
-      onMouseDown={[Function]}
-      onMouseEnter={[Function]}
-      onMouseLeave={[Function]}
-      onMouseUp={[Function]}
-      onTouchCancel={[Function]}
-      onTouchEnd={[Function]}
-      onTouchMove={[Function]}
-      onTouchStart={[Function]}
-      role="switch"
-      type="checkbox"
-    />
-  </div>
   <span
     className="monday-style-toggle__text"
   >
     Off
   </span>
+  <input
+    aria-checked={true}
+    checked={true}
+    className="monday-style-toggle_input"
+    disabled={false}
+    onBlur={[Function]}
+    onChange={[Function]}
+    onClick={[Function]}
+    onDragStart={[Function]}
+    onFocus={[Function]}
+    onKeyDown={[Function]}
+    onKeyUp={[Function]}
+    onMouseDown={[Function]}
+    onMouseEnter={[Function]}
+    onMouseLeave={[Function]}
+    onMouseUp={[Function]}
+    onTouchCancel={[Function]}
+    onTouchEnd={[Function]}
+    onTouchMove={[Function]}
+    onTouchStart={[Function]}
+    role="switch"
+    type="checkbox"
+  />
   <div
     aria-hidden="true"
-    className="monday-style-toggle__toggle monday-style-toggle__toggle--selected"
+    className="monday-style-toggle_toggle monday-style-toggle_toggle--selected"
   />
   <span
     className="monday-style-toggle__text"

--- a/src/styles/global-css-settings.scss
+++ b/src/styles/global-css-settings.scss
@@ -42,3 +42,10 @@ $expand-animation-timing: cubic-bezier(0, 0, 0.35, 1);
 @mixin box-shadow-large() {
   @include theme-prop(box-shadow, box-shadow-large);
 }
+
+@mixin hidden-element() {
+  opacity: 0;
+  width: 0;
+  height: 0;
+  position: absolute;
+}


### PR DESCRIPTION
Description: fix toggle focus to not support click events (by replace use focus ring with pure css)

### Updating existing component
#### Basic
- [V ] PR has description
- [ ] Changes to the component are backward compatible (including selectors structure). If not - add to the title of the PR "BREAKABLE_CHANGE""
- [ ] All changes to the component are reflected in the ReadMe
- [ ] If component is old and was not compliant with the latest guidelines - it was fixed (optional) 
#### Style
- [V ] CSS selectors are named using [BEM convention](http://getbem.com/naming/) 
- [V ] Design is compatible with [Monday Design System](https://design.monday.com/)
#### Storybook
- [ ] All the changes to the component should be reflected in the Storybook.
- [V ] Component passed Accessibility Plugin checks
#### Tests
- [V ] All current tests are passing
- [ ] New functionality is covered with tests
- [V] Tests are compliant with TESTING_README.md instructions


