### PR TITLE
add MenuButton onClick prop

### DIFF
--- a/src/components/MenuButton/MenuButton.jsx
+++ b/src/components/MenuButton/MenuButton.jsx
@@ -3,6 +3,7 @@ import React, { useCallback, useState, useMemo, useRef, useLayoutEffect } from "
 import PropTypes from "prop-types";
 import cx from "classnames";
 import NOOP from "lodash/noop";
+import isFunction from "lodash/isFunction";
 import Dialog from "../Dialog/Dialog";
 import Menu from "../Icon/Icons/components/Menu";
 import DialogContentContainer from "../DialogContentContainer/DialogContentContainer";
@@ -30,6 +31,7 @@ const MenuButton = ({
   component,
   size,
   open,
+  onClick,
   zIndex,
   ariaLabel,
   closeDialogOnContentClick,
@@ -120,7 +122,7 @@ const MenuButton = ({
   }, [children, onMenuDidClose, closeDialogOnContentClick, removeTabCloseTrigger]);
 
   const content = useMemo(() => {
-    if (clonedChildren.length === 0) return <div />;
+    if (clonedChildren.length === 0) return null;
     return (
       <DialogContentContainer size={dialogPaddingSize} type={DialogContentContainer.types.POPOVER}>
         {clonedChildren}
@@ -139,6 +141,8 @@ const MenuButton = ({
   const onMouseUp = event => {
     if (disabled) {
       event.currentTarget.blur();
+    } else {
+      isFunction(onClick) && onClick();
     }
   };
 
@@ -250,6 +254,7 @@ MenuButton.propTypes = {
     MenuButtonSizes.LARGE
   ]),
   open: PropTypes.bool,
+  onClick: PropTypes.func,
   zIndex: PropTypes.number,
   ariaLabel: PropTypes.string,
   closeDialogOnContentClick: PropTypes.bool,
@@ -328,6 +333,7 @@ MenuButton.defaultProps = {
   component: Menu,
   size: MenuButtonSizes.SMALL,
   open: false,
+  onClick: undefined,
   zIndex: null,
   ariaLabel: "Menu",
   startingEdge: "bottom",

--- a/src/components/MenuButton/MenuButton.jsx
+++ b/src/components/MenuButton/MenuButton.jsx
@@ -3,7 +3,6 @@ import React, { useCallback, useState, useMemo, useRef, useLayoutEffect } from "
 import PropTypes from "prop-types";
 import cx from "classnames";
 import NOOP from "lodash/noop";
-import isFunction from "lodash/isFunction";
 import Dialog from "../Dialog/Dialog";
 import Menu from "../Icon/Icons/components/Menu";
 import DialogContentContainer from "../DialogContentContainer/DialogContentContainer";
@@ -141,9 +140,9 @@ const MenuButton = ({
   const onMouseUp = event => {
     if (disabled) {
       event.currentTarget.blur();
-    } else {
-      isFunction(onClick) && onClick();
+      return;
     }
+    onClick();
   };
 
   const Icon = component;
@@ -333,7 +332,7 @@ MenuButton.defaultProps = {
   component: Menu,
   size: MenuButtonSizes.SMALL,
   open: false,
-  onClick: undefined,
+  onClick: NOOP,
   zIndex: null,
   ariaLabel: "Menu",
   startingEdge: "bottom",

--- a/src/components/MenuButton/__stories__/menuButton.stories.js
+++ b/src/components/MenuButton/__stories__/menuButton.stories.js
@@ -196,6 +196,16 @@ export const WithText = () => (
   </div>
 );
 
+export const NoChildren = () => (
+  <div style={{ width: "100px" }}>
+    <MenuButton
+      component={Favorite}
+      text="Favorite"
+      onClick={() => alert('Now I\'m just regular a button')}
+    />
+  </div>
+);
+
 export default {
   title: "Components|MenuButton",
   component: MenuButton,


### PR DESCRIPTION
The MenuButton at its core is.. a button. I can imagine there are plenty of legitimate scenarios where a user would want to perform some logic when it's clicked. What's the harm in exposing an `onClick`? This is in addition to and would not directly affect the "show dialog" trigger. 

Also, when MenuButton was not passed any `children`, instead of rendering a Dialog with an empty div, just don't render the dialog at all. (The Dialog component already gracefully handles being passed `content` of null)

### Updating existing component
#### Basic
- [x] PR has description
- [x] Changes to the component are backward compatible (including selectors structure). If not - add to the title of the PR "BREAKABLE_CHANGE""
- [ ] All changes to the component are reflected in the ReadMe
- [ ] If component is old and was not compliant with the latest guidelines - it was fixed (optional) 
#### Style
- [ ] CSS selectors are named using [BEM convention](http://getbem.com/naming/) 
- [ ] Design is compatible with [Monday Design System](https://design.monday.com/)
#### Storybook
- [ ] All the changes to the component should be reflected in the Storybook.
- [ ] Component passed Accessibility Plugin checks
#### Tests
- [ ] All current tests are passing
- [ ] New functionality is covered with tests
- [ ] Tests are compliant with TESTING_README.md instructions


