### PR TITLE
ruti/tabList-support-both-tab-onClick-and-panel-switch

### DIFF
--- a/src/components/Tabs/TabList/TabList.jsx
+++ b/src/components/Tabs/TabList/TabList.jsx
@@ -18,7 +18,8 @@ const TabList = forwardRef(({ className, id, onTabChange, activeTabId, tabType, 
   }
 
   const onTabClick = useCallback(
-    tabId => {
+    (tabId, tabCallbackFunc) => {
+      if (tabCallbackFunc) tabCallbackFunc(tabId);
       onTabSelect(tabId);
       setFocusTab(-1);
     },
@@ -71,7 +72,7 @@ const TabList = forwardRef(({ className, id, onTabChange, activeTabId, tabType, 
             value: index,
             active: activeTab === index,
             focus: focusTab === index,
-            onClick: onTabClick
+            onClick: value => onTabClick(value, child.props.onClick)
           });
         })}
       </ul>


### PR DESCRIPTION
Now a Tab that is a part of TabList can have onClick callback and it won't be overridden by the panel switch.

