### PR TITLE
Bugfix : scroll menu if needed

### DIFF
--- a/src/components/Menu/Menu/Menu.jsx
+++ b/src/components/Menu/Menu/Menu.jsx
@@ -32,7 +32,7 @@ const Menu = forwardRef(
       focusItemIndexOnMount,
       isSubMenu,
       useDocumentEventListeners,
-      shouldScrollMenu = false
+      shouldScrollMenu
     },
     forwardedRef
   ) => {
@@ -179,7 +179,8 @@ Menu.defaultProps = {
   focusItemIndex: -1,
   isSubMenu: false,
   useDocumentEventListeners: false,
-  focusItemIndexOnMount: -1
+  focusItemIndexOnMount: -1,
+  shouldScrollMenu: false
 };
 
 Menu.propTypes = {
@@ -195,7 +196,8 @@ Menu.propTypes = {
   focusItemIndex: PropTypes.number,
   isSubMenu: PropTypes.bool,
   useDocumentEventListeners: PropTypes.bool,
-  focusItemIndexOnMount: PropTypes.number
+  focusItemIndexOnMount: PropTypes.number,
+  shouldScrollMenu: PropTypes.bool
 };
 
 export default Menu;

--- a/src/components/Menu/Menu/Menu.jsx
+++ b/src/components/Menu/Menu/Menu.jsx
@@ -31,7 +31,8 @@ const Menu = forwardRef(
       focusItemIndex,
       focusItemIndexOnMount,
       isSubMenu,
-      useDocumentEventListeners
+      useDocumentEventListeners,
+      shouldScrollMenu = false
     },
     forwardedRef
   ) => {
@@ -151,7 +152,8 @@ const Menu = forwardRef(
                   closeMenu: onCloseMenu,
                   menuId: id,
                   useDocumentEventListeners,
-                  isInitialSelectedState
+                  isInitialSelectedState,
+                  shouldScrollMenu
                 })
               : null;
           })}

--- a/src/components/Menu/MenuItem/MenuItem.jsx
+++ b/src/components/Menu/MenuItem/MenuItem.jsx
@@ -288,7 +288,8 @@ MenuItem.defaultProps = {
   tooltipPosition: MenuItem.tooltipPositions.RIGHT,
   tooltipShowDelay: 300,
   onMouseLeave: undefined,
-  onMouseEnter: undefined
+  onMouseEnter: undefined,
+  shouldScrollMenu: false
 };
 
 MenuItem.propTypes = {
@@ -318,7 +319,8 @@ MenuItem.propTypes = {
   ]),
   tooltipShowDelay: PropTypes.number,
   onMouseLeave: PropTypes.func,
-  onMouseEnter: PropTypes.func
+  onMouseEnter: PropTypes.func,
+  shouldScrollMenu: PropTypes.bool
 };
 
 MenuItem.isSelectable = true;

--- a/src/components/Menu/MenuItem/MenuItem.jsx
+++ b/src/components/Menu/MenuItem/MenuItem.jsx
@@ -1,5 +1,5 @@
 /* eslint-disable react/jsx-props-no-spreading */
-import React, { useCallback, useRef, useLayoutEffect, useMemo } from "react";
+import React, { useCallback, useRef, useLayoutEffect, useMemo, useEffect } from "react";
 
 import PropTypes from "prop-types";
 import isFunction from "lodash/isFunction";
@@ -50,7 +50,8 @@ const MenuItem = ({
   tooltipShowDelay,
   isInitialSelectedState,
   onMouseEnter,
-  onMouseLeave
+  onMouseLeave,
+  shouldScrollMenu
 }) => {
   const overrideClassName = backwardCompatibilityForProperties([className, classname]);
   const isActive = activeItemIndex === index;
@@ -82,6 +83,16 @@ const MenuItem = ({
   const { styles, attributes } = usePopover(referenceElement, popperElement, {
     isOpen: isSubMenuOpen
   });
+
+  useEffect(() => {
+    if (isActive && shouldScrollMenu && referenceElement) {
+      if (referenceElement.scrollIntoViewIfNeeded) {
+        referenceElement.scrollIntoViewIfNeeded({ behaviour: "smooth" });
+      } else {
+        referenceElement.scrollIntoView({ behavior: "smooth", block: "center" });
+      }
+    }
+  }, [isActive]);
 
   const isMouseEnter = useMenuItemMouseEvents(
     ref,

--- a/src/components/Menu/MenuItem/MenuItem.jsx
+++ b/src/components/Menu/MenuItem/MenuItem.jsx
@@ -85,7 +85,7 @@ const MenuItem = ({
   });
 
   useEffect(() => {
-    if (isActive && shouldScrollMenu && referenceElement) {
+    if (isActive && shouldScrollMenu) {
       if (referenceElement.scrollIntoViewIfNeeded) {
         referenceElement.scrollIntoViewIfNeeded({ behaviour: "smooth" });
       } else {
@@ -288,8 +288,7 @@ MenuItem.defaultProps = {
   tooltipPosition: MenuItem.tooltipPositions.RIGHT,
   tooltipShowDelay: 300,
   onMouseLeave: undefined,
-  onMouseEnter: undefined,
-  shouldScrollMenu: false
+  onMouseEnter: undefined
 };
 
 MenuItem.propTypes = {
@@ -319,8 +318,7 @@ MenuItem.propTypes = {
   ]),
   tooltipShowDelay: PropTypes.number,
   onMouseLeave: PropTypes.func,
-  onMouseEnter: PropTypes.func,
-  shouldScrollMenu: PropTypes.bool
+  onMouseEnter: PropTypes.func
 };
 
 MenuItem.isSelectable = true;

--- a/src/components/Menu/MenuItem/MenuItem.jsx
+++ b/src/components/Menu/MenuItem/MenuItem.jsx
@@ -92,7 +92,7 @@ const MenuItem = ({
         referenceElement.scrollIntoView({ behavior: "smooth", block: "center" });
       }
     }
-  }, [isActive]);
+  }, [isActive, referenceElement, shouldScrollMenu]);
 
   const isMouseEnter = useMenuItemMouseEvents(
     ref,


### PR DESCRIPTION
As we talked about now you can pass arg to menu that will scroll to the active menu item if needed
<!--

Please go over the checklist and make sure all conditions are met.

--->

#### Basic
- [ ] Used plop (`npm run plop`) to create a new component.
- [ ] PR has description.
- [ ] New component is functional and uses Hooks. 
- [ ] Component defines [`PropTypes`](https://reactjs.org/docs/typechecking-with-proptypes.html).
#### Style
- [ ] Styles are added to `NewComponent.modules.scss` file inside of the `NewComponent` folder.
- [ ] Component uses CSS Modules.
- [ ] Design is compatible with [Monday Design System](https://design.monday.com/).
#### Storybook
- [ ] Stories were added to `/src/NewComponent/__stories__/NewComponent.stories.js` file.
- [ ] Stories include all flows of using the component.
#### Tests
- [ ] Tests are compliant with [TESTING_README.md](TESTING_README.md) instructions.
