### PR TITLE
margin between toast button & give access to toast types 

### DIFF
--- a/src/components/Toast/Toast.jsx
+++ b/src/components/Toast/Toast.jsx
@@ -95,6 +95,8 @@ const Toast = ({ open, autoHideDuration, type, icon, hideIcon, action, children,
   );
 };
 
+Toast.types = TOAST_TYPES;
+
 Toast.propTypes = {
   /** If true, Toast is open (visible) */
   open: PropTypes.bool,

--- a/src/components/Toast/Toast.jsx
+++ b/src/components/Toast/Toast.jsx
@@ -33,9 +33,8 @@ const getIcon = (type, icon) => {
     />
   ) : null;
 };
-
-const Toast = ({ open, autoHideDuration, type, icon, hideIcon, action, children, closeable, onClose }) => {
-  const classNames = useMemo(() => cx("monday-style-toast", `monday-style-toast--type-${type}`), [type]);
+const Toast = ({ open, autoHideDuration, type, icon, hideIcon, action, children, closeable, onClose, className }) => {
+  const classNames = useMemo(() => cx("monday-style-toast", `monday-style-toast--type-${type}`, className), [type]);
   const handleClose = useCallback(() => {
     if (onClose) {
       onClose();
@@ -99,6 +98,7 @@ Toast.types = TOAST_TYPES;
 
 Toast.propTypes = {
   /** If true, Toast is open (visible) */
+  className: PropTypes.string,
   open: PropTypes.bool,
   type: PropTypes.oneOf([TOAST_TYPES.NORMAL, TOAST_TYPES.POSITIVE, TOAST_TYPES.NEGATIVE]),
   /** Possible to override the dafult icon */
@@ -118,6 +118,7 @@ Toast.propTypes = {
 
 Toast.defaultProps = {
   type: TOAST_TYPES.NORMAL,
+  className: "",
   open: false,
   action: null,
   hideIcon: false,

--- a/src/components/Toast/Toast.scss
+++ b/src/components/Toast/Toast.scss
@@ -35,6 +35,7 @@
 
   &-action {
     padding-right: $spacing-small;
+    margin-left: $spacing-large;
   }
 
   &--type {

--- a/src/components/Toast/__stories__/toast.stories.js
+++ b/src/components/Toast/__stories__/toast.stories.js
@@ -52,7 +52,7 @@ export const Sandbox = () => {
             autoHideDuration={knobs.autoHideDuration}
             hideIcon={knobs.hideIcon}
           >
-            Something Happened!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+            Something Happened
           </Toast>
         </StoryStateColumn>
       </StoryStateRow>

--- a/src/components/Toast/__stories__/toast.stories.js
+++ b/src/components/Toast/__stories__/toast.stories.js
@@ -52,7 +52,7 @@ export const Sandbox = () => {
             autoHideDuration={knobs.autoHideDuration}
             hideIcon={knobs.hideIcon}
           >
-            Something Happened
+            Something Happened!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
           </Toast>
         </StoryStateColumn>
       </StoryStateRow>

--- a/src/components/Toast/__stories__/toast.stories.js
+++ b/src/components/Toast/__stories__/toast.stories.js
@@ -1,21 +1,21 @@
-import { useState } from "react";
+import React, { useMemo, useState } from "react";
 import { number, select, boolean } from "@storybook/addon-knobs";
-import { TOAST_TYPES } from "../ToastConstants";
 import Toast from "../Toast";
 import Button from "../../Button/Button";
 import Icon from "../../Icon/Icon";
 import Send from "../../Icon/Icons/components/Send";
 import { StoryStateColumn, StoryStateRow } from "../../storybook-helpers";
 
-export const Toasts = () => {
+export const Sandbox = () => {
   const sendIconElement = (
     <Icon iconType={Icon.type.SVG} clickable={false} icon={Send} iconSize="20px" ignoreFocusStyle />
   );
+
   const knobs = {
     type: select("type", {
-      Normal: TOAST_TYPES.NORMAL,
-      Positive: TOAST_TYPES.POSITIVE,
-      Negative: TOAST_TYPES.NEGATIVE
+      Normal: Toast.types.NORMAL,
+      Positive: Toast.types.POSITIVE,
+      Negative: Toast.types.NEGATIVE
     }),
     closeable: boolean("closeable", true),
     autoHideDuration: number("autoHideDuration", 0),
@@ -59,7 +59,6 @@ export const Toasts = () => {
     </section>
   );
 };
-
 export default {
   title: "Components|Toast",
   component: Toast

--- a/src/components/Toast/__stories__/toast.stories.js
+++ b/src/components/Toast/__stories__/toast.stories.js
@@ -52,7 +52,7 @@ export const Sandbox = () => {
             autoHideDuration={knobs.autoHideDuration}
             hideIcon={knobs.hideIcon}
           >
-            Something Happened
+            Something Happened!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
           </Toast>
         </StoryStateColumn>
       </StoryStateRow>


### PR DESCRIPTION
give access to toast types, css change and add support on class name property
before:
<img width="498" alt="Screen Shot 2021-07-20 at 10 00 35" src="https://user-images.githubusercontent.com/72390374/126276140-679a7e1e-10a5-494d-9ccb-872099a1f43c.png">

after:
<img width="540" alt="Screen Shot 2021-07-20 at 10 00 09" src="https://user-images.githubusercontent.com/72390374/126276097-2ad12812-f3a7-491b-9b9f-6f3e0646e9cf.png">
