### PR TITLE
Added controlled input decorator

### DIFF
--- a/src/components/ColorPicker/__stories__/ColorPicker.stories.js
+++ b/src/components/ColorPicker/__stories__/ColorPicker.stories.js
@@ -1,0 +1,15 @@
+import ColorPicker from "../ColorPicker";
+import TextColorIndicator from "../../Icon/Icons/components/TextColorIndicator";
+import Check from "../../Icon/Icons/components/Check";
+
+export const colorPickerTemplate = args => <ColorPicker {...args}/>;
+
+export const colorPickerWithIndicatorTemplate = args => <ColorPicker ColorIndicatorIcon={TextColorIndicator} {...args} />;
+
+export const colorPickerTextIndicatorTemplate = args => <ColorPicker ColorIndicatorIcon={TextColorIndicator} shouldRenderIndicatorWithoutBackground value="peach" {...args} />;
+
+export const colorPickerSelectedTemplate = args => <ColorPicker ColorIndicatorIcon={TextColorIndicator} colorStyle={ColorPicker.COLOR_STYLES.SELECTED} {...args} />;
+
+export const colorPickerNoColorTemplate = args => <ColorPicker noColorText="Clear color" />;
+
+export const colorPickerSelectedIconTemplate = args => <ColorPicker isMultiselect SelectedIndicatorIcon={Check} value="peach" {...args} />;

--- a/src/components/ColorPicker/__stories__/ColorPicker.stories.mdx
+++ b/src/components/ColorPicker/__stories__/ColorPicker.stories.mdx
@@ -1,20 +1,26 @@
 import ColorPicker from "../ColorPicker";
 import { ArgsTable, Story, Canvas, Meta } from "@storybook/addon-docs";
-import { createComponentTemplate, createStoryMetaSettings } from "../../../storybook/functions/create-component-story";
-import TextColorIndicator from "../../Icon/Icons/components/TextColorIndicator";
-import Check from "../../Icon/Icons/components/Check";
+import { createComponentTemplate, createStoryMetaSettings, createControlledInputDecorator } from "../../../storybook/functions/create-component-story";
+import {
+  colorPickerTemplate,
+  colorPickerWithIndicatorTemplate,
+  colorPickerTextIndicatorTemplate,
+  colorPickerSelectedTemplate,
+  colorPickerNoColorTemplate,
+  colorPickerSelectedIconTemplate,
+  withColorsStateDecorator
+} from "./ColorPicker.stories";
 
 export const argTypes = createStoryMetaSettings({
   component: ColorPicker,
   enumPropNamesArray: ["colorStyle", "colorSize"],
-  actionPropsArray: ["onSave"]
 });
 
-<Meta title="Pickers/ColorPicker" component={ColorPicker} argTypes={argTypes}/>
+export const decorators = [
+  createControlledInputDecorator({fromCbProp: 'onSave', toProp: 'value'})
+];
 
-<!--- Component template -->
-
-export const colorPickerTemplate = createComponentTemplate(ColorPicker);
+<Meta title="Pickers/ColorPicker" component={ColorPicker} argTypes={argTypes} decorators={decorators}/>
 
 <!--- Component documentation -->
 
@@ -43,7 +49,7 @@ ColorPicker is our component for selecting our content colors
 
 <Canvas>
   <Story name="With Indicator">
-    <ColorPicker ColorIndicatorIcon={TextColorIndicator} />
+    {colorPickerWithIndicatorTemplate.bind({})}
   </Story>
 </Canvas>
 
@@ -51,7 +57,7 @@ ColorPicker is our component for selecting our content colors
 
 <Canvas>
   <Story name="Text Indication">
-    <ColorPicker ColorIndicatorIcon={TextColorIndicator} shouldRenderIndicatorWithoutBackground value="peach" />
+    {colorPickerTextIndicatorTemplate.bind({})}
   </Story>
 </Canvas>
 
@@ -59,7 +65,7 @@ ColorPicker is our component for selecting our content colors
 
 <Canvas>
   <Story name="Selected">
-    <ColorPicker ColorIndicatorIcon={TextColorIndicator} colorStyle={ColorPicker.COLOR_STYLES.SELECTED} />
+    {colorPickerSelectedTemplate.bind({})}
   </Story>
 </Canvas>
 
@@ -69,16 +75,16 @@ Ability to revert to initial color
 
 <Canvas>
   <Story name="No color">
-    <ColorPicker noColorText="Clear color" />
+    {colorPickerNoColorTemplate.bind({})}
   </Story>
 </Canvas>
 
 ### Selected icon
 
-Selected colors indication
+Selected colors indication, when using multi-selection
 
 <Canvas>
   <Story name="Selected icon">
-    <ColorPicker isMultiselect SelectedIndicatorIcon={Check} value="peach" />
+    {colorPickerSelectedIconTemplate.bind({})}
   </Story>
 </Canvas>

--- a/src/storybook/functions/create-component-story.js
+++ b/src/storybook/functions/create-component-story.js
@@ -1,5 +1,7 @@
-import React from "react";
+import React, { useState, useCallback, useMemo } from "react";
 import { iconsMetaData } from "monday-ui-style/src/Icons/iconsMetaData";
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { action } from "@storybook/addon-actions";
 import * as AllIcons from "../../components/Icon/Icons";
 
 export function createComponentTemplate(ComponentClass) {
@@ -46,4 +48,30 @@ export function createStoryMetaSettings({ component, enumPropNamesArray, iconPro
   });
 
   return argTypes;
+}
+
+/**
+ * Creates a decorator which maps a callback prop to an input prop.
+ * Useful for adding interactivity to stories of controlled components.
+ * For example: mapping the onChange callback of a Select component to its currentValue prop.
+ * Additionally, the callback will trigger a Storybook action, that can be seen on the Actions tab.
+ */
+export function createControlledInputDecorator({ fromCbProp, toProp }) {
+  return (Story, context) => {
+    const [propValue, setPropValue] = useState(context.initialArgs[toProp]);
+    const createAction = useMemo(() => action(fromCbProp), []);
+
+    const injectedCallback = useCallback(
+      newPropValue => {
+        setPropValue(newPropValue);
+        createAction(newPropValue);
+      },
+      [setPropValue, createAction]
+    );
+
+    context.args[fromCbProp] = injectedCallback;
+    context.args[toProp] = propValue;
+
+    return Story();
+  };
 }


### PR DESCRIPTION
Added a convenient decorator which allows adding more interactivity to controlled component. 

[Before](https://user-images.githubusercontent.com/96776835/149083361-3643082d-c318-4f93-ac43-c683201bc905.mov)  ->  [After](https://user-images.githubusercontent.com/96776835/149083425-7e50d0ca-f467-4db1-ac14-6b6bda5056c5.mov)


I found it difficult to understand the behavior of some components without actually seeing a proper "flow". 
I think this decorator will be useful in more cases. However, if you think it's open for abuse I'm ok with not adding a generic decorator, and I'll add a specific decorator for my component.