### PR TITLE
Bug/hadas/a11y feedback

### DIFF
--- a/src/components/AttentionBox/__tests__/__snapshots__/attentionBox.jest.js.snap
+++ b/src/components/AttentionBox/__tests__/__snapshots__/attentionBox.jest.js.snap
@@ -9,14 +9,12 @@ exports[`AttentionBox Tests Snapshot Tests renders correctly 1`] = `
     className="monday-style-attention-box-component__title-container monday-style-attention-box-component--type-primary__title-container"
   >
     <svg
-      aria-hidden="true"
-      aria-label="attention"
+      aria-hidden={true}
       className="icon_component monday-style-attention-box-component__title-container__icon monday-style-attention-box-component--type-primary__title-container__icon icon_component--no-focus-style"
       fill="currentColor"
       height="24"
       onClick={[Function]}
-      role=""
-      tabIndex={-1}
+      role="img"
       viewBox="0 0 20 20"
       width="24"
     >
@@ -50,14 +48,12 @@ exports[`AttentionBox Tests Snapshot Tests renders correctly with empty props 1`
     className="monday-style-attention-box-component__title-container monday-style-attention-box-component--type-primary__title-container"
   >
     <svg
-      aria-hidden="true"
-      aria-label="attention"
+      aria-hidden={true}
       className="icon_component monday-style-attention-box-component__title-container__icon monday-style-attention-box-component--type-primary__title-container__icon icon_component--no-focus-style"
       fill="currentColor"
       height="24"
       onClick={[Function]}
-      role=""
-      tabIndex={-1}
+      role="img"
       viewBox="0 0 20 20"
       width="24"
     >

--- a/src/components/Checkbox/Checkbox.js
+++ b/src/components/Checkbox/Checkbox.js
@@ -69,9 +69,9 @@ export const Checkbox = ({
           className={`${BASE_CLASS_NAME}__icon`}
           iconType={Icon.type.SVG}
           icon={Check}
-          iconLabel="checkbox"
           ignoreFocusStyle
           clickable={false}
+          ariaHidden={true}
           iconSize="16"
         />
       </div>
@@ -96,7 +96,7 @@ Checkbox.propTypes = {
 Checkbox.defaultProps = {
   id: undefined,
   componentClassName: "",
-  label: "",
+  label: undefined,
   onChange: NOOP,
   disabled: false,
   name: "",

--- a/src/components/Checkbox/__tests__/__snapshots__/checkbox.jest.js.snap
+++ b/src/components/Checkbox/__tests__/__snapshots__/checkbox.jest.js.snap
@@ -19,14 +19,12 @@ exports[`Checkbox Tests Snapshot Tests renders correctly 1`] = `
     className="monday-style-checkbox__checkbox monday-style-checkbox__prevent-animation"
   >
     <svg
-      aria-hidden={false}
-      aria-label="checkbox"
-      className="icon_component monday-style-checkbox__icon icon_component--clickable icon_component--no-focus-style"
+      aria-hidden={true}
+      className="icon_component monday-style-checkbox__icon icon_component--no-focus-style"
       fill="currentColor"
       height="16"
       onClick={[Function]}
-      role="button"
-      tabIndex={0}
+      role="img"
       viewBox="0 0 20 20"
       width="16"
     >
@@ -52,7 +50,6 @@ exports[`Checkbox Tests Snapshot Tests renders correctly when checked 1`] = `
   onMouseUp={[Function]}
 >
   <input
-    aria-label=""
     checked={true}
     className="monday-style-checkbox__input"
     disabled={false}
@@ -65,14 +62,12 @@ exports[`Checkbox Tests Snapshot Tests renders correctly when checked 1`] = `
     className="monday-style-checkbox__checkbox monday-style-checkbox__prevent-animation"
   >
     <svg
-      aria-hidden={false}
-      aria-label="checkbox"
-      className="icon_component monday-style-checkbox__icon icon_component--clickable icon_component--no-focus-style"
+      aria-hidden={true}
+      className="icon_component monday-style-checkbox__icon icon_component--no-focus-style"
       fill="currentColor"
       height="16"
       onClick={[Function]}
-      role="button"
-      tabIndex={0}
+      role="img"
       viewBox="0 0 20 20"
       width="16"
     >
@@ -86,9 +81,7 @@ exports[`Checkbox Tests Snapshot Tests renders correctly when checked 1`] = `
   </div>
   <span
     className="monday-style-checkbox__label"
-  >
-    
-  </span>
+  />
 </label>
 `;
 
@@ -98,7 +91,6 @@ exports[`Checkbox Tests Snapshot Tests renders correctly when disabled 1`] = `
   onMouseUp={[Function]}
 >
   <input
-    aria-label=""
     className="monday-style-checkbox__input"
     defaultChecked={false}
     disabled={true}
@@ -111,14 +103,12 @@ exports[`Checkbox Tests Snapshot Tests renders correctly when disabled 1`] = `
     className="monday-style-checkbox__checkbox monday-style-checkbox__prevent-animation"
   >
     <svg
-      aria-hidden={false}
-      aria-label="checkbox"
-      className="icon_component monday-style-checkbox__icon icon_component--clickable icon_component--no-focus-style"
+      aria-hidden={true}
+      className="icon_component monday-style-checkbox__icon icon_component--no-focus-style"
       fill="currentColor"
       height="16"
       onClick={[Function]}
-      role="button"
-      tabIndex={0}
+      role="img"
       viewBox="0 0 20 20"
       width="16"
     >
@@ -132,9 +122,7 @@ exports[`Checkbox Tests Snapshot Tests renders correctly when disabled 1`] = `
   </div>
   <span
     className="monday-style-checkbox__label"
-  >
-    
-  </span>
+  />
 </label>
 `;
 
@@ -144,7 +132,6 @@ exports[`Checkbox Tests Snapshot Tests renders correctly with empty props 1`] = 
   onMouseUp={[Function]}
 >
   <input
-    aria-label=""
     className="monday-style-checkbox__input"
     defaultChecked={false}
     disabled={false}
@@ -157,14 +144,12 @@ exports[`Checkbox Tests Snapshot Tests renders correctly with empty props 1`] = 
     className="monday-style-checkbox__checkbox monday-style-checkbox__prevent-animation"
   >
     <svg
-      aria-hidden={false}
-      aria-label="checkbox"
-      className="icon_component monday-style-checkbox__icon icon_component--clickable icon_component--no-focus-style"
+      aria-hidden={true}
+      className="icon_component monday-style-checkbox__icon icon_component--no-focus-style"
       fill="currentColor"
       height="16"
       onClick={[Function]}
-      role="button"
-      tabIndex={0}
+      role="img"
       viewBox="0 0 20 20"
       width="16"
     >
@@ -178,8 +163,6 @@ exports[`Checkbox Tests Snapshot Tests renders correctly with empty props 1`] = 
   </div>
   <span
     className="monday-style-checkbox__label"
-  >
-    
-  </span>
+  />
 </label>
 `;

--- a/src/components/Combobox/__tests__/__snapshots__/combobox.jest.js.snap
+++ b/src/components/Combobox/__tests__/__snapshots__/combobox.jest.js.snap
@@ -55,11 +55,11 @@ exports[`<Combobox /> renders correctly with empty props 1`] = `
           tabIndex="-1"
         >
           <span
+            aria-hidden={false}
             aria-label="Search"
             className="icon_component input-component__icon icon_component--no-focus-style fa fa-search"
             onClick={[Function]}
             role="img"
-            tabIndex={-1}
           />
         </div>
         <div
@@ -80,11 +80,11 @@ exports[`<Combobox /> renders correctly with empty props 1`] = `
           tabIndex="-1"
         >
           <span
+            aria-hidden={false}
             aria-label="Clear Search"
             className="icon_component input-component__icon icon_component--no-focus-style fa fa-close"
             onClick={[Function]}
             role="img"
-            tabIndex={-1}
           />
         </div>
       </div>
@@ -157,11 +157,11 @@ exports[`<Combobox /> renders correctly with one option 1`] = `
           tabIndex="-1"
         >
           <span
+            aria-hidden={false}
             aria-label="Search"
             className="icon_component input-component__icon icon_component--no-focus-style fa fa-search"
             onClick={[Function]}
             role="img"
-            tabIndex={-1}
           />
         </div>
         <div
@@ -182,11 +182,11 @@ exports[`<Combobox /> renders correctly with one option 1`] = `
           tabIndex="-1"
         >
           <span
+            aria-hidden={false}
             aria-label="Clear Search"
             className="icon_component input-component__icon icon_component--no-focus-style fa fa-close"
             onClick={[Function]}
             role="img"
-            tabIndex={-1}
           />
         </div>
       </div>
@@ -279,11 +279,11 @@ exports[`<Combobox /> renders correctly with options and categories 1`] = `
           tabIndex="-1"
         >
           <span
+            aria-hidden={false}
             aria-label="Search"
             className="icon_component input-component__icon icon_component--no-focus-style fa fa-search"
             onClick={[Function]}
             role="img"
-            tabIndex={-1}
           />
         </div>
         <div
@@ -304,11 +304,11 @@ exports[`<Combobox /> renders correctly with options and categories 1`] = `
           tabIndex="-1"
         >
           <span
+            aria-hidden={false}
             aria-label="Clear Search"
             className="icon_component input-component__icon icon_component--no-focus-style fa fa-close"
             onClick={[Function]}
             role="img"
-            tabIndex={-1}
           />
         </div>
       </div>

--- a/src/components/Dropdown/__tests__/__snapshots__/dropdown.jest.js.snap
+++ b/src/components/Dropdown/__tests__/__snapshots__/dropdown.jest.js.snap
@@ -69,7 +69,6 @@ exports[`Dropdown should open menu on click if set 1`] = `
         >
           <svg
             aria-hidden="false"
-            aria-label=""
             class="icon_component icon_component--clickable"
             fill="currentColor"
             height="20px"
@@ -209,7 +208,6 @@ exports[`Dropdown should open menu on focus if set 1`] = `
         >
           <svg
             aria-hidden="false"
-            aria-label=""
             class="icon_component icon_component--clickable"
             fill="currentColor"
             height="20px"
@@ -373,7 +371,6 @@ exports[`Dropdown should render correctly for the different sizes 1`] = `
       >
         <svg
           aria-hidden={false}
-          aria-label=""
           className="icon_component icon_component--clickable"
           fill="currentColor"
           height="20px"
@@ -487,7 +484,6 @@ exports[`Dropdown should render correctly for the different sizes 2`] = `
       >
         <svg
           aria-hidden={false}
-          aria-label=""
           className="icon_component icon_component--clickable"
           fill="currentColor"
           height="20px"
@@ -601,7 +597,6 @@ exports[`Dropdown should render correctly for the different sizes 3`] = `
       >
         <svg
           aria-hidden={false}
-          aria-label=""
           className="icon_component icon_component--clickable"
           fill="currentColor"
           height="16px"
@@ -715,7 +710,6 @@ exports[`Dropdown should render correctly with empty props 1`] = `
       >
         <svg
           aria-hidden={false}
-          aria-label=""
           className="icon_component icon_component--clickable"
           fill="currentColor"
           height="20px"
@@ -819,7 +813,6 @@ exports[`Dropdown should use async if set 1`] = `
         >
           <svg
             aria-hidden="false"
-            aria-label=""
             class="icon_component icon_component--clickable"
             fill="currentColor"
             height="20px"
@@ -909,7 +902,6 @@ exports[`Dropdown should use virtualization if set 1`] = `
         >
           <svg
             aria-hidden="false"
-            aria-label=""
             class="icon_component icon_component--clickable"
             fill="currentColor"
             height="20px"

--- a/src/components/Icon/CustomSvgIcon.jsx
+++ b/src/components/Icon/CustomSvgIcon.jsx
@@ -4,13 +4,17 @@ import PropTypes from "prop-types";
 import cx from "classnames";
 import SVG from "react-inlinesvg";
 import "./CustomSvgIcon.scss";
-import { getScreenReaderAccessProps } from "../../helpers/screenReaderAccessHelper";
+import useIconScreenReaderAccessProps from "../../hooks/useIconScreenReaderAccessProps";
 
-const CustomSvgIcon = ({ className, src, onClick, clickable, ...props }) => {
-  const screenReaderAccessProps = useMemo(() => getScreenReaderAccessProps(), []);
+const CustomSvgIcon = ({ className, src, onClick, clickable, ariaLabel, ariaHidden, ...props }) => {
+  const screenReaderAccessProps = useIconScreenReaderAccessProps({
+    isClickable: clickable,
+    label: ariaLabel,
+    isDecorationOnly: ariaHidden
+  });
   return (
     <SVG
-      tabIndex={tabIndex}
+      {...screenReaderAccessProps}
       onClick={onClick}
       src={src}
       className={cx("monday-style-custom-svg-icon--wrapper", className)}
@@ -21,11 +25,15 @@ const CustomSvgIcon = ({ className, src, onClick, clickable, ...props }) => {
 
 CustomSvgIcon.defaultProps = {
   className: PropTypes.string,
-  src: PropTypes.string
+  src: PropTypes.string,
+  ariaLabel: PropTypes.string,
+  ariaHidden: PropTypes.bool
 };
 CustomSvgIcon.propTypes = {
   className: "",
-  src: ""
+  src: "",
+  ariaLabel: undefined,
+  ariaHidden: false
 };
 
 export default CustomSvgIcon;

--- a/src/components/Icon/CustomSvgIcon.jsx
+++ b/src/components/Icon/CustomSvgIcon.jsx
@@ -1,12 +1,13 @@
 /* eslint-disable react/jsx-props-no-spreading */
-import React from "react";
+import React, { useMemo } from "react";
 import PropTypes from "prop-types";
 import cx from "classnames";
 import SVG from "react-inlinesvg";
 import "./CustomSvgIcon.scss";
+import { getScreenReaderAccessProps } from "../../helpers/screenReaderAccessHelper";
 
 const CustomSvgIcon = ({ className, src, onClick, clickable, ...props }) => {
-  const tabIndex = clickable ? 0 : -1;
+  const screenReaderAccessProps = useMemo(() => getScreenReaderAccessProps(), []);
   return (
     <SVG
       tabIndex={tabIndex}

--- a/src/components/Icon/FontIcon/FontIcon.jsx
+++ b/src/components/Icon/FontIcon/FontIcon.jsx
@@ -2,20 +2,25 @@ import React, { forwardRef } from "react";
 import "./FontIcon.scss";
 import classNames from "classnames";
 
-const FontIcon = forwardRef(({ className, onClick, iconLabel, tabIndex, icon, role = "img", ariaHidden }, iconRef) => {
-  const iconClassName = typeof icon === "function" ? "" : icon;
-  return (
-    <span
-      aria-hidden={ariaHidden}
-      className={classNames(className, "fa", iconClassName)}
-      onClick={onClick}
-      ref={iconRef}
-      aria-label={iconLabel}
-      tabIndex={tabIndex}
-      role={role}
-    >
-      {typeof icon === "function" && icon()}
-    </span>
-  );
-});
+const FontIcon = forwardRef(
+  (
+    { className, onClick, "aria-label": iconLabel, tabIndex, icon, role = "img", "aria-hidden": ariaHidden },
+    iconRef
+  ) => {
+    const iconClassName = typeof icon === "function" ? "" : icon;
+    return (
+      <span
+        aria-hidden={ariaHidden}
+        className={classNames(className, "fa", iconClassName)}
+        onClick={onClick}
+        ref={iconRef}
+        aria-label={iconLabel}
+        tabIndex={tabIndex}
+        role={role}
+      >
+        {typeof icon === "function" && icon()}
+      </span>
+    );
+  }
+);
 export default FontIcon;

--- a/src/components/Icon/Icon.jsx
+++ b/src/components/Icon/Icon.jsx
@@ -25,21 +25,16 @@ const Icon = forwardRef(
     },
     ref
   ) => {
-    const {
-      tabIndex,
-      ["aria-hidden"]: isHidden,
-      ["aria-label"]: ariaLabel,
-      onClickCallback,
-      computedClassName,
-      iconRef,
-      role
-    } = useIconProps({
+    const { screenReaderAccessProps, onClickCallback, computedClassName, iconRef } = useIconProps({
       onClick,
+      iconLabel,
       clickable,
       className,
       isDecorationOnly: ariaHidden,
       ignoreFocusStyle
     });
+
+    screenReaderAccessProps.tabIndex = externalTabIndex ?? screenReaderAccessProps.tabIndex;
 
     const mergedRef = useMergeRefs({ refs: [ref, iconRef] });
 
@@ -51,28 +46,22 @@ const Icon = forwardRef(
       const IconComponent = icon;
       return (
         <IconComponent
+          {...screenReaderAccessProps}
           ref={mergedRef}
-          aria-hidden={isHidden}
-          aria-label={iconLabel}
           size={iconSize.toString()}
           onClick={onClick}
-          tabIndex={externalTabIndex ?? tabIndex}
           className={computedClassName}
-          role={role}
         />
       );
     }
 
     return (
       <FontIcon
-        aria-hidden={isHidden}
+        {...screenReaderAccessProps}
         className={cx(computedClassName)}
         onClick={onClickCallback}
         ref={mergedRef}
-        iconLabel={iconLabel}
-        tabIndex={externalTabIndex ?? tabIndex}
         icon={icon}
-        role={role}
       />
     );
   }

--- a/src/components/Icon/Icon.jsx
+++ b/src/components/Icon/Icon.jsx
@@ -31,10 +31,9 @@ const Icon = forwardRef(
       clickable,
       className,
       isDecorationOnly: ariaHidden,
-      ignoreFocusStyle
+      ignoreFocusStyle,
+      externalTabIndex
     });
-
-    screenReaderAccessProps.tabIndex = externalTabIndex ?? screenReaderAccessProps.tabIndex;
 
     const mergedRef = useMergeRefs({ refs: [ref, iconRef] });
 

--- a/src/components/Icon/Icon.jsx
+++ b/src/components/Icon/Icon.jsx
@@ -25,10 +25,19 @@ const Icon = forwardRef(
     },
     ref
   ) => {
-    const { tabindex, onClickCallback, computedClassName, iconRef, role } = useIconProps({
+    const {
+      tabIndex,
+      ["aria-hidden"]: isHidden,
+      ["aria-label"]: ariaLabel,
+      onClickCallback,
+      computedClassName,
+      iconRef,
+      role
+    } = useIconProps({
       onClick,
       clickable,
       className,
+      isDecorationOnly: ariaHidden,
       ignoreFocusStyle
     });
 
@@ -43,11 +52,11 @@ const Icon = forwardRef(
       return (
         <IconComponent
           ref={mergedRef}
-          aria-hidden={clickable ? ariaHidden : "true"}
+          aria-hidden={isHidden}
           aria-label={iconLabel}
           size={iconSize.toString()}
           onClick={onClick}
-          tabIndex={externalTabIndex ?? tabindex}
+          tabIndex={externalTabIndex ?? tabIndex}
           className={computedClassName}
           role={role}
         />
@@ -56,12 +65,12 @@ const Icon = forwardRef(
 
     return (
       <FontIcon
-        aria-hidden={clickable ? ariaHidden : "true"}
+        aria-hidden={isHidden}
         className={cx(computedClassName)}
         onClick={onClickCallback}
         ref={mergedRef}
         iconLabel={iconLabel}
-        tabIndex={externalTabIndex ?? tabindex}
+        tabIndex={externalTabIndex ?? tabIndex}
         icon={icon}
         role={role}
       />

--- a/src/components/Icon/__stories__/icon.stories.js
+++ b/src/components/Icon/__stories__/icon.stories.js
@@ -22,7 +22,11 @@ export const Icons = () => {
       </FlexLayout>
       <FlexLayout className="main-icon-story">
         <div className="single-icon-wrapper" style={{ color: "var(--color-egg_yolk)" }}>
-          <Icon iconType={Icon.type.ICON_FONT} iconLabel="my font awesome start icon" icon="fa fa-star" clickable />
+          <Icon
+            iconType={Icon.type.ICON_FONT}
+            iconLabel="my font awesome start icon"
+            icon="fa fa-star"
+          />
         </div>
         <DescriptionLabel>Font Icon</DescriptionLabel>
       </FlexLayout>

--- a/src/components/Icon/__stories__/icon.stories.js
+++ b/src/components/Icon/__stories__/icon.stories.js
@@ -22,11 +22,7 @@ export const Icons = () => {
       </FlexLayout>
       <FlexLayout className="main-icon-story">
         <div className="single-icon-wrapper" style={{ color: "var(--color-egg_yolk)" }}>
-          <Icon
-            iconType={Icon.type.ICON_FONT}
-            iconLabel="my font awesome start icon"
-            icon="fa fa-star"
-          />
+          <Icon iconType={Icon.type.ICON_FONT} iconLabel="my font awesome start icon" icon="fa fa-star" clickable />
         </div>
         <DescriptionLabel>Font Icon</DescriptionLabel>
       </FlexLayout>

--- a/src/components/Icon/hooks/useIconProps.js
+++ b/src/components/Icon/hooks/useIconProps.js
@@ -8,7 +8,15 @@ import useIconScreenReaderAccessProps from "../../../hooks/useIconScreenReaderAc
 
 const KEYS = [keyCodes.ENTER, keyCodes.SPACE];
 
-export default function useIconProps({ onClick, className, clickable, ignoreFocusStyle, isDecorationOnly, iconLabel }) {
+export default function useIconProps({
+  onClick,
+  className,
+  clickable,
+  ignoreFocusStyle,
+  isDecorationOnly,
+  iconLabel,
+  externalTabIndex
+}) {
   const iconRef = useRef(null);
   const onEnterCallback = useCallback(
     event => {
@@ -61,6 +69,8 @@ export default function useIconProps({ onClick, className, clickable, ignoreFocu
     label: iconLabel,
     isDecorationOnly
   });
+
+  screenReaderAccessProps.tabIndex = externalTabIndex ?? screenReaderAccessProps.tabIndex;
 
   return {
     screenReaderAccessProps,

--- a/src/components/Icon/hooks/useIconProps.js
+++ b/src/components/Icon/hooks/useIconProps.js
@@ -63,7 +63,7 @@ export default function useIconProps({ onClick, className, clickable, ignoreFocu
   });
 
   return {
-    ...screenReaderAccessProps,
+    screenReaderAccessProps,
     onClickCallback,
     computedClassName,
     onEnterCallback,

--- a/src/components/Icon/hooks/useIconProps.js
+++ b/src/components/Icon/hooks/useIconProps.js
@@ -4,10 +4,11 @@ import NOOP from "lodash/noop";
 import useEventListener from "../../../hooks/useEventListener";
 import useKeyEvent from "../../../hooks/useKeyEvent";
 import { keyCodes } from "../../../constants/KeyCodes";
+import useIconScreenReaderAccessProps from "../../../hooks/useIconScreenReaderAccessProps";
 
 const KEYS = [keyCodes.ENTER, keyCodes.SPACE];
 
-export default function useIconProps({ onClick, className, clickable, ignoreFocusStyle }) {
+export default function useIconProps({ onClick, className, clickable, ignoreFocusStyle, isDecorationOnly, iconLabel }) {
   const iconRef = useRef(null);
   const onEnterCallback = useCallback(
     event => {
@@ -54,15 +55,18 @@ export default function useIconProps({ onClick, className, clickable, ignoreFocu
     },
     [onClick]
   );
-  const tabindex = clickable ? 0 : -1;
-  const role = clickable ? "button" : undefined;
+
+  const screenReaderAccessProps = useIconScreenReaderAccessProps({
+    isClickable: clickable,
+    label: iconLabel,
+    isDecorationOnly
+  });
 
   return {
-    tabindex,
+    ...screenReaderAccessProps,
     onClickCallback,
     computedClassName,
     onEnterCallback,
-    iconRef,
-    role
+    iconRef
   };
 }

--- a/src/components/MultiStepIndicator/__tests__/__snapshots__/multiStepIndicator.jest.js.snap
+++ b/src/components/MultiStepIndicator/__tests__/__snapshots__/multiStepIndicator.jest.js.snap
@@ -21,14 +21,12 @@ exports[`MultiStepIndicator Render tests Renders correctly with non-default prop
         className="monday-style-step-indicator-component__number-container__text monday-style-step-indicator-component--type-success__number-container__text monday-style-step-indicator-component--status-fulfilled__number-container__text"
       >
         <svg
-          aria-hidden="true"
-          aria-label="fulfilled"
+          aria-hidden={true}
           className="icon_component monday-style-step-indicator-component__number-container__text__check-icon icon_component--no-focus-style"
           fill="currentColor"
           height="16"
           onClick={[Function]}
-          role=""
-          tabIndex={-1}
+          role="img"
           viewBox="0 0 20 20"
           width="16"
         >

--- a/src/components/MultiStepIndicator/components/StepIndicator/StepIndicator.jsx
+++ b/src/components/MultiStepIndicator/components/StepIndicator/StepIndicator.jsx
@@ -80,6 +80,7 @@ const StepIndicator = ({
         iconType={fulfilledStepIconType}
         ignoreFocusStyle
         clickable={false}
+        ariaHidden={true}
       />
     ) : (
       stepNumber

--- a/src/components/Search/Search.jsx
+++ b/src/components/Search/Search.jsx
@@ -146,7 +146,7 @@ Search.defaultProps = {
   className: "",
   id: "search",
   validation: null,
-  inputAriaLabel: "",
+  inputAriaLabel: undefined,
   searchResultsContainerId: "",
   activeDescendant: "",
   iconNames: ICON_NAMES

--- a/src/components/Tabs/Tab/Tab.jsx
+++ b/src/components/Tabs/Tab/Tab.jsx
@@ -5,59 +5,49 @@ import useMergeRefs from "../../../hooks/useMergeRefs";
 import Icon from "../../Icon/Icon";
 import "./Tab.scss";
 
-const Tab = forwardRef(({
-  className,
-  id,
-  value,
-  disabled,
-  active,
-  focus,
-  onClick,
-  icon,
-  iconType,
-  iconSide,
-  children
-}, ref) => {
-  const componentRef = useRef(null);
-  const mergedRef = useMergeRefs({ refs: [ref, componentRef] });
+const Tab = forwardRef(
+  ({ className, id, value, disabled, active, focus, onClick, icon, iconType, iconSide, children }, ref) => {
+    const componentRef = useRef(null);
+    const mergedRef = useMergeRefs({ refs: [ref, componentRef] });
 
-  function renderIconAndChildren() {
-    if (!icon) return children;
+    function renderIconAndChildren() {
+      if (!icon) return children;
 
-    const iconElement = (
-      <Icon
-        clickable={false}
-        icon={icon}
-        className={cx("tab-icon", iconSide)}
-        iconSize={18}
-        ignoreFocusStyle
-      />
-    );
+      const iconElement = (
+        <Icon
+          clickable={false}
+          ariaHidden={true}
+          icon={icon}
+          className={cx("tab-icon", iconSide)}
+          iconSize={18}
+          ignoreFocusStyle
+        />
+      );
 
-    if (iconSide === "left") {
-      return [iconElement, ...children];
+      if (iconSide === "left") {
+        return [iconElement, ...children];
+      }
+
+      return [...children, iconElement];
     }
 
-    return [...children, iconElement];
-  }
-
-  return (
-    <li ref={mergedRef}
+    return (
+      <li
+        ref={mergedRef}
         key={id}
         className={cx("tab--wrapper", className, { active, disabled, "focus-visible": focus })}
         id={id}
         role="tab"
         aria-selected={active}
         aria-disabled={disabled}
-    >
-        <a className="tab-inner"
-           onClick={() => !disabled && onClick(value)}
-        >
-            {renderIconAndChildren()}
+      >
+        <a className="tab-inner" onClick={() => !disabled && onClick(value)}>
+          {renderIconAndChildren()}
         </a>
-    </li>
-  );
-});
+      </li>
+    );
+  }
+);
 
 Tab.propTypes = {
   className: PropTypes.string,

--- a/src/components/Tabs/Tab/__tests__/__snapshots__/tab.jest.js.snap
+++ b/src/components/Tabs/Tab/__tests__/__snapshots__/tab.jest.js.snap
@@ -73,14 +73,12 @@ exports[`<Tab /> Snapshot tests renders correctly tab with icon on left 1`] = `
     onClick={[Function]}
   >
     <svg
-      aria-hidden="true"
-      aria-label=""
+      aria-hidden={true}
       className="icon_component tab-icon left icon_component--no-focus-style"
       fill="currentColor"
       height="18"
       onClick={[Function]}
-      role=""
-      tabIndex={-1}
+      role="img"
       viewBox="0 0 20 20"
       width="18"
     >
@@ -114,14 +112,12 @@ exports[`<Tab /> Snapshot tests renders correctly tab with icon on right 1`] = `
     a
     b
     <svg
-      aria-hidden="true"
-      aria-label=""
+      aria-hidden={true}
       className="icon_component tab-icon right icon_component--no-focus-style"
       fill="currentColor"
       height="18"
       onClick={[Function]}
-      role=""
-      tabIndex={-1}
+      role="img"
       viewBox="0 0 20 20"
       width="18"
     >

--- a/src/components/TextField/TextField.jsx
+++ b/src/components/TextField/TextField.jsx
@@ -278,7 +278,7 @@ TextField.defaultProps = {
   clearOnIconClick: false,
   labelIconName: "",
   showCharCount: false,
-  inputAriaLabel: "",
+  inputAriaLabel: undefined,
   searchResultsContainerId: "",
   activeDescendant: "",
   iconsNames: EMPTY_OBJECT,

--- a/src/components/Toggle/Toggle.scss
+++ b/src/components/Toggle/Toggle.scss
@@ -7,6 +7,9 @@
     align-items: center;
     &--disabled {
       opacity: 0.4;
+      & .monday-style-toggle {
+
+      }
       & .monday-style-toggle_text {
         color: rgba(var(--primary-text-color), 0.4);
       }

--- a/src/components/Toggle/Toggle.scss
+++ b/src/components/Toggle/Toggle.scss
@@ -7,8 +7,8 @@
     align-items: center;
     &--disabled {
       opacity: 0.4;
-      & .monday-style-toggle {
-
+      & .monday-style-toggle_toggle {
+        cursor: not-allowed;
       }
       & .monday-style-toggle_text {
         color: rgba(var(--primary-text-color), 0.4);

--- a/src/helpers/screenReaderAccessHelper.js
+++ b/src/helpers/screenReaderAccessHelper.js
@@ -1,0 +1,28 @@
+export function getIconScreenReaderAccessProps({ isClickable, isDecorationOnly, isKeyboardAccessible, label }) {
+  if (isClickable) return getClickableIconScreenReaderAccessProps({ label, isDecorationOnly, isKeyboardAccessible });
+  return {
+    role: "img",
+    "aria-hidden": isDecorationOnly,
+    tabIndex: undefined,
+    "aria-label": isDecorationOnly ? undefined : label
+  };
+}
+
+export function getClickableScreenReaderAccessProps({ isKeyboardAccessible = true, isDecorationOnly = false }) {
+  return {
+    role: "button",
+    tabIndex: isKeyboardAccessible ? 0 : -1,
+    isDecorationOnly
+  };
+}
+
+export function getClickableIconScreenReaderAccessProps({
+  label,
+  isDecorationOnly = false,
+  isKeyboardAccessible = true
+}) {
+  return {
+    ...getClickableScreenReaderAccessProps({ isDecorationOnly, isKeyboardAccessible }),
+    "aria-label": label
+  };
+}

--- a/src/helpers/screenReaderAccessHelper.js
+++ b/src/helpers/screenReaderAccessHelper.js
@@ -12,7 +12,7 @@ export function getClickableScreenReaderAccessProps({ isKeyboardAccessible = tru
   return {
     role: "button",
     tabIndex: isKeyboardAccessible ? 0 : -1,
-    isDecorationOnly
+    "aria-hidden": isDecorationOnly
   };
 }
 

--- a/src/hooks/useIconScreenReaderAccessProps.js
+++ b/src/hooks/useIconScreenReaderAccessProps.js
@@ -1,0 +1,15 @@
+import { useMemo } from "react";
+import { getIconScreenReaderAccessProps } from "../helpers/screenReaderAccessHelper";
+
+export default function useIconScreenReaderAccessProps({ isClickable, label, isDecorationOnly }) {
+  const screenReaderAccessProps = useMemo(
+    () =>
+      getIconScreenReaderAccessProps({
+        isClickable,
+        label,
+        isDecorationOnly
+      }),
+    [isClickable, label, isDecorationOnly]
+  );
+  return screenReaderAccessProps;
+}


### PR DESCRIPTION
## Go over this checklist before submitting your Pull Request

- please do not merge before talk with me :) !
- fix toggle curser when disable
- according to Talya feedback about icons: from now on each icon has 3 a11y states:
- **clickble**: tab index :0, aria hidden false, aria label and role:" button"
- **hidden**: _no tab index (instead of -1, because not clickable item should not have any tab index)_, aria-hidden: true , no aria-label 
- not hidden and not clickable (like text): aria-hidden: false, role: img, aria-label, **no tab index (instead of -1, because not clickable item should not have any tab index**
- Custom svg icon is now support ariaLabel and aria hidden (and same logic as above will be activate)
**- we need to notice that after this change icon will not be hidden by default if they have clickable false value**

### before merge we need to understand how this change will effect the monolith (api wise)


### Updating existing component
#### Basic
- [ V] PR has description
- [ V] Changes to the component are backward compatible (including selectors structure). If not - add to the title of the PR "BREAKABLE_CHANGE""
- [ V] All changes to the component are reflected in the ReadMe
- [ v] If component is old and was not compliant with the latest guidelines - it was fixed (optional) 
#### Style
- [ ] CSS selectors are named using [BEM convention](http://getbem.com/naming/) 
- [ ] Design is compatible with [Monday Design System](https://design.monday.com/)
#### Storybook
- [ V] All the changes to the component should be reflected in the Storybook.
- [ V] Component passed Accessibility Plugin checks
#### Tests
- [ v] All current tests are passing
- [ ] New functionality is covered with tests
- [ V] Tests are compliant with TESTING_README.md instructions


