### PR TITLE
add MenuButton props to control dialog hide/show trigger ignore class

### DIFF
--- a/src/components/MenuButton/MenuButton.jsx
+++ b/src/components/MenuButton/MenuButton.jsx
@@ -37,6 +37,8 @@ const MenuButton = ({
   dialogPosition,
   dialogClassName,
   dialogPaddingSize,
+  dialogShowTriggerIgnoreClass,
+  dialogHideTriggerIgnoreClass,
   onMenuHide,
   onMenuShow,
   disabled,
@@ -169,6 +171,8 @@ const MenuButton = ({
         moveBy={computedDialogOffset}
         showTrigger={disabled ? EMPTY_ARRAY : showTrigger}
         hideTrigger={hideTrigger}
+        showTriggerIgnoreClass={dialogShowTriggerIgnoreClass}
+        hideTriggerIgnoreClass={dialogHideTriggerIgnoreClass}
         useDerivedStateFromProps={true}
         onDialogDidShow={onDialogDidShow}
         onDialogDidHide={onDialogDidHide}
@@ -284,6 +288,8 @@ MenuButton.propTypes = {
     MenuButton.dialogPositions.TOP_END,
     MenuButton.dialogPositions.TOP_START
   ]),
+  dialogShowTriggerIgnoreClass: PropTypes.string,
+  dialogHideTriggerIgnoreClass: PropTypes.string,
 
   /**
    * Dialog Alignment
@@ -337,6 +343,8 @@ MenuButton.defaultProps = {
   dialogOffset: MOVE_BY,
   dialogPaddingSize: DialogContentContainer.sizes.MEDIUM,
   dialogPosition: MenuButton.dialogPositions.BOTTOM_START,
+  dialogShowTriggerIgnoreClass: undefined,
+  dialogHideTriggerIgnoreClass: undefined,
   onMenuShow: NOOP,
   onMenuHide: NOOP,
   disabled: false,


### PR DESCRIPTION
Add props `dialogShowTriggerIgnoreClass` and `dialogHideTriggerIgnoreClass` which are passed to the Dialog's corresponding props. Exposing these on MenuButton will allow users to craft more complex menu button use cases. 

Example usage of `dialogShowTriggerIgnoreClass`:
Creating more involved menu button components (via prop `component`) and using `dialogShowTriggerIgnoreClass` to prevent all clicks withing target area from opening the dialog.

Example usage of `dialogHideTriggerIgnoreClass`:
My use case 😄 - Allow users to create sub-hierarchies of MenuButtons and not having all clicks within the sub-dialogs close the parent dialog

### Updating existing component
#### Basic
- [x] PR has description
- [x] Changes to the component are backward compatible (including selectors structure). If not - add to the title of the PR "BREAKABLE_CHANGE""
- [ ] All changes to the component are reflected in the ReadMe
- [ ] If component is old and was not compliant with the latest guidelines - it was fixed (optional) 
#### Style
- [ ] CSS selectors are named using [BEM convention](http://getbem.com/naming/) 
- [ ] Design is compatible with [Monday Design System](https://design.monday.com/)
#### Storybook
- [ ] All the changes to the component should be reflected in the Storybook.
- [ ] Component passed Accessibility Plugin checks
#### Tests
- [ ] All current tests are passing
- [ ] New functionality is covered with tests
- [ ] Tests are compliant with TESTING_README.md instructions


