### PR TITLE
Fixed code example of 'Menu with 2-depth sub menu'

### DIFF
--- a/src/components/Menu/Menu/__stories__/menu.stories.js
+++ b/src/components/Menu/Menu/__stories__/menu.stories.js
@@ -86,7 +86,7 @@ export const menuWithSubMenuTemplate = args => (
   </DialogContentContainer>
 );
 
-export const menuWith2DepthSubMenuTemplate = () => (
+export const menuWith2DepthSubMenuTemplate = args => (
   <DialogContentContainer>
     <Menu>
       <MenuItem title="Menu item" icon={Favorite} />


### PR DESCRIPTION
Small fix for the code example of `Menu with 2-depth sub menu`.
| Before | After |
| - | - |
| ![image](https://user-images.githubusercontent.com/96776835/148681830-7fc5e416-34ae-4b8a-b14a-94945e902354.png) |  ![image](https://user-images.githubusercontent.com/96776835/148681843-8c84fa8e-6503-455f-8b24-a87b1dfdba46.png) |