### PR TITLE
export color utils as default object (for fixing error while trying to create new version)

### DIFF
--- a/src/components/ColorPicker/components/ColorPickerItemComponent/ColorPickerItemComponent.jsx
+++ b/src/components/ColorPicker/components/ColorPickerItemComponent/ColorPickerItemComponent.jsx
@@ -3,7 +3,7 @@ import PropTypes from "prop-types";
 import cx from "classnames";
 import NOOP from "lodash/noop";
 import { COLOR_STYLES } from "../../../../general-stories/colors/colors-vars-map";
-import { getMondayColorAsStyle } from "../../../../utils/colors-utils";
+import ColorUtils from "../../../../utils/colors-utils";
 import "./ColorPickerItemComponent.scss";
 import Icon from "../../../Icon/Icon";
 import Tooltip from "../../../Tooltip/Tooltip";
@@ -22,7 +22,7 @@ const ColorPickerItemComponent = ({
   colorSize,
   tooltipContent
 }) => {
-  const colorAsStyle = getMondayColorAsStyle(color, colorStyle);
+  const colorAsStyle = ColorUtils.getMondayColorAsStyle(color, colorStyle);
   const itemRef = useRef(null);
 
   const onMouseDown = useCallback(e => e.preventDefault(), []);
@@ -33,9 +33,9 @@ const ColorPickerItemComponent = ({
     const item = itemRef.current;
     const onHover = e => {
       if (colorStyle === COLOR_STYLES.SELECTED) {
-        e.target.style.background = getMondayColorAsStyle(color, COLOR_STYLES.REGULAR);
+        e.target.style.background = ColorUtils.getMondayColorAsStyle(color, COLOR_STYLES.REGULAR);
       } else {
-        e.target.style.background = getMondayColorAsStyle(color, COLOR_STYLES.SELECTED);
+        e.target.style.background = ColorUtils.getMondayColorAsStyle(color, COLOR_STYLES.SELECTED);
       }
     };
     const onMouseLeave = e => {

--- a/src/utils/colors-utils.js
+++ b/src/utils/colors-utils.js
@@ -1,4 +1,8 @@
 import { COLOR_STYLES } from "../general-stories/colors/colors-vars-map";
 
-export const getMondayColorAsStyle = (color, mode = COLOR_STYLES.REGULAR, withVar = true) =>
-  `${withVar ? "var(" : ""}--color-${color}${mode !== COLOR_STYLES.REGULAR ? `-${mode}` : ""}${withVar ? ")" : ""}`;
+const ColorUtils = {
+  getMondayColorAsStyle: (color, mode = COLOR_STYLES.REGULAR, withVar = true) =>
+    `${withVar ? "var(" : ""}--color-${color}${mode !== COLOR_STYLES.REGULAR ? `-${mode}` : ""}${withVar ? ")" : ""}`
+};
+
+export default Object.freeze(ColorUtils);


### PR DESCRIPTION
we want to export color utils for everyone. until now we don't have a default export on the color utils file which is problematic when I try to export the color utils file