### PR TITLE
Combobox: fix the space between the search box to the first option

### DIFF
--- a/src/components/Combobox/__tests__/__snapshots__/combobox.jest.js.snap
+++ b/src/components/Combobox/__tests__/__snapshots__/combobox.jest.js.snap
@@ -207,7 +207,7 @@ exports[`<Combobox /> renders correctly with one option 1`] = `
     <div
       aria-label="Test"
       aria-selected={false}
-      className="combobox-option"
+      className="combobox-option first"
       id="combobox-item-0"
       onClick={[Function]}
       onKeyDown={[Function]}
@@ -338,7 +338,7 @@ exports[`<Combobox /> renders correctly with options and categories 1`] = `
       <div
         aria-label="Test"
         aria-selected={false}
-        className="combobox-option"
+        className="combobox-option first"
         id="combobox-item-0"
         onClick={[Function]}
         onKeyDown={[Function]}

--- a/src/components/Combobox/components/ComboboxOption/ComboboxOption.jsx
+++ b/src/components/Combobox/components/ComboboxOption/ComboboxOption.jsx
@@ -114,7 +114,8 @@ const ComboboxOption = ({
           disabled,
           selected,
           active: isActive,
-          "active-outline": isActiveByKeyboard && isActive
+          "active-outline": isActiveByKeyboard && isActive,
+          first: index === 0
         })}
         style={{ height: optionLineHeight }}
       >

--- a/src/components/Combobox/components/ComboboxOption/ComboboxOption.scss
+++ b/src/components/Combobox/components/ComboboxOption/ComboboxOption.scss
@@ -1,5 +1,6 @@
 @import "../../../../styles/themes.scss";
 @import "../../../../styles/typography.scss";
+@import "../../../../styles/global-css-settings.scss";
 @import "../../../../styles/states.scss";
 
 $icon-margin: 4px;
@@ -33,6 +34,10 @@ $icon-margin: 4px;
     &.active-outline {
       @include focus-style-css();
     }
+  }
+
+  &.first {
+    margin-top: $spacing-small;
   }
 
   .option-label {


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/78405958/141686380-6470a474-b254-4060-af3b-8eb5de8ff31a.png)

The first item was close to the search. added spacing to it.

### Updating existing component
#### Basic
- [ ] PR has description
- [ ] Changes to the component are backward compatible (including selectors structure). If not - add to the title of the PR "BREAKABLE_CHANGE""
- [ ] All changes to the component are reflected in the ReadMe
- [ ] If component is old and was not compliant with the latest guidelines - it was fixed (optional) 
#### Style
- [ ] CSS selectors are named using [BEM convention](http://getbem.com/naming/) 
- [ ] Design is compatible with [Monday Design System](https://design.monday.com/)
#### Storybook
- [ ] All the changes to the component should be reflected in the Storybook.
- [ ] Component passed Accessibility Plugin checks
#### Tests
- [ ] All current tests are passing
- [ ] New functionality is covered with tests
- [ ] Tests are compliant with TESTING_README.md instructions


