### PR TITLE
Storybook actions

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -33,7 +33,8 @@ module.exports = {
     "storybook-addon-themes",
     "@storybook/addon-a11y",
     "storybook-addon-performance/register",
-    "@storybook/addon-docs"
+    "@storybook/addon-docs",
+    "@storybook/addon-actions",
   ],
   core: {
     builder: "webpack5"

--- a/src/components/Button/__stories__/button.stories.mdx
+++ b/src/components/Button/__stories__/button.stories.mdx
@@ -10,7 +10,8 @@ import "./button.stories.scss";
 export const argTypes = createStoryMetaSettings({
   component: Button,
   enumPropNamesArray: ["kind", "size", "color", "type"],
-  iconPropNamesArray: ["leftIcon", "rightIcon", "successIcon"]
+  iconPropNamesArray: ["leftIcon", "rightIcon", "successIcon"],
+  actionPropsArray: ["onClick"],
 })
 
 <Meta

--- a/src/components/ColorPicker/__stories__/ColorPicker.stories.mdx
+++ b/src/components/ColorPicker/__stories__/ColorPicker.stories.mdx
@@ -6,7 +6,8 @@ import Check from "../../Icon/Icons/components/Check";
 
 export const argTypes = createStoryMetaSettings({
   component: ColorPicker,
-  enumPropNamesArray: ["colorStyle", "colorSize"]
+  enumPropNamesArray: ["colorStyle", "colorSize"],
+  actionPropsArray: ["onSave"]
 });
 
 <Meta title="Pickers/ColorPicker" component={ColorPicker} argTypes={argTypes}/>

--- a/src/storybook/functions/create-component-story.js
+++ b/src/storybook/functions/create-component-story.js
@@ -17,7 +17,7 @@ const allowedIcons = iconsMetaData.reduce(
   { options: [], mapping: {} }
 );
 
-export function createStoryMetaSettings({ component, enumPropNamesArray, iconPropNamesArray }) {
+export function createStoryMetaSettings({ component, enumPropNamesArray, iconPropNamesArray, actionPropsArray }) {
   const argTypes = {};
 
   // set enum allowed values inside argsTypes object
@@ -39,6 +39,10 @@ export function createStoryMetaSettings({ component, enumPropNamesArray, iconPro
         type: "select"
       }
     };
+  });
+
+  actionPropsArray?.forEach(propName => {
+    argTypes[propName] = { action: propName };
   });
 
   return argTypes;


### PR DESCRIPTION
Added [Storybook actions](https://storybook.js.org/docs/react/essentials/actions), which can be easily configured to show callback examples.
I added it only to two components for now, just as a test case.
![image](https://user-images.githubusercontent.com/96776835/148804983-f3d5aeb1-8dd4-4a4f-acf3-7f34bfe021cb.png)


I found it useful for my current task, but please let me know if you think it shouldn't be used.