### PR TITLE
amitha/fix/combobox-disable-active-scroll-without-categories

### DIFF
--- a/src/components/Combobox/Combobox.jsx
+++ b/src/components/Combobox/Combobox.jsx
@@ -130,6 +130,7 @@ const Combobox = forwardRef(
             onOptionHover={onOptionEnter}
             onOptionLeave={onOptionLeave}
             optionLineHeight={optionLineHeight}
+            shouldScrollWhenActive={shouldScrollToSelectedItem}
           />
         );
       });


### PR DESCRIPTION
Did not propagate the prop to the ComboOption without categories

### Updating existing component
#### Basic
- [ ] PR has description
- [ ] Changes to the component are backward compatible (including selectors structure). If not - add to the title of the PR "BREAKABLE_CHANGE""
- [ ] All changes to the component are reflected in the ReadMe
- [ ] If component is old and was not compliant with the latest guidelines - it was fixed (optional) 
#### Style
- [ ] CSS selectors are named using [BEM convention](http://getbem.com/naming/) 
- [ ] Design is compatible with [Monday Design System](https://design.monday.com/)
#### Storybook
- [ ] All the changes to the component should be reflected in the Storybook.
- [ ] Component passed Accessibility Plugin checks
#### Tests
- [ ] All current tests are passing
- [ ] New functionality is covered with tests
- [ ] Tests are compliant with TESTING_README.md instructions


