### PR TITLE
Add support in tipseen component for: submitButtonText & submitButtonOnClick & dismissButtonText & dismissButtonOnClick & hideWhenReferenceHidden

### DIFF
--- a/src/components/Tipseen/Tipseen.jsx
+++ b/src/components/Tipseen/Tipseen.jsx
@@ -135,7 +135,7 @@ Tipseen.propTypes = {
     main: PropTypes.number,
     secondary: PropTypes.number
   }),
-  hideWhenReferenceHidden: false
+  hideWhenReferenceHidden: PropTypes.bool
 };
 Tipseen.defaultProps = {
   className: "",

--- a/src/components/Tipseen/Tipseen.jsx
+++ b/src/components/Tipseen/Tipseen.jsx
@@ -38,7 +38,8 @@ const Tipseen = forwardRef(
       isCloseButtonOnImage,
       showTrigger,
       width,
-      moveBy
+      moveBy,
+      hideWhenReferenceHidden
     },
     ref
   ) => {
@@ -91,6 +92,7 @@ const Tipseen = forwardRef(
           containerSelector={containerSelector}
           disableDialogSlide={false}
           moveBy={moveBy}
+          hideWhenReferenceHidden={hideWhenReferenceHidden}
         >
           {children}
         </Tooltip>
@@ -132,7 +134,8 @@ Tipseen.propTypes = {
   moveBy: PropTypes.shape({
     main: PropTypes.number,
     secondary: PropTypes.number
-  })
+  }),
+  hideWhenReferenceHidden: false
 };
 Tipseen.defaultProps = {
   className: "",
@@ -149,7 +152,8 @@ Tipseen.defaultProps = {
   showTrigger: [],
   justify: Tipseen.justifyTypes.CENTER,
   width: undefined,
-  moveBy: undefined
+  moveBy: undefined,
+  hideWhenReferenceHidden: false
 };
 
 export default Tipseen;

--- a/src/components/Tipseen/TipseenContent.jsx
+++ b/src/components/Tipseen/TipseenContent.jsx
@@ -25,7 +25,6 @@ const TipseenContent = ({
   // Backward compatibility for props naming
   submitButtonProps
 }) => {
-  debugger;
   const {
     content: dismissContent,
     className: dismissClassName,

--- a/src/components/Tipseen/TipseenContent.jsx
+++ b/src/components/Tipseen/TipseenContent.jsx
@@ -9,8 +9,9 @@ import "./TipseenContent.scss";
 import { backwardCompatibilityForProperties } from "../../helpers/backwardCompatibilityForProperties";
 
 const BASE_CSS_CLASS = "monday-style-tipseen-content";
-
 const bemHelper = BEMClass(BASE_CSS_CLASS);
+const EMPTY_OBJECT = {};
+
 const TipseenContent = ({
   title,
   children,
@@ -30,7 +31,7 @@ const TipseenContent = ({
     className: dismissClassName,
     onClick: dismissDeprecatedOnClick,
     ...otherDismissButtonProps
-  } = dismissButtonProps || {};
+  } = dismissButtonProps || EMPTY_OBJECT;
   const overrideDismissContent = backwardCompatibilityForProperties(
     [dismissButtonText, dismissContent],
     DISMISS_BUTTON_TEXT
@@ -41,7 +42,7 @@ const TipseenContent = ({
     className: submitClassName,
     onClick: submitDeprecatedOnClick,
     ...otherSubmitButtonProps
-  } = submitButtonProps || {};
+  } = submitButtonProps || EMPTY_OBJECT;
   const overrideSubmitContent = backwardCompatibilityForProperties(
     [submitButtonText, submitContent],
     SUBMIT_BUTTON_TEXT

--- a/src/components/Tipseen/TipseenContent.jsx
+++ b/src/components/Tipseen/TipseenContent.jsx
@@ -17,9 +17,9 @@ const TipseenContent = ({
   isDismissHidden,
   isSubmitHidden,
   submitButtonText,
-  submitButtonOnClick,
+  onSubmit,
   dismissButtonText,
-  dismissButtonOnClick,
+  onDismiss,
   // Backward compatibility for props naming
   dismissButtonProps,
   // Backward compatibility for props naming
@@ -36,10 +36,7 @@ const TipseenContent = ({
     [dismissButtonText, dismissContent],
     DISMISS_BUTTON_TEXT
   );
-  const overrideDismissOnClick = backwardCompatibilityForProperties(
-    [dismissButtonOnClick, dismissDeprecatedOnClick],
-    NOOP
-  );
+  const overrideDismissOnClick = backwardCompatibilityForProperties([onDismiss, dismissDeprecatedOnClick], NOOP);
   const {
     content: submitContent,
     className: submitClassName,
@@ -50,10 +47,7 @@ const TipseenContent = ({
     [submitButtonText, submitContent],
     SUBMIT_BUTTON_TEXT
   );
-  const overrideSubmitOnClick = backwardCompatibilityForProperties(
-    [submitButtonOnClick, submitDeprecatedOnClick],
-    NOOP
-  );
+  const overrideSubmitOnClick = backwardCompatibilityForProperties([onSubmit, submitDeprecatedOnClick], NOOP);
   return (
     <TipseenBasicContent title={title} className={BASE_CSS_CLASS}>
       {children ? <span className={bemHelper({ element: "content" })}>{children}</span> : null}
@@ -89,28 +83,24 @@ const TipseenContent = ({
 
 TipseenContent.propTypes = {
   title: PropTypes.string,
-  onSubmit: PropTypes.func,
-  onDismiss: PropTypes.func,
   isDismissHidden: PropTypes.bool,
   children: PropTypes.oneOfType([PropTypes.arrayOf(PropTypes.node), PropTypes.node]),
   isSubmitHidden: PropTypes.bool,
   submitButtonText: PropTypes.string,
-  submitButtonOnClick: PropTypes.func,
+  onSubmit: PropTypes.func,
   dismissButtonText: PropTypes.string,
-  dismissButtonOnClick: PropTypes.func
+  onDismiss: PropTypes.func
 };
 
 TipseenContent.defaultProps = {
   title: undefined,
   children: null,
-  onSubmit: NOOP,
-  onDismiss: NOOP,
   isDismissHidden: true,
   isSubmitHidden: false,
   submitButtonText: undefined,
-  submitButtonOnClick: NOOP,
+  onSubmit: NOOP,
   dismissButtonText: undefined,
-  dismissButtonOnClick: NOOP
+  onDismiss: NOOP
 };
 
 export default TipseenContent;

--- a/src/components/Tipseen/TipseenContent.jsx
+++ b/src/components/Tipseen/TipseenContent.jsx
@@ -6,6 +6,7 @@ import Button from "../Button/Button";
 import { DISMISS_BUTTON_TEXT, SUBMIT_BUTTON_TEXT } from "./TipseenConstants";
 import TipseenBasicContent from "./TipseenBasicContent";
 import "./TipseenContent.scss";
+import { backwardCompatibilityForProperties } from "../../helpers/backwardCompatibilityForProperties";
 
 const BASE_CSS_CLASS = "monday-style-tipseen-content";
 
@@ -15,11 +16,44 @@ const TipseenContent = ({
   children,
   isDismissHidden,
   isSubmitHidden,
+  submitButtonText,
+  submitButtonOnClick,
+  dismissButtonText,
+  dismissButtonOnClick,
+  // Backward compatibility for props naming
   dismissButtonProps,
+  // Backward compatibility for props naming
   submitButtonProps
 }) => {
-  const { content: dismissContent, className: dismissClassName, ...otherDismissButtonProps } = dismissButtonProps;
-  const { content: submitContent, className: submitClassName, ...otherSubmitButtonProps } = submitButtonProps;
+  debugger;
+  const {
+    content: dismissContent,
+    className: dismissClassName,
+    onClick: dismissDeprecatedOnClick,
+    ...otherDismissButtonProps
+  } = dismissButtonProps || {};
+  const overrideDismissContent = backwardCompatibilityForProperties(
+    [dismissButtonText, dismissContent],
+    DISMISS_BUTTON_TEXT
+  );
+  const overrideDismissOnClick = backwardCompatibilityForProperties(
+    [dismissButtonOnClick, dismissDeprecatedOnClick],
+    NOOP
+  );
+  const {
+    content: submitContent,
+    className: submitClassName,
+    onClick: submitDeprecatedOnClick,
+    ...otherSubmitButtonProps
+  } = submitButtonProps || {};
+  const overrideSubmitContent = backwardCompatibilityForProperties(
+    [submitButtonText, submitContent],
+    SUBMIT_BUTTON_TEXT
+  );
+  const overrideSubmitOnClick = backwardCompatibilityForProperties(
+    [submitButtonOnClick, submitDeprecatedOnClick],
+    NOOP
+  );
   return (
     <TipseenBasicContent title={title} className={BASE_CSS_CLASS}>
       {children ? <span className={bemHelper({ element: "content" })}>{children}</span> : null}
@@ -30,9 +64,10 @@ const TipseenContent = ({
             color={Button.colors.ON_PRIMARY_COLOR}
             className={cx(bemHelper({ element: "dismiss" }), dismissClassName)}
             size={Button.sizes.SMALL}
+            onClick={overrideDismissOnClick}
             {...otherDismissButtonProps}
           >
-            {dismissContent || DISMISS_BUTTON_TEXT}
+            {overrideDismissContent}
           </Button>
         )}
         {isSubmitHidden ? null : (
@@ -41,9 +76,10 @@ const TipseenContent = ({
             color={Button.colors.ON_PRIMARY_COLOR}
             size={Button.sizes.SMALL}
             className={cx(bemHelper({ element: "submit" }), submitClassName)}
+            onClick={overrideSubmitOnClick}
             {...otherSubmitButtonProps}
           >
-            {submitContent || SUBMIT_BUTTON_TEXT}
+            {overrideSubmitContent}
           </Button>
         )}
       </div>
@@ -58,14 +94,10 @@ TipseenContent.propTypes = {
   isDismissHidden: PropTypes.bool,
   children: PropTypes.oneOfType([PropTypes.arrayOf(PropTypes.node), PropTypes.node]),
   isSubmitHidden: PropTypes.bool,
-  // An object that contains all the props that will be passed to the dismiss button in order to
-  // override its default settings - support all button props with the same syntax
-  // eslint-disable-next-line react/forbid-prop-types
-  dismissButtonProps: PropTypes.object,
-  // An object that contains all the props that will be passed to the submit button in order to
-  // override its default settings - support all button props with the same syntax
-  // eslint-disable-next-line react/forbid-prop-types
-  submitButtonProps: PropTypes.object
+  submitButtonText: PropTypes.string,
+  submitButtonOnClick: PropTypes.func,
+  dismissButtonText: PropTypes.string,
+  dismissButtonOnClick: PropTypes.func
 };
 
 TipseenContent.defaultProps = {
@@ -75,8 +107,10 @@ TipseenContent.defaultProps = {
   onDismiss: NOOP,
   isDismissHidden: true,
   isSubmitHidden: false,
-  dismissButtonProps: {},
-  submitButtonProps: {}
+  submitButtonText: undefined,
+  submitButtonOnClick: NOOP,
+  dismissButtonText: undefined,
+  dismissButtonOnClick: NOOP
 };
 
 export default TipseenContent;

--- a/src/components/Tipseen/__stories__/tipseen.stories.js
+++ b/src/components/Tipseen/__stories__/tipseen.stories.js
@@ -94,6 +94,7 @@ export const Sandbox = () => (
       animationTypes={select("Animation types", Tipseen.animationTypes, Tipseen.animationTypes.EXPAND)}
       justify={select("justify", Tipseen.justifyTypes, Tipseen.justifyTypes.CENTER)}
       isCloseButtonHidden={boolean("Is close button hidden", false)}
+      hideWhenReferenceHidden={boolean("Hide when reference hidden", false)}
       content={
         <TipseenContent
           title={text("Title", "Title")}

--- a/src/components/Tipseen/__stories__/tipseen.stories.js
+++ b/src/components/Tipseen/__stories__/tipseen.stories.js
@@ -97,8 +97,10 @@ export const Sandbox = () => (
       content={
         <TipseenContent
           title={text("Title", "Title")}
-          isDismissHidden={boolean("Is dismiss hidden", false)}
+          isDismissHidden={boolean("Is dismiss hidden", true)}
           children={text("Tipseen content text", "Popover message will appear here loremipsum dolor samet…")}
+          submitButtonText={text("Submit button text", "Submit button text")}
+          dismissButtonText={text("Dismiss button text", "Dismiss button text")}
         />
       }
     >

--- a/src/components/Tipseen/__tests__/__snapshots__/tipseenContent.jest.js.snap
+++ b/src/components/Tipseen/__tests__/__snapshots__/tipseenContent.jest.js.snap
@@ -49,6 +49,64 @@ exports[`Tipseen content tests Snapshot Tests renders correctly 1`] = `
 </div>
 `;
 
+exports[`Tipseen content tests Snapshot Tests renders correctly when override dismiss button text 1`] = `
+<div
+  className="monday-style-tipseen-basic-content monday-style-tipseen-content"
+>
+  <span
+    className="monday-style-tipseen-content_content"
+  >
+    content
+  </span>
+  <div
+    className="monday-style-tipseen-content_buttons"
+  >
+    <button
+      aria-disabled={false}
+      className="monday-style-tipseen-content_submit monday-style-button monday-style-button--size-small monday-style-button--kind-primary monday-style-button--color-on-primary-color"
+      disabled={false}
+      onBlur={[Function]}
+      onClick={[Function]}
+      onFocus={[Function]}
+      onMouseDown={[Function]}
+      onMouseUp={[Function]}
+      type="button"
+    >
+      Submit
+    </button>
+  </div>
+</div>
+`;
+
+exports[`Tipseen content tests Snapshot Tests renders correctly when override submit button text 1`] = `
+<div
+  className="monday-style-tipseen-basic-content monday-style-tipseen-content"
+>
+  <span
+    className="monday-style-tipseen-content_content"
+  >
+    content
+  </span>
+  <div
+    className="monday-style-tipseen-content_buttons"
+  >
+    <button
+      aria-disabled={false}
+      className="monday-style-tipseen-content_submit monday-style-button monday-style-button--size-small monday-style-button--kind-primary monday-style-button--color-on-primary-color"
+      disabled={false}
+      onBlur={[Function]}
+      onClick={[Function]}
+      onFocus={[Function]}
+      onMouseDown={[Function]}
+      onMouseUp={[Function]}
+      type="button"
+    >
+      submit button text
+    </button>
+  </div>
+</div>
+`;
+
 exports[`Tipseen content tests Snapshot Tests renders correctly with empty props 1`] = `
 <div
   className="monday-style-tipseen-basic-content monday-style-tipseen-content"

--- a/src/components/Tipseen/__tests__/tipseenContent.jest.js
+++ b/src/components/Tipseen/__tests__/tipseenContent.jest.js
@@ -83,7 +83,7 @@ describe("Tipseen content tests", () => {
     it("call onSubmit function when click on dismiss button", () => {
       const onSubmitMock = jest.fn();
       const tipseenContent = renderComponent({
-        onSubmitButton: onSubmitMock
+        onSubmit: onSubmitMock
       });
       const submitButton = tipseenContent.getByText(SUBMIT_BUTTON_TEXT);
 

--- a/src/components/Tipseen/__tests__/tipseenContent.jest.js
+++ b/src/components/Tipseen/__tests__/tipseenContent.jest.js
@@ -44,6 +44,18 @@ describe("Tipseen content tests", () => {
         .toJSON();
       expect(tree).toMatchSnapshot();
     });
+    it("renders correctly when override submit button text", () => {
+      const tree = renderer
+        .create(<TipseenContent submitButtonText="submit button text">content</TipseenContent>)
+        .toJSON();
+      expect(tree).toMatchSnapshot();
+    });
+    it("renders correctly when override dismiss button text", () => {
+      const tree = renderer
+        .create(<TipseenContent dismissButtonText="dismiss button text">content</TipseenContent>)
+        .toJSON();
+      expect(tree).toMatchSnapshot();
+    });
   });
   describe("Integration Tests", () => {
     afterEach(() => {
@@ -51,37 +63,34 @@ describe("Tipseen content tests", () => {
     });
 
     it("call onDismiss function when click on dismiss button", () => {
-      const onClickMock = jest.fn();
-      const dismissButtonProps = {
-        onClick: onClickMock
+      const onDismissMock = jest.fn();
+      const onDismissButtonProps = {
+        onClick: onDismissMock
       };
 
       const tipseenContent = renderComponent({
         isDismissHidden: false,
-        dismissButtonProps
+        onDismiss: onDismissMock
       });
       const dismissButton = tipseenContent.getByText(DISMISS_BUTTON_TEXT);
 
       act(() => {
         fireEvent.click(dismissButton);
       });
-      expect(onClickMock.mock.calls.length).toBe(1);
+      expect(onDismissMock.mock.calls.length).toBe(1);
     });
 
     it("call onSubmit function when click on dismiss button", () => {
-      const onClickMock = jest.fn();
-      const submitButtonProps = {
-        onClick: onClickMock
-      };
+      const onSubmitMock = jest.fn();
       const tipseenContent = renderComponent({
-        submitButtonProps
+        onSubmitButton: onSubmitMock
       });
       const submitButton = tipseenContent.getByText(SUBMIT_BUTTON_TEXT);
 
       act(() => {
         fireEvent.click(submitButton);
       });
-      expect(onClickMock.mock.calls.length).toBe(1);
+      expect(onSubmitMock.mock.calls.length).toBe(1);
     });
   });
 });

--- a/src/components/Tooltip/Tooltip.jsx
+++ b/src/components/Tooltip/Tooltip.jsx
@@ -147,5 +147,6 @@ Tooltip.defaultProps = {
   withoutDialog: false,
   containerSelector: "#tooltips-container",
   immediateShowDelay: null,
-  tip: true
+  tip: true,
+  hideWhenReferenceHidden: false
 };

--- a/src/helpers/backwardCompatibilityForProperties.js
+++ b/src/helpers/backwardCompatibilityForProperties.js
@@ -1,3 +1,4 @@
-export function backwardCompatibilityForProperties(valuesArrayByMostUpdateNaming) {
-  return valuesArrayByMostUpdateNaming.find(value => value !== undefined);
+export function backwardCompatibilityForProperties(valuesArrayByMostUpdateNaming, defaultValue) {
+  const value = valuesArrayByMostUpdateNaming.find(currentValue => currentValue !== undefined);
+  return value || defaultValue;
 }

--- a/src/helpers/backwardCompatibilityForProperties.js
+++ b/src/helpers/backwardCompatibilityForProperties.js
@@ -1,4 +1,4 @@
-export function backwardCompatibilityForProperties(valuesArrayByMostUpdateNaming, defaultValue) {
+export function backwardCompatibilityForProperties(valuesArrayByMostUpdateNaming = [], defaultValue) {
   const value = valuesArrayByMostUpdateNaming.find(currentValue => currentValue !== undefined);
   return value || defaultValue;
 }


### PR DESCRIPTION
## Go over this checklist before submitting your Pull Request

Description: Add support in tipseen component for: submitButtonText & submitButtonOnClick & dismissButtonText & dismissButtonOnClick & hideWhenReferenceHidden.
The change in the button props is moshe tzemach idea after reviewing the tipseen in monolith changes.
The hideWhenReferenceHidden support is for fixing the monolith bug.

### Updating existing component
#### Basic
- [v] PR has description
- [ ] Changes to the component are backward compatible (including selectors structure). If not - add to the title of the PR "BREAKABLE_CHANGE""
- [v] All changes to the component are reflected in the ReadMe
- [ ] If component is old and was not compliant with the latest guidelines - it was fixed (optional) 
#### Style
- [ ] CSS selectors are named using [BEM convention](http://getbem.com/naming/) 
- [ ] Design is compatible with [Monday Design System](https://design.monday.com/)
#### Storybook
- [v] All the changes to the component should be reflected in the Storybook.
- [v] Component passed Accessibility Plugin checks
#### Tests
- [v] All current tests are passing
- [v] New functionality is covered with tests
- [v] Tests are compliant with TESTING_README.md instructions


