### PR TITLE
Added optional mapping from action to input props

### DIFF
--- a/plop/general/component-stories-mdx.txt
+++ b/plop/general/component-stories-mdx.txt
@@ -1,11 +1,20 @@
 import {{properCase componentName}} from "../{{properCase componentName}}";
 import { ArgsTable, Story, Canvas, Meta } from "@storybook/addon-docs";
-import { createComponentTemplate } from "../../../storybook/functions/create-component-story";
+import { createComponentTemplate, createStoryMetaSettings } from "../../../storybook/functions/create-component-story";
 import "./{{properCase componentName}}.stories.scss";
+
+export const metaSettings = createStoryMetaSettings({
+  component: {{properCase componentName}},
+  enumPropNamesArray: [], // List enum props here
+  iconPropNamesArray: [], // List props that are typed as icons here
+  actionPropsArray: [], // List the component's actions here
+});
 
 <Meta
   title="Components/{{properCase componentName}}/{{properCase componentName}}"
   component={ {{properCase componentName}} }
+  argTypes={ metaSettings.argTypes }
+  decorators={ metaSettings.decorators }
 />
 
 <!--- Component template -->

--- a/src/components/AlertBanner/__stories__/alertBanner.stories.mdx
+++ b/src/components/AlertBanner/__stories__/alertBanner.stories.mdx
@@ -16,7 +16,7 @@ export const metaSettings = createStoryMetaSettings({
 <Meta
   title="Feedback/AlertBanner"
   component={ AlertBanner }
-  argType={ metaSettings.argTypes }
+  argTypes={ metaSettings.argTypes }
   decorators={ metaSettings.decorators }
 />
 

--- a/src/components/AlertBanner/__stories__/alertBanner.stories.mdx
+++ b/src/components/AlertBanner/__stories__/alertBanner.stories.mdx
@@ -8,7 +8,7 @@ import { createStoryMetaSettings } from "../../../storybook/functions/create-com
 import { TOOLTIP, ATTENTION_BOX, TOAST } from "../../../storybook/components/related-components/component-description-map";
 import "./alertBanner.stories.scss";
 
-export const argTypes = createStoryMetaSettings({
+export const metaSettings = createStoryMetaSettings({
   component: AlertBanner,
   enumPropNamesArray: ["backgroundColor"],
 });
@@ -16,7 +16,7 @@ export const argTypes = createStoryMetaSettings({
 <Meta
   title="Feedback/AlertBanner"
   component={ AlertBanner }
-  argTypes={argTypes}
+  argType={ metaSettings.argTypes }
 />
 
 <!--- Component template -->

--- a/src/components/AlertBanner/__stories__/alertBanner.stories.mdx
+++ b/src/components/AlertBanner/__stories__/alertBanner.stories.mdx
@@ -17,6 +17,7 @@ export const metaSettings = createStoryMetaSettings({
   title="Feedback/AlertBanner"
   component={ AlertBanner }
   argType={ metaSettings.argTypes }
+  decorators={ metaSettings.decorators }
 />
 
 <!--- Component template -->

--- a/src/components/AttentionBox/__stories__/attentionBox.stories.mdx
+++ b/src/components/AttentionBox/__stories__/attentionBox.stories.mdx
@@ -23,6 +23,7 @@ export const metaSettings = createStoryMetaSettings({
   title="Feedback/AttentionBox"
   component={AttentionBox}
   argType={ metaSettings.argTypes }
+  decorators={ metaSettings.decorators }
 />
 
 <!--- Component template -->

--- a/src/components/AttentionBox/__stories__/attentionBox.stories.mdx
+++ b/src/components/AttentionBox/__stories__/attentionBox.stories.mdx
@@ -22,7 +22,7 @@ export const metaSettings = createStoryMetaSettings({
 <Meta
   title="Feedback/AttentionBox"
   component={AttentionBox}
-  argType={ metaSettings.argTypes }
+  argTypes={ metaSettings.argTypes }
   decorators={ metaSettings.decorators }
 />
 

--- a/src/components/AttentionBox/__stories__/attentionBox.stories.mdx
+++ b/src/components/AttentionBox/__stories__/attentionBox.stories.mdx
@@ -13,7 +13,7 @@ import { TOOLTIP, ALERT_BANNER, TOAST } from "../../../storybook/components/rela
 import person from "./assets/person.png";
 import "./attentionBox.stories.scss";
 
-export const argsTypes = createStoryMetaSettings({
+export const argTypes = createStoryMetaSettings({
   component: AttentionBox,
   enumPropNamesArray: ["type", "iconType"],
   iconPropNamesArray: ["icon"]
@@ -22,7 +22,7 @@ export const argsTypes = createStoryMetaSettings({
 <Meta
   title="Feedback/AttentionBox"
   component={AttentionBox}
-  argTypes={argsTypes}
+  argTypes={argTypes}
 />
 
 <!--- Component template -->

--- a/src/components/AttentionBox/__stories__/attentionBox.stories.mdx
+++ b/src/components/AttentionBox/__stories__/attentionBox.stories.mdx
@@ -13,7 +13,7 @@ import { TOOLTIP, ALERT_BANNER, TOAST } from "../../../storybook/components/rela
 import person from "./assets/person.png";
 import "./attentionBox.stories.scss";
 
-export const argTypes = createStoryMetaSettings({
+export const metaSettings = createStoryMetaSettings({
   component: AttentionBox,
   enumPropNamesArray: ["type", "iconType"],
   iconPropNamesArray: ["icon"]
@@ -22,7 +22,7 @@ export const argTypes = createStoryMetaSettings({
 <Meta
   title="Feedback/AttentionBox"
   component={AttentionBox}
-  argTypes={argTypes}
+  argType={ metaSettings.argTypes }
 />
 
 <!--- Component template -->

--- a/src/components/Avatar/__stories__/avatar.stories.mdx
+++ b/src/components/Avatar/__stories__/avatar.stories.mdx
@@ -7,7 +7,7 @@ import { MultipleStoryElementsWrapper } from "../../../storybook/components";
 import { home, guest, minus, person1, person2, person3, maleIcon, femaleIcon, owner } from "./assets";
 import "./avatar.stories.scss";
 
-export const argTypes = createStoryMetaSettings({
+export const metaSettings = createStoryMetaSettings({
   component: Avatar,
   enumPropNamesArray: ["type", "size"],
   iconPropNamesArray: ["icon"]
@@ -16,7 +16,7 @@ export const argTypes = createStoryMetaSettings({
 <Meta 
   title="Media/Avatar"
   component={Avatar}
-  argTypes={argTypes}
+  argType={ metaSettings.argTypes }
 />
 
 <!--- Component template -->

--- a/src/components/Avatar/__stories__/avatar.stories.mdx
+++ b/src/components/Avatar/__stories__/avatar.stories.mdx
@@ -16,7 +16,7 @@ export const metaSettings = createStoryMetaSettings({
 <Meta 
   title="Media/Avatar"
   component={Avatar}
-  argType={ metaSettings.argTypes }
+  argTypes={ metaSettings.argTypes }
   decorators={ metaSettings.decorators }
 />
 

--- a/src/components/Avatar/__stories__/avatar.stories.mdx
+++ b/src/components/Avatar/__stories__/avatar.stories.mdx
@@ -17,6 +17,7 @@ export const metaSettings = createStoryMetaSettings({
   title="Media/Avatar"
   component={Avatar}
   argType={ metaSettings.argTypes }
+  decorators={ metaSettings.decorators }
 />
 
 <!--- Component template -->

--- a/src/components/BreadcrumbsBar/BreadcrumbItem/__stories__/breadcrumbItem.stories.mdx
+++ b/src/components/BreadcrumbsBar/BreadcrumbItem/__stories__/breadcrumbItem.stories.mdx
@@ -17,6 +17,7 @@ export const metaSettings = createStoryMetaSettings({
   title="Navigation/BreadcrumbsBar/BreadcrumbItem"
   component={ BreadcrumbItem }
   argType={ metaSettings.argTypes }
+  decorators={ metaSettings.decorators }
 />
 
 <!--- Component template -->

--- a/src/components/BreadcrumbsBar/BreadcrumbItem/__stories__/breadcrumbItem.stories.mdx
+++ b/src/components/BreadcrumbsBar/BreadcrumbItem/__stories__/breadcrumbItem.stories.mdx
@@ -16,7 +16,7 @@ export const metaSettings = createStoryMetaSettings({
 <Meta
   title="Navigation/BreadcrumbsBar/BreadcrumbItem"
   component={ BreadcrumbItem }
-  argType={ metaSettings.argTypes }
+  argTypes={ metaSettings.argTypes }
   decorators={ metaSettings.decorators }
 />
 

--- a/src/components/BreadcrumbsBar/BreadcrumbItem/__stories__/breadcrumbItem.stories.mdx
+++ b/src/components/BreadcrumbsBar/BreadcrumbItem/__stories__/breadcrumbItem.stories.mdx
@@ -8,7 +8,7 @@ import BreadcrumbItem from "../BreadcrumbItem";
 import { Workspace } from "../../../Icon/Icons";
 import "./breadcrumbItem.stories.scss";
 
-export const argTypes = createStoryMetaSettings({
+export const metaSettings = createStoryMetaSettings({
   component: BreadcrumbItem,
   iconPropNamesArray: ["icon"]
 })
@@ -16,7 +16,7 @@ export const argTypes = createStoryMetaSettings({
 <Meta
   title="Navigation/BreadcrumbsBar/BreadcrumbItem"
   component={ BreadcrumbItem }
-  argTypes={ argTypes }
+  argType={ metaSettings.argTypes }
 />
 
 <!--- Component template -->

--- a/src/components/BreadcrumbsBar/__stories__/breadcrumbsBar.stories.mdx
+++ b/src/components/BreadcrumbsBar/__stories__/breadcrumbsBar.stories.mdx
@@ -18,7 +18,7 @@ export const metaSettings = createStoryMetaSettings({
 <Meta
   title="Navigation/BreadcrumbsBar/BreadcrumbsBar"
   component={ BreadcrumbsBar }
-  argType={ metaSettings.argTypes }
+  argTypes={ metaSettings.argTypes }
   decorators={ metaSettings.decorators }
 />
 

--- a/src/components/BreadcrumbsBar/__stories__/breadcrumbsBar.stories.mdx
+++ b/src/components/BreadcrumbsBar/__stories__/breadcrumbsBar.stories.mdx
@@ -10,7 +10,7 @@ import { BUTTON_GROUP, WIZARD, TABS } from "../../../storybook/components/relate
 import { createStoryMetaSettings } from "../../../storybook/functions/create-component-story";
 import "./breadcrumbsBar.stories.scss";
 
-export const argTypes = createStoryMetaSettings({
+export const metaSettings = createStoryMetaSettings({
   component: BreadcrumbsBar,
   enumPropNamesArray: ["type"]
 });
@@ -18,7 +18,7 @@ export const argTypes = createStoryMetaSettings({
 <Meta
   title="Navigation/BreadcrumbsBar/BreadcrumbsBar"
   component={ BreadcrumbsBar }
-  argTypes={ argTypes }
+  argType={ metaSettings.argTypes }
 />
 
 <!--- Component template -->

--- a/src/components/BreadcrumbsBar/__stories__/breadcrumbsBar.stories.mdx
+++ b/src/components/BreadcrumbsBar/__stories__/breadcrumbsBar.stories.mdx
@@ -19,6 +19,7 @@ export const metaSettings = createStoryMetaSettings({
   title="Navigation/BreadcrumbsBar/BreadcrumbsBar"
   component={ BreadcrumbsBar }
   argType={ metaSettings.argTypes }
+  decorators={ metaSettings.decorators }
 />
 
 <!--- Component template -->

--- a/src/components/Button/__stories__/button.stories.mdx
+++ b/src/components/Button/__stories__/button.stories.mdx
@@ -18,6 +18,7 @@ export const metaSettings = createStoryMetaSettings({
   title="Buttons/Button"
   component={Button}
   argType={ metaSettings.argTypes }
+  decorators={ metaSettings.decorators }
 />
 
 <!--- Component template -->

--- a/src/components/Button/__stories__/button.stories.mdx
+++ b/src/components/Button/__stories__/button.stories.mdx
@@ -7,7 +7,7 @@ import { BUTTON_GROUP, SPLIT_BUTTON, CHIP } from "../../../storybook/components/
 import { MultipleStoryElementsWrapper, Link } from "../../../storybook/components";
 import "./button.stories.scss";
 
-export const argTypes = createStoryMetaSettings({
+export const metaSettings = createStoryMetaSettings({
   component: Button,
   enumPropNamesArray: ["kind", "size", "color", "type"],
   iconPropNamesArray: ["leftIcon", "rightIcon", "successIcon"],
@@ -17,7 +17,7 @@ export const argTypes = createStoryMetaSettings({
 <Meta
   title="Buttons/Button"
   component={Button}
-  argTypes={argTypes}
+  argType={ metaSettings.argTypes }
 />
 
 <!--- Component template -->

--- a/src/components/Button/__stories__/button.stories.mdx
+++ b/src/components/Button/__stories__/button.stories.mdx
@@ -17,7 +17,7 @@ export const metaSettings = createStoryMetaSettings({
 <Meta
   title="Buttons/Button"
   component={Button}
-  argType={ metaSettings.argTypes }
+  argTypes={ metaSettings.argTypes }
   decorators={ metaSettings.decorators }
 />
 

--- a/src/components/ButtonGroup/__stories__/ButtonGroup.stories.mdx
+++ b/src/components/ButtonGroup/__stories__/ButtonGroup.stories.mdx
@@ -16,6 +16,7 @@ export const metaSettings = createStoryMetaSettings({
   title="Buttons/ButtonGroup"
   component={ ButtonGroup }
   argType={ metaSettings.argTypes }
+  decorators={ metaSettings.decorators }
 />
 
 <!--- Component template -->

--- a/src/components/ButtonGroup/__stories__/ButtonGroup.stories.mdx
+++ b/src/components/ButtonGroup/__stories__/ButtonGroup.stories.mdx
@@ -7,7 +7,7 @@ import { Link } from "../../../storybook/components";
 import Desktop from "./assets/Desktop.js"
 import "./buttonGroup.stories.scss";
 
-export const argTypes = createStoryMetaSettings({
+export const metaSettings = createStoryMetaSettings({
   component: ButtonGroup,
   enumPropNamesArray: ["kind", "size"]
 });
@@ -15,7 +15,7 @@ export const argTypes = createStoryMetaSettings({
 <Meta
   title="Buttons/ButtonGroup"
   component={ ButtonGroup }
-  argTypes={argTypes}
+  argType={ metaSettings.argTypes }
 />
 
 <!--- Component template -->

--- a/src/components/ButtonGroup/__stories__/ButtonGroup.stories.mdx
+++ b/src/components/ButtonGroup/__stories__/ButtonGroup.stories.mdx
@@ -15,7 +15,7 @@ export const metaSettings = createStoryMetaSettings({
 <Meta
   title="Buttons/ButtonGroup"
   component={ ButtonGroup }
-  argType={ metaSettings.argTypes }
+  argTypes={ metaSettings.argTypes }
   decorators={ metaSettings.decorators }
 />
 

--- a/src/components/Chips/__stories__/chips.stories.mdx
+++ b/src/components/Chips/__stories__/chips.stories.mdx
@@ -10,7 +10,7 @@ import { Email } from "../../Icon/Icons";
 import person1 from "./assets/person1.png"
 import "./chips.stories.scss";
 
-export const argTypes = createStoryMetaSettings({
+export const metaSettings = createStoryMetaSettings({
   component: Chips,
   enumPropNamesArray: ["color"],
   iconPropNamesArray: ["rightIcon", "leftIcon"]
@@ -19,7 +19,7 @@ export const argTypes = createStoryMetaSettings({
 <Meta
   title="Data display/Chips"
   component={Chips}
-  argTypes={argTypes}
+  argType={ metaSettings.argTypes }
 />
 
 <!--- Component template -->

--- a/src/components/Chips/__stories__/chips.stories.mdx
+++ b/src/components/Chips/__stories__/chips.stories.mdx
@@ -20,6 +20,7 @@ export const metaSettings = createStoryMetaSettings({
   title="Data display/Chips"
   component={Chips}
   argType={ metaSettings.argTypes }
+  decorators={ metaSettings.decorators }
 />
 
 <!--- Component template -->

--- a/src/components/Chips/__stories__/chips.stories.mdx
+++ b/src/components/Chips/__stories__/chips.stories.mdx
@@ -19,7 +19,7 @@ export const metaSettings = createStoryMetaSettings({
 <Meta
   title="Data display/Chips"
   component={Chips}
-  argType={ metaSettings.argTypes }
+  argTypes={ metaSettings.argTypes }
   decorators={ metaSettings.decorators }
 />
 

--- a/src/components/ColorPicker/__stories__/ColorPicker.stories.mdx
+++ b/src/components/ColorPicker/__stories__/ColorPicker.stories.mdx
@@ -10,7 +10,11 @@ export const metaSettings = createStoryMetaSettings({
   actionPropsArray: ["onSave"]
 });
 
-<Meta title="Pickers/ColorPicker" component={ColorPicker} argType={ metaSettings.argTypes }/>
+<Meta 
+  title="Pickers/ColorPicker"
+  component={ ColorPicker }
+  argType={ metaSettings.argTypes }
+/>
 
 <!--- Component template -->
 

--- a/src/components/ColorPicker/__stories__/ColorPicker.stories.mdx
+++ b/src/components/ColorPicker/__stories__/ColorPicker.stories.mdx
@@ -7,7 +7,7 @@ import Check from "../../Icon/Icons/components/Check";
 export const metaSettings = createStoryMetaSettings({
   component: ColorPicker,
   enumPropNamesArray: ["colorStyle", "colorSize"],
-  actionPropsArray: [{name: 'onSave', linkToValueProp: 'value'}]
+  actionPropsArray: [{name: "onSave", linkedToPropValue: "value"}]
 });
 
 <Meta 

--- a/src/components/ColorPicker/__stories__/ColorPicker.stories.mdx
+++ b/src/components/ColorPicker/__stories__/ColorPicker.stories.mdx
@@ -13,7 +13,7 @@ export const metaSettings = createStoryMetaSettings({
 <Meta 
   title="Pickers/ColorPicker"
   component={ ColorPicker }
-  argType={ metaSettings.argTypes }
+  argTypes={ metaSettings.argTypes }
   decorators={ metaSettings.decorators }
 />
 

--- a/src/components/ColorPicker/__stories__/ColorPicker.stories.mdx
+++ b/src/components/ColorPicker/__stories__/ColorPicker.stories.mdx
@@ -4,13 +4,13 @@ import { createComponentTemplate, createStoryMetaSettings } from "../../../story
 import TextColorIndicator from "../../Icon/Icons/components/TextColorIndicator";
 import Check from "../../Icon/Icons/components/Check";
 
-export const argTypes = createStoryMetaSettings({
+export const metaSettings = createStoryMetaSettings({
   component: ColorPicker,
   enumPropNamesArray: ["colorStyle", "colorSize"],
   actionPropsArray: ["onSave"]
 });
 
-<Meta title="Pickers/ColorPicker" component={ColorPicker} argTypes={argTypes}/>
+<Meta title="Pickers/ColorPicker" component={ColorPicker} argType={ metaSettings.argTypes }/>
 
 <!--- Component template -->
 

--- a/src/components/ColorPicker/__stories__/ColorPicker.stories.mdx
+++ b/src/components/ColorPicker/__stories__/ColorPicker.stories.mdx
@@ -7,7 +7,7 @@ import Check from "../../Icon/Icons/components/Check";
 export const metaSettings = createStoryMetaSettings({
   component: ColorPicker,
   enumPropNamesArray: ["colorStyle", "colorSize"],
-  actionPropsArray: ["onSave"]
+  actionPropsArray: [{name: 'onSave', linkToValueProp: 'value'}]
 });
 
 <Meta 

--- a/src/components/ColorPicker/__stories__/ColorPicker.stories.mdx
+++ b/src/components/ColorPicker/__stories__/ColorPicker.stories.mdx
@@ -14,6 +14,7 @@ export const metaSettings = createStoryMetaSettings({
   title="Pickers/ColorPicker"
   component={ ColorPicker }
   argType={ metaSettings.argTypes }
+  decorators={ metaSettings.decorators }
 />
 
 <!--- Component template -->

--- a/src/components/Counter/__stories__/counter.stories.mdx
+++ b/src/components/Counter/__stories__/counter.stories.mdx
@@ -9,7 +9,7 @@ import Icon from "../../Icon/Icon.jsx"
 import { Link } from "../../../storybook/components";
 import "./counter.stories.scss";
 
-export const argTypes = createStoryMetaSettings({
+export const metaSettings = createStoryMetaSettings({
   component: Counter,
   enumPropNamesArray: ["size", "color", "kind", ]
 });
@@ -17,7 +17,7 @@ export const argTypes = createStoryMetaSettings({
 <Meta
   title="Feedback/Counter"
   component={ Counter }
-  argTypes={ argTypes }
+  argType={ metaSettings.argTypes }
 />
 
 <!--- Component template -->

--- a/src/components/Counter/__stories__/counter.stories.mdx
+++ b/src/components/Counter/__stories__/counter.stories.mdx
@@ -18,6 +18,7 @@ export const metaSettings = createStoryMetaSettings({
   title="Feedback/Counter"
   component={ Counter }
   argType={ metaSettings.argTypes }
+  decorators={ metaSettings.decorators }
 />
 
 <!--- Component template -->

--- a/src/components/Counter/__stories__/counter.stories.mdx
+++ b/src/components/Counter/__stories__/counter.stories.mdx
@@ -17,7 +17,7 @@ export const metaSettings = createStoryMetaSettings({
 <Meta
   title="Feedback/Counter"
   component={ Counter }
-  argType={ metaSettings.argTypes }
+  argTypes={ metaSettings.argTypes }
   decorators={ metaSettings.decorators }
 />
 

--- a/src/components/DialogContentContainer/__stories__/DialogContentContainer.stories.mdx
+++ b/src/components/DialogContentContainer/__stories__/DialogContentContainer.stories.mdx
@@ -11,7 +11,7 @@ export const metaSettings = createStoryMetaSettings({
 <Meta
   title="Popover/DialogContentContainer"
   component={DialogContentContainer}
-  argType={ metaSettings.argTypes }
+  argTypes={ metaSettings.argTypes }
   decorators={ metaSettings.decorators }
 />
 

--- a/src/components/DialogContentContainer/__stories__/DialogContentContainer.stories.mdx
+++ b/src/components/DialogContentContainer/__stories__/DialogContentContainer.stories.mdx
@@ -3,7 +3,7 @@ import { ArgsTable, Story, Canvas, Meta } from "@storybook/addon-docs";
 import { createComponentTemplate, createStoryMetaSettings } from "../../../storybook/functions/create-component-story";
 import DialogContentContainerExample from "./DialogContentContainerExample";
 
-export const argTypes = createStoryMetaSettings({
+export const metaSettings = createStoryMetaSettings({
   component: DialogContentContainer,
   enumPropNamesArray: ["type", "size"]
 });
@@ -11,7 +11,7 @@ export const argTypes = createStoryMetaSettings({
 <Meta
   title="Popover/DialogContentContainer"
   component={DialogContentContainer}
-  argTypes={ argTypes }
+  argType={ metaSettings.argTypes }
 />
 
 <!--- Component template -->

--- a/src/components/DialogContentContainer/__stories__/DialogContentContainer.stories.mdx
+++ b/src/components/DialogContentContainer/__stories__/DialogContentContainer.stories.mdx
@@ -12,6 +12,7 @@ export const metaSettings = createStoryMetaSettings({
   title="Popover/DialogContentContainer"
   component={DialogContentContainer}
   argType={ metaSettings.argTypes }
+  decorators={ metaSettings.decorators }
 />
 
 <!--- Component template -->

--- a/src/components/Divider/__stories__/Divider.stories.mdx
+++ b/src/components/Divider/__stories__/Divider.stories.mdx
@@ -12,7 +12,8 @@ export const metaSettings = createStoryMetaSettings({
 <Meta 
   title="Data display/Divider" 
   component={ Divider } 
-  argType={ metaSettings.argTypes } 
+  argType={ metaSettings.argTypes }
+  decorators={ metaSettings.decorators } 
   />
 
 <!--- Component template -->

--- a/src/components/Divider/__stories__/Divider.stories.mdx
+++ b/src/components/Divider/__stories__/Divider.stories.mdx
@@ -9,7 +9,11 @@ export const metaSettings = createStoryMetaSettings({
   enumPropNamesArray: ["direction"]
 });
 
-<Meta title="Data display/Divider" component={Divider} argType={ metaSettings.argTypes } />
+<Meta 
+  title="Data display/Divider" 
+  component={ Divider } 
+  argType={ metaSettings.argTypes } 
+  />
 
 <!--- Component template -->
 

--- a/src/components/Divider/__stories__/Divider.stories.mdx
+++ b/src/components/Divider/__stories__/Divider.stories.mdx
@@ -4,12 +4,12 @@ import { createComponentTemplate, createStoryMetaSettings } from "../../../story
 import { CHIP, ICONS, LABEL } from "../../../storybook/components/related-components/component-description-map";
 import classes from "./Divider.stories.module.scss";
 
-export const argTypes = createStoryMetaSettings({
+export const metaSettings = createStoryMetaSettings({
   component: Divider,
   enumPropNamesArray: ["direction"]
 });
 
-<Meta title="Data display/Divider" component={Divider} argTypes={argTypes} />
+<Meta title="Data display/Divider" component={Divider} argType={ metaSettings.argTypes } />
 
 <!--- Component template -->
 

--- a/src/components/Divider/__stories__/Divider.stories.mdx
+++ b/src/components/Divider/__stories__/Divider.stories.mdx
@@ -12,7 +12,7 @@ export const metaSettings = createStoryMetaSettings({
 <Meta 
   title="Data display/Divider" 
   component={ Divider } 
-  argType={ metaSettings.argTypes }
+  argTypes={ metaSettings.argTypes }
   decorators={ metaSettings.decorators } 
   />
 

--- a/src/components/EditableHeading/__stories__/EditableHeading.stories.mdx
+++ b/src/components/EditableHeading/__stories__/EditableHeading.stories.mdx
@@ -10,7 +10,7 @@ export const metaSettings = createStoryMetaSettings({
 <Meta
   title="Inputs/EditableHeading"
   component={ EditableHeading }
-  argType={ metaSettings.argTypes }
+  argTypes={ metaSettings.argTypes }
   decorators={ metaSettings.decorators }
 />
 

--- a/src/components/EditableHeading/__stories__/EditableHeading.stories.mdx
+++ b/src/components/EditableHeading/__stories__/EditableHeading.stories.mdx
@@ -11,6 +11,7 @@ export const metaSettings = createStoryMetaSettings({
   title="Inputs/EditableHeading"
   component={ EditableHeading }
   argType={ metaSettings.argTypes }
+  decorators={ metaSettings.decorators }
 />
 
 <!--- Component template -->

--- a/src/components/EditableHeading/__stories__/EditableHeading.stories.mdx
+++ b/src/components/EditableHeading/__stories__/EditableHeading.stories.mdx
@@ -2,7 +2,7 @@ import EditableHeading from "../EditableHeading";
 import { ArgsTable, Story, Canvas, Meta } from "@storybook/addon-docs";
 import { createComponentTemplate, createStoryMetaSettings } from "../../../storybook/functions/create-component-story";
 
-export const argTypes = createStoryMetaSettings({
+export const metaSettings = createStoryMetaSettings({
   component: EditableHeading,
   enumPropNamesArray: ["size", "type"],
 })
@@ -10,7 +10,7 @@ export const argTypes = createStoryMetaSettings({
 <Meta
   title="Inputs/EditableHeading"
   component={ EditableHeading }
-  argTypes={argTypes}
+  argType={ metaSettings.argTypes }
 />
 
 <!--- Component template -->

--- a/src/components/Heading/__stories__/Heading.stories.mdx
+++ b/src/components/Heading/__stories__/Heading.stories.mdx
@@ -16,7 +16,7 @@ import {
   TEXT_FIELD
 } from "../../../storybook/components/related-components/component-description-map";
 
-export const argsTypes = createStoryMetaSettings({
+export const argTypes = createStoryMetaSettings({
   component: Heading,
   enumPropNamesArray: ["type", "size"]
 })
@@ -24,7 +24,7 @@ export const argsTypes = createStoryMetaSettings({
 <Meta
   title="Text/Heading"
   component={ Heading }
-  argTypes={ argsTypes }
+  argTypes={ argTypes }
 />
 
 <!--- Component template -->

--- a/src/components/Heading/__stories__/Heading.stories.mdx
+++ b/src/components/Heading/__stories__/Heading.stories.mdx
@@ -25,6 +25,7 @@ export const metaSettings = createStoryMetaSettings({
   title="Text/Heading"
   component={ Heading }
   argType={ metaSettings.argTypes }
+  decorators={ metaSettings.decorators }
 />
 
 <!--- Component template -->

--- a/src/components/Heading/__stories__/Heading.stories.mdx
+++ b/src/components/Heading/__stories__/Heading.stories.mdx
@@ -16,7 +16,7 @@ import {
   TEXT_FIELD
 } from "../../../storybook/components/related-components/component-description-map";
 
-export const argTypes = createStoryMetaSettings({
+export const metaSettings = createStoryMetaSettings({
   component: Heading,
   enumPropNamesArray: ["type", "size"]
 })
@@ -24,7 +24,7 @@ export const argTypes = createStoryMetaSettings({
 <Meta
   title="Text/Heading"
   component={ Heading }
-  argTypes={ argTypes }
+  argType={ metaSettings.argTypes }
 />
 
 <!--- Component template -->

--- a/src/components/Heading/__stories__/Heading.stories.mdx
+++ b/src/components/Heading/__stories__/Heading.stories.mdx
@@ -24,7 +24,7 @@ export const metaSettings = createStoryMetaSettings({
 <Meta
   title="Text/Heading"
   component={ Heading }
-  argType={ metaSettings.argTypes }
+  argTypes={ metaSettings.argTypes }
   decorators={ metaSettings.decorators }
 />
 

--- a/src/components/Icon/__stories__/Icon.stories.mdx
+++ b/src/components/Icon/__stories__/Icon.stories.mdx
@@ -5,12 +5,12 @@ import { createComponentTemplate, createStoryMetaSettings } from "../../../story
 import { IconsList } from "./icon.stories.helperComponents";
 import "./Icon.stories.scss";
 
-export const argTypes = createStoryMetaSettings({
+export const metaSettings = createStoryMetaSettings({
   component: Icon,
   iconPropNamesArray: ["icon"]
 });
 
-<Meta title="Media/Icon" component={Icon} argTypes={argTypes} />
+<Meta title="Media/Icon" component={Icon} argType={ metaSettings.argTypes } />
 
 <!--- Component template -->
 

--- a/src/components/Icon/__stories__/Icon.stories.mdx
+++ b/src/components/Icon/__stories__/Icon.stories.mdx
@@ -14,6 +14,7 @@ export const metaSettings = createStoryMetaSettings({
   title="Media/Icon"
   component={ Icon }
   argType={ metaSettings.argTypes }
+  decorators={ metaSettings.decorators }
 />
 
 <!--- Component template -->

--- a/src/components/Icon/__stories__/Icon.stories.mdx
+++ b/src/components/Icon/__stories__/Icon.stories.mdx
@@ -10,7 +10,11 @@ export const metaSettings = createStoryMetaSettings({
   iconPropNamesArray: ["icon"]
 });
 
-<Meta title="Media/Icon" component={Icon} argType={ metaSettings.argTypes } />
+<Meta
+  title="Media/Icon"
+  component={ Icon }
+  argType={ metaSettings.argTypes }
+/>
 
 <!--- Component template -->
 

--- a/src/components/Icon/__stories__/Icon.stories.mdx
+++ b/src/components/Icon/__stories__/Icon.stories.mdx
@@ -13,7 +13,7 @@ export const metaSettings = createStoryMetaSettings({
 <Meta
   title="Media/Icon"
   component={ Icon }
-  argType={ metaSettings.argTypes }
+  argTypes={ metaSettings.argTypes }
   decorators={ metaSettings.decorators }
 />
 

--- a/src/components/IconButton/__stories__/IconButton.stories.mdx
+++ b/src/components/IconButton/__stories__/IconButton.stories.mdx
@@ -16,6 +16,7 @@ export const metaSettings = createStoryMetaSettings({
   title="Buttons/IconButton"
   component={ IconButton }
   argType={ metaSettings.argTypes }
+  decorators={ metaSettings.decorators }
 />
 
 <!--- Component template -->

--- a/src/components/IconButton/__stories__/IconButton.stories.mdx
+++ b/src/components/IconButton/__stories__/IconButton.stories.mdx
@@ -15,7 +15,7 @@ export const metaSettings = createStoryMetaSettings({
 <Meta
   title="Buttons/IconButton"
   component={ IconButton }
-  argType={ metaSettings.argTypes }
+  argTypes={ metaSettings.argTypes }
   decorators={ metaSettings.decorators }
 />
 

--- a/src/components/IconButton/__stories__/IconButton.stories.mdx
+++ b/src/components/IconButton/__stories__/IconButton.stories.mdx
@@ -6,7 +6,7 @@ import { createComponentTemplate, createStoryMetaSettings } from "../../../story
 import { BUTTON_GROUP, MENU_BUTTON, BUTTON } from "../../../storybook/components/related-components/component-description-map";
 import { Link } from "../../../storybook/components";
 
-export const argTypes = createStoryMetaSettings({
+export const metaSettings = createStoryMetaSettings({
   component: IconButton,
   enumPropNamesArray: ["kind", "size"],
   iconPropNamesArray: ["icon"]
@@ -15,7 +15,7 @@ export const argTypes = createStoryMetaSettings({
 <Meta
   title="Buttons/IconButton"
   component={ IconButton }
-  argTypes={argTypes}
+  argType={ metaSettings.argTypes }
 />
 
 <!--- Component template -->

--- a/src/components/Label/__stories__/label.stories.mdx
+++ b/src/components/Label/__stories__/label.stories.mdx
@@ -5,7 +5,7 @@ import { TOOLTIP, COUNTER, CHIP } from "../../../storybook/components/related-co
 import { MultipleStoryElementsWrapper, Link } from "../../../storybook/components";
 import "./label.stories.scss";
 
-export const argTypes = createStoryMetaSettings({
+export const metaSettings = createStoryMetaSettings({
   component: Label,
   enumPropNamesArray: ["kind" ,"color"]
 })
@@ -13,7 +13,7 @@ export const argTypes = createStoryMetaSettings({
 <Meta
   title="Data display/Label"
   component={ Label }
-  argTypes={ argTypes }
+  argType={ metaSettings.argTypes }
 />
 
 <!--- Component template -->

--- a/src/components/Label/__stories__/label.stories.mdx
+++ b/src/components/Label/__stories__/label.stories.mdx
@@ -13,7 +13,7 @@ export const metaSettings = createStoryMetaSettings({
 <Meta
   title="Data display/Label"
   component={ Label }
-  argType={ metaSettings.argTypes }
+  argTypes={ metaSettings.argTypes }
   decorators={ metaSettings.decorators }
 />
 

--- a/src/components/Label/__stories__/label.stories.mdx
+++ b/src/components/Label/__stories__/label.stories.mdx
@@ -14,6 +14,7 @@ export const metaSettings = createStoryMetaSettings({
   title="Data display/Label"
   component={ Label }
   argType={ metaSettings.argTypes }
+  decorators={ metaSettings.decorators }
 />
 
 <!--- Component template -->

--- a/src/components/Link/__stories__/Link.stories.mdx
+++ b/src/components/Link/__stories__/Link.stories.mdx
@@ -6,7 +6,7 @@ import { BUTTON, CHIP, BREADCRUBMS } from "../../../storybook/components/related
 import { Link as StorybookLink } from "../../../storybook/components";
 import "./Link.stories.scss";
 
-export const argTypes = createStoryMetaSettings({
+export const metaSettings = createStoryMetaSettings({
   component: Link,
   enumPropNamesArray: ["iconPosition", "target"],
   iconPropNamesArray: ["icon"]
@@ -15,7 +15,7 @@ export const argTypes = createStoryMetaSettings({
 <Meta
   title="Navigation/Link"
   component={ Link }
-  argTypes={argTypes}
+  argType={ metaSettings.argTypes }
 />
 
 <!--- Component template -->

--- a/src/components/Link/__stories__/Link.stories.mdx
+++ b/src/components/Link/__stories__/Link.stories.mdx
@@ -15,7 +15,7 @@ export const metaSettings = createStoryMetaSettings({
 <Meta
   title="Navigation/Link"
   component={ Link }
-  argType={ metaSettings.argTypes }
+  argTypes={ metaSettings.argTypes }
   decorators={ metaSettings.decorators }
 />
 

--- a/src/components/Link/__stories__/Link.stories.mdx
+++ b/src/components/Link/__stories__/Link.stories.mdx
@@ -16,6 +16,7 @@ export const metaSettings = createStoryMetaSettings({
   title="Navigation/Link"
   component={ Link }
   argType={ metaSettings.argTypes }
+  decorators={ metaSettings.decorators }
 />
 
 <!--- Component template -->

--- a/src/components/ListItem/__stories__/ListItem.stories.mdx
+++ b/src/components/ListItem/__stories__/ListItem.stories.mdx
@@ -13,6 +13,7 @@ export const metaSettings = createStoryMetaSettings({
   title="Navigation/List/ListItem"
   component={ ListItem }
   argType={ metaSettings.argTypes }
+  decorators={ metaSettings.decorators }
 />
 
 <!--- Component template -->

--- a/src/components/ListItem/__stories__/ListItem.stories.mdx
+++ b/src/components/ListItem/__stories__/ListItem.stories.mdx
@@ -4,7 +4,7 @@ import { createComponentTemplate, createStoryMetaSettings } from "../../../story
 import Send from "../../Icon/Icons/components/Send";
 import ListItemIcon from "../../ListItemIcon/ListItemIcon";
 
-export const argTypes = createStoryMetaSettings({
+export const metaSettings = createStoryMetaSettings({
   component: ListItem,
   enumPropNamesArray: ["size"]
   });
@@ -12,7 +12,7 @@ export const argTypes = createStoryMetaSettings({
 <Meta
   title="Navigation/List/ListItem"
   component={ ListItem }
-  argTypes={ argTypes }
+  argType={ metaSettings.argTypes }
 />
 
 <!--- Component template -->

--- a/src/components/ListItem/__stories__/ListItem.stories.mdx
+++ b/src/components/ListItem/__stories__/ListItem.stories.mdx
@@ -4,7 +4,7 @@ import { createComponentTemplate, createStoryMetaSettings } from "../../../story
 import Send from "../../Icon/Icons/components/Send";
 import ListItemIcon from "../../ListItemIcon/ListItemIcon";
 
-export const argsTypes = createStoryMetaSettings({
+export const argTypes = createStoryMetaSettings({
   component: ListItem,
   enumPropNamesArray: ["size"]
   });
@@ -12,7 +12,7 @@ export const argsTypes = createStoryMetaSettings({
 <Meta
   title="Navigation/List/ListItem"
   component={ ListItem }
-  argTypes={ argsTypes }
+  argTypes={ argTypes }
 />
 
 <!--- Component template -->

--- a/src/components/ListItem/__stories__/ListItem.stories.mdx
+++ b/src/components/ListItem/__stories__/ListItem.stories.mdx
@@ -12,7 +12,7 @@ export const metaSettings = createStoryMetaSettings({
 <Meta
   title="Navigation/List/ListItem"
   component={ ListItem }
-  argType={ metaSettings.argTypes }
+  argTypes={ metaSettings.argTypes }
   decorators={ metaSettings.decorators }
 />
 

--- a/src/components/Menu/MenuItem/__stories__/MenuItem.stories.mdx
+++ b/src/components/Menu/MenuItem/__stories__/MenuItem.stories.mdx
@@ -18,6 +18,7 @@ export const metaSettings = createStoryMetaSettings({
   title="Navigation/Menu/MenuItem"
   component={ MenuItem }
   argType={ metaSettings.argTypes }
+  decorators={ metaSettings.decorators }
 />
 
 <!--- Component documentation -->

--- a/src/components/Menu/MenuItem/__stories__/MenuItem.stories.mdx
+++ b/src/components/Menu/MenuItem/__stories__/MenuItem.stories.mdx
@@ -8,7 +8,7 @@ import {
 } from "./MenuItem.stories";
 import MenuItem from "../MenuItem";
 
-export const argTypes = createStoryMetaSettings({
+export const metaSettings = createStoryMetaSettings({
   component: MenuItem,
   enumPropNamesArray: ["tooltipPosition"],
   iconPropNamesArray: ["icon"]
@@ -17,7 +17,7 @@ export const argTypes = createStoryMetaSettings({
 <Meta
   title="Navigation/Menu/MenuItem"
   component={ MenuItem }
-  argTypes={argTypes}
+  argType={ metaSettings.argTypes }
 />
 
 <!--- Component documentation -->

--- a/src/components/Menu/MenuItem/__stories__/MenuItem.stories.mdx
+++ b/src/components/Menu/MenuItem/__stories__/MenuItem.stories.mdx
@@ -17,7 +17,7 @@ export const metaSettings = createStoryMetaSettings({
 <Meta
   title="Navigation/Menu/MenuItem"
   component={ MenuItem }
-  argType={ metaSettings.argTypes }
+  argTypes={ metaSettings.argTypes }
   decorators={ metaSettings.decorators }
 />
 

--- a/src/components/Menu/MenuItemButton/__stories__/MenuItemButton.stories.mdx
+++ b/src/components/Menu/MenuItemButton/__stories__/MenuItemButton.stories.mdx
@@ -19,7 +19,7 @@ export const metaSettings = createStoryMetaSettings({
 <Meta
   title="Navigation/Menu/MenuItemButton"
   component={ MenuItemButton }
-  argType={ metaSettings.argTypes }
+  argTypes={ metaSettings.argTypes }
   decorators={ metaSettings.decorators }
 />
 

--- a/src/components/Menu/MenuItemButton/__stories__/MenuItemButton.stories.mdx
+++ b/src/components/Menu/MenuItemButton/__stories__/MenuItemButton.stories.mdx
@@ -20,6 +20,7 @@ export const metaSettings = createStoryMetaSettings({
   title="Navigation/Menu/MenuItemButton"
   component={ MenuItemButton }
   argType={ metaSettings.argTypes }
+  decorators={ metaSettings.decorators }
 />
 
 <!--- Component template -->

--- a/src/components/Menu/MenuItemButton/__stories__/MenuItemButton.stories.mdx
+++ b/src/components/Menu/MenuItemButton/__stories__/MenuItemButton.stories.mdx
@@ -10,7 +10,7 @@ import {
   menuItemButtonDisabledTemplate
 } from "./menuItemButton.stories";
 
-export const argTypes = createStoryMetaSettings({
+export const metaSettings = createStoryMetaSettings({
   component: MenuItemButton,
   enumPropNamesArray: ["kind", "tooltipPosition"],
   iconPropNamesArray: ["leftIcon", "rightIcon"]
@@ -19,7 +19,7 @@ export const argTypes = createStoryMetaSettings({
 <Meta
   title="Navigation/Menu/MenuItemButton"
   component={ MenuItemButton }
-  argTypes={argTypes}
+  argType={ metaSettings.argTypes }
 />
 
 <!--- Component template -->

--- a/src/components/Menu/MenuTitle/__stories__/MenuTitle.stories.mdx
+++ b/src/components/Menu/MenuTitle/__stories__/MenuTitle.stories.mdx
@@ -13,7 +13,7 @@ export const metaSettings = createStoryMetaSettings({
 <Meta
   title="Navigation/Menu/MenuTitle"
   component={ MenuTitle }
-  argType={ metaSettings.argTypes }
+  argTypes={ metaSettings.argTypes }
   decorators={ metaSettings.decorators }
 />
 

--- a/src/components/Menu/MenuTitle/__stories__/MenuTitle.stories.mdx
+++ b/src/components/Menu/MenuTitle/__stories__/MenuTitle.stories.mdx
@@ -14,6 +14,7 @@ export const metaSettings = createStoryMetaSettings({
   title="Navigation/Menu/MenuTitle"
   component={ MenuTitle }
   argType={ metaSettings.argTypes }
+  decorators={ metaSettings.decorators }
 />
 
 <!--- Component documentation -->

--- a/src/components/Menu/MenuTitle/__stories__/MenuTitle.stories.mdx
+++ b/src/components/Menu/MenuTitle/__stories__/MenuTitle.stories.mdx
@@ -5,7 +5,7 @@ import {
 import MenuTitle from "../MenuTitle";
 import { menuTitleCaptionPositionsTemplate, menuTitleTemplate } from "./MenuTitle.stories";
 
-export const argTypes = createStoryMetaSettings({
+export const metaSettings = createStoryMetaSettings({
   component: MenuTitle,
   enumPropNamesArray: ["captionPosition"]
 });
@@ -13,7 +13,7 @@ export const argTypes = createStoryMetaSettings({
 <Meta
   title="Navigation/Menu/MenuTitle"
   component={ MenuTitle }
-  argTypes={argTypes}
+  argType={ metaSettings.argTypes }
 />
 
 <!--- Component documentation -->

--- a/src/components/MenuButton/__stories__/MenuButton.stories.mdx
+++ b/src/components/MenuButton/__stories__/MenuButton.stories.mdx
@@ -20,7 +20,7 @@ export const metaSettings = createStoryMetaSettings({
 <Meta
   title="Buttons/MenuButton"
   component={ MenuButton }
-  argType={ metaSettings.argTypes }
+  argTypes={ metaSettings.argTypes }
   decorators={ metaSettings.decorators }
 />
 

--- a/src/components/MenuButton/__stories__/MenuButton.stories.mdx
+++ b/src/components/MenuButton/__stories__/MenuButton.stories.mdx
@@ -21,6 +21,7 @@ export const metaSettings = createStoryMetaSettings({
   title="Buttons/MenuButton"
   component={ MenuButton }
   argType={ metaSettings.argTypes }
+  decorators={ metaSettings.decorators }
 />
 
 <!--- Component template -->

--- a/src/components/MenuButton/__stories__/MenuButton.stories.mdx
+++ b/src/components/MenuButton/__stories__/MenuButton.stories.mdx
@@ -12,7 +12,7 @@ import MoveArrowLeft from "../../Icon/Icons/components/MoveArrowLeft";
 import MoveArrowRight from "../../Icon/Icons/components/MoveArrowRight";
 
 
-export const argTypes = createStoryMetaSettings({
+export const metaSettings = createStoryMetaSettings({
   component: MenuButton,
   iconPropNamesArray: ["component"]
 });
@@ -20,7 +20,7 @@ export const argTypes = createStoryMetaSettings({
 <Meta
   title="Buttons/MenuButton"
   component={ MenuButton }
-  argTypes={argTypes}
+  argType={ metaSettings.argTypes }
 />
 
 <!--- Component template -->

--- a/src/components/ProgressBars/LinearProgressBar/__stories__/linearProgressBar.stories.mdx
+++ b/src/components/ProgressBars/LinearProgressBar/__stories__/linearProgressBar.stories.mdx
@@ -23,6 +23,7 @@ export const metaSettings = createStoryMetaSettings({
   title="Feedback/LinearProgressBar"
   component={ LinearProgressBar }
   argType={ metaSettings.argTypes }
+  decorators={ metaSettings.decorators }
 />
 
 <!--- Component template -->

--- a/src/components/ProgressBars/LinearProgressBar/__stories__/linearProgressBar.stories.mdx
+++ b/src/components/ProgressBars/LinearProgressBar/__stories__/linearProgressBar.stories.mdx
@@ -14,7 +14,7 @@ import BreadcrumbsBar from "../../../BreadcrumbsBar/BreadcrumbsBar.jsx";
 import BreadcrumbItem from "../../../BreadcrumbsBar/BreadcrumbItem/BreadcrumbItem.jsx";
 import "./linearProgressBar.stories.scss";
 
-export const argTypes = createStoryMetaSettings({
+export const metaSettings = createStoryMetaSettings({
   component: LinearProgressBar,
   enumPropNamesArray: ["size", "barStyle"]
 });
@@ -22,7 +22,7 @@ export const argTypes = createStoryMetaSettings({
 <Meta
   title="Feedback/LinearProgressBar"
   component={ LinearProgressBar }
-  argTypes={ argTypes }
+  argType={ metaSettings.argTypes }
 />
 
 <!--- Component template -->

--- a/src/components/ProgressBars/LinearProgressBar/__stories__/linearProgressBar.stories.mdx
+++ b/src/components/ProgressBars/LinearProgressBar/__stories__/linearProgressBar.stories.mdx
@@ -22,7 +22,7 @@ export const metaSettings = createStoryMetaSettings({
 <Meta
   title="Feedback/LinearProgressBar"
   component={ LinearProgressBar }
-  argType={ metaSettings.argTypes }
+  argTypes={ metaSettings.argTypes }
   decorators={ metaSettings.decorators }
 />
 

--- a/src/components/Search/__stories__/Search.stories.mdx
+++ b/src/components/Search/__stories__/Search.stories.mdx
@@ -16,7 +16,7 @@ export const metaSettings = createStoryMetaSettings({
 <Meta
   title="Inputs/Search"
   component={ Search }
-  argType={ metaSettings.argTypes }
+  argTypes={ metaSettings.argTypes }
   decorators={ metaSettings.decorators }
 />
 

--- a/src/components/Search/__stories__/Search.stories.mdx
+++ b/src/components/Search/__stories__/Search.stories.mdx
@@ -17,6 +17,7 @@ export const metaSettings = createStoryMetaSettings({
   title="Inputs/Search"
   component={ Search }
   argType={ metaSettings.argTypes }
+  decorators={ metaSettings.decorators }
 />
 
 <!--- Component template -->

--- a/src/components/Search/__stories__/Search.stories.mdx
+++ b/src/components/Search/__stories__/Search.stories.mdx
@@ -7,7 +7,7 @@ import Combobox from "../../Combobox/Combobox.jsx";
 import { DROPDOWN, TEXT_FIELD, COMBOBOX } from "../../../storybook/components/related-components/component-description-map";
 import "./Search.stories.scss";
 
-export const argTypes = createStoryMetaSettings({
+export const metaSettings = createStoryMetaSettings({
   component: Search,
   enumPropNamesArray: ["type", "size"],
   iconPropNamesArray: ["secondaryIconName", "iconName"]
@@ -16,7 +16,7 @@ export const argTypes = createStoryMetaSettings({
 <Meta
   title="Inputs/Search"
   component={ Search }
-  argTypes={argTypes}
+  argType={ metaSettings.argTypes }
 />
 
 <!--- Component template -->

--- a/src/components/SplitButton/__stories__/splitButton.stories.mdx
+++ b/src/components/SplitButton/__stories__/splitButton.stories.mdx
@@ -9,13 +9,13 @@ import SplitButtonExampleDialog from "./SplitButtonExampleDialog";
 import { MultipleStoryElementsWrapper, Link } from "../../../storybook/components";
 import "./splitButton.stories.scss";
 
-export const argTypes = createStoryMetaSettings({
+export const metaSettings = createStoryMetaSettings({
   component: SplitButton,
   enumPropNamesArray: ["dialogPaddingSize", "kind", "secondaryDialogPosition"],
   iconPropNamesArray: ["leftIcon", "rightIcon"]
 });
 
-<Meta title="Buttons/Split Button" component={SplitButton} argTypes={argTypes} />
+<Meta title="Buttons/Split Button" component={SplitButton} argType={ metaSettings.argTypes } />
 
 <!--- Component template -->
 

--- a/src/components/SplitButton/__stories__/splitButton.stories.mdx
+++ b/src/components/SplitButton/__stories__/splitButton.stories.mdx
@@ -15,7 +15,11 @@ export const metaSettings = createStoryMetaSettings({
   iconPropNamesArray: ["leftIcon", "rightIcon"]
 });
 
-<Meta title="Buttons/Split Button" component={SplitButton} argType={ metaSettings.argTypes } />
+<Meta 
+  title="Buttons/Split Button"
+  component={ SplitButton }
+  argType={ metaSettings.argTypes }
+/>
 
 <!--- Component template -->
 

--- a/src/components/SplitButton/__stories__/splitButton.stories.mdx
+++ b/src/components/SplitButton/__stories__/splitButton.stories.mdx
@@ -19,6 +19,7 @@ export const metaSettings = createStoryMetaSettings({
   title="Buttons/Split Button"
   component={ SplitButton }
   argType={ metaSettings.argTypes }
+  decorators={ metaSettings.decorators }
 />
 
 <!--- Component template -->

--- a/src/components/SplitButton/__stories__/splitButton.stories.mdx
+++ b/src/components/SplitButton/__stories__/splitButton.stories.mdx
@@ -18,7 +18,7 @@ export const metaSettings = createStoryMetaSettings({
 <Meta 
   title="Buttons/Split Button"
   component={ SplitButton }
-  argType={ metaSettings.argTypes }
+  argTypes={ metaSettings.argTypes }
   decorators={ metaSettings.decorators }
 />
 

--- a/src/components/Steps/__stories__/steps.stories.mdx
+++ b/src/components/Steps/__stories__/steps.stories.mdx
@@ -16,7 +16,7 @@ export const metaSettings = createStoryMetaSettings({
 <Meta
   title="Data display/Steps"
   component={ Steps }
-  argType={ metaSettings.argTypes }
+  argTypes={ metaSettings.argTypes }
   decorators={ metaSettings.decorators }
 />
 

--- a/src/components/Steps/__stories__/steps.stories.mdx
+++ b/src/components/Steps/__stories__/steps.stories.mdx
@@ -17,6 +17,7 @@ export const metaSettings = createStoryMetaSettings({
   title="Data display/Steps"
   component={ Steps }
   argType={ metaSettings.argTypes }
+  decorators={ metaSettings.decorators }
 />
 
 <!--- Component template -->

--- a/src/components/Steps/__stories__/steps.stories.mdx
+++ b/src/components/Steps/__stories__/steps.stories.mdx
@@ -8,7 +8,7 @@ import { modifiers } from "./helpers.js";
 import { BREADCRUBMS, TABS, WIZARD } from "../../../storybook/components/related-components/component-description-map";
 import "./steps.stories.scss";
 
-export const argTypes = createStoryMetaSettings({
+export const metaSettings = createStoryMetaSettings({
   component: Steps,
   enumPropNamesArray: ["type"]
 });
@@ -16,7 +16,7 @@ export const argTypes = createStoryMetaSettings({
 <Meta
   title="Data display/Steps"
   component={ Steps }
-  argTypes={ argTypes }
+  argType={ metaSettings.argTypes }
 />
 
 <!--- Component template -->

--- a/src/components/Tabs/TabPanels/__stories__/tab-panels.stories.mdx
+++ b/src/components/Tabs/TabPanels/__stories__/tab-panels.stories.mdx
@@ -3,7 +3,7 @@ import { createStoryMetaSettings } from "../../../../storybook/functions/create-
 import TabPanel from "../../TabPanel/TabPanel";
 import TabPanels from "../TabPanels";
 
-export const argTypes = createStoryMetaSettings({
+export const metaSettings = createStoryMetaSettings({
   component: TabPanels,
   enumPropNamesArray: ["animationDirection"]
 })
@@ -11,7 +11,7 @@ export const argTypes = createStoryMetaSettings({
 <Meta
   title="Navigation/Tabs/TabPanels"
   component={ TabPanels }
-  argTypes={argTypes}
+  argType={ metaSettings.argTypes }
 />
 
 <!--- Component template -->

--- a/src/components/Tabs/TabPanels/__stories__/tab-panels.stories.mdx
+++ b/src/components/Tabs/TabPanels/__stories__/tab-panels.stories.mdx
@@ -11,7 +11,7 @@ export const metaSettings = createStoryMetaSettings({
 <Meta
   title="Navigation/Tabs/TabPanels"
   component={ TabPanels }
-  argType={ metaSettings.argTypes }
+  argTypes={ metaSettings.argTypes }
   decorators={ metaSettings.decorators }
 />
 

--- a/src/components/Tabs/TabPanels/__stories__/tab-panels.stories.mdx
+++ b/src/components/Tabs/TabPanels/__stories__/tab-panels.stories.mdx
@@ -12,6 +12,7 @@ export const metaSettings = createStoryMetaSettings({
   title="Navigation/Tabs/TabPanels"
   component={ TabPanels }
   argType={ metaSettings.argTypes }
+  decorators={ metaSettings.decorators }
 />
 
 <!--- Component template -->

--- a/src/components/TextField/__stories__/TextField.stories.mdx
+++ b/src/components/TextField/__stories__/TextField.stories.mdx
@@ -16,6 +16,7 @@ export const metaSettings = createStoryMetaSettings({
   title="Inputs/TextField"
   component={ TextField }
   argType={ metaSettings.argTypes }
+  decorators={ metaSettings.decorators }
 />
 
 <!--- Component template -->

--- a/src/components/TextField/__stories__/TextField.stories.mdx
+++ b/src/components/TextField/__stories__/TextField.stories.mdx
@@ -6,7 +6,7 @@ import { Email, CloseSmall, Check } from "../../Icon/Icons";
 import { DROPDOWN, SEARCH, COMBOBOX } from "../../../storybook/components/related-components/component-description-map";
 import "./TextField.stories.scss";
 
-export const argTypes = createStoryMetaSettings({
+export const metaSettings = createStoryMetaSettings({
   component: TextField,
   enumPropNamesArray: ["type", "size"],
   iconPropNamesArray: ["secondaryIconName", "iconName", "labelIconName"]
@@ -15,7 +15,7 @@ export const argTypes = createStoryMetaSettings({
 <Meta
   title="Inputs/TextField"
   component={ TextField }
-  argTypes={ argTypes}
+  argType={ metaSettings.argTypes }
 />
 
 <!--- Component template -->

--- a/src/components/TextField/__stories__/TextField.stories.mdx
+++ b/src/components/TextField/__stories__/TextField.stories.mdx
@@ -15,7 +15,7 @@ export const metaSettings = createStoryMetaSettings({
 <Meta
   title="Inputs/TextField"
   component={ TextField }
-  argType={ metaSettings.argTypes }
+  argTypes={ metaSettings.argTypes }
   decorators={ metaSettings.decorators }
 />
 

--- a/src/components/Tipseen/__stories__/tipseen.stories.mdx
+++ b/src/components/Tipseen/__stories__/tipseen.stories.mdx
@@ -22,6 +22,7 @@ export const metaSettings = createStoryMetaSettings({
   title="Popover/Tipseen"
   component={ Tipseen }
   argType={ metaSettings.argTypes }
+  decorators={ metaSettings.decorators }
 />
 
 <!--- Component documentation -->

--- a/src/components/Tipseen/__stories__/tipseen.stories.mdx
+++ b/src/components/Tipseen/__stories__/tipseen.stories.mdx
@@ -13,7 +13,7 @@ import { createStoryMetaSettings } from "../../../storybook/functions/create-com
 import { tipseenTemplate } from "./tipseen.stories";
 import "./tipseen.stories.scss";
 
-export const argTypes = createStoryMetaSettings({
+export const metaSettings = createStoryMetaSettings({
   component: Tipseen,
   enumPropNamesArray: ["position", "animationType", "justify"],
 });
@@ -21,7 +21,7 @@ export const argTypes = createStoryMetaSettings({
 <Meta
   title="Popover/Tipseen"
   component={ Tipseen }
-  argTypes={argTypes}
+  argType={ metaSettings.argTypes }
 />
 
 <!--- Component documentation -->

--- a/src/components/Tipseen/__stories__/tipseen.stories.mdx
+++ b/src/components/Tipseen/__stories__/tipseen.stories.mdx
@@ -21,7 +21,7 @@ export const metaSettings = createStoryMetaSettings({
 <Meta
   title="Popover/Tipseen"
   component={ Tipseen }
-  argType={ metaSettings.argTypes }
+  argTypes={ metaSettings.argTypes }
   decorators={ metaSettings.decorators }
 />
 

--- a/src/components/Toast/__stories__/toast.stories.mdx
+++ b/src/components/Toast/__stories__/toast.stories.mdx
@@ -17,7 +17,7 @@ export const metaSettings = createStoryMetaSettings({
 <Meta
   title="Feedback/Toast"
   component={ Toast }
-  argType={ metaSettings.argTypes }
+  argTypes={ metaSettings.argTypes }
   decorators={ metaSettings.decorators }
 />
 

--- a/src/components/Toast/__stories__/toast.stories.mdx
+++ b/src/components/Toast/__stories__/toast.stories.mdx
@@ -8,7 +8,7 @@ import { TOOLTIP, ATTENTION_BOX, ALERT_BANNER } from "../../../storybook/compone
 import { Delete } from "../../Icon/Icons"
 import "./toast.stories.scss";
 
-export const argTypes = createStoryMetaSettings({
+export const metaSettings = createStoryMetaSettings({
   component: Toast,
   enumPropNamesArray: ["type"],
   iconPropNamesArray: ["icon"]
@@ -17,7 +17,7 @@ export const argTypes = createStoryMetaSettings({
 <Meta
   title="Feedback/Toast"
   component={ Toast }
-  argTypes={argTypes}
+  argType={ metaSettings.argTypes }
 />
 
 <!--- Component template -->

--- a/src/components/Toast/__stories__/toast.stories.mdx
+++ b/src/components/Toast/__stories__/toast.stories.mdx
@@ -18,6 +18,7 @@ export const metaSettings = createStoryMetaSettings({
   title="Feedback/Toast"
   component={ Toast }
   argType={ metaSettings.argTypes }
+  decorators={ metaSettings.decorators }
 />
 
 <!--- Component template -->

--- a/src/storybook/functions/create-component-story.js
+++ b/src/storybook/functions/create-component-story.js
@@ -1,4 +1,6 @@
-import React from "react";
+import React, { useState, useCallback, useMemo } from "react";
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { action } from "@storybook/addon-actions";
 import { iconsMetaData } from "monday-ui-style/src/Icons/iconsMetaData";
 import * as AllIcons from "../../components/Icon/Icons";
 
@@ -19,6 +21,7 @@ const allowedIcons = iconsMetaData.reduce(
 
 export function createStoryMetaSettings({ component, enumPropNamesArray, iconPropNamesArray, actionPropsArray }) {
   const argTypes = {};
+  const decorators = [];
 
   // set enum allowed values inside argsTypes object
   enumPropNamesArray?.forEach(propName => {
@@ -41,9 +44,43 @@ export function createStoryMetaSettings({ component, enumPropNamesArray, iconPro
     };
   });
 
-  actionPropsArray?.forEach(propName => {
-    argTypes[propName] = { action: propName };
+  actionPropsArray?.forEach(actionProp => {
+    if (typeof actionProp === "string") {
+      argTypes[actionProp] = { action: actionProp };
+    } else if (actionProp?.name && actionProp.linkToValueProp) {
+      // we assume that actionPropsArray is static. If it changes, things may break, since internally we call React.useState for the story decorator.
+      decorators.push(createMappedActionToInputPropDecorator(actionProp.name, actionProp.linkToValueProp));
+    }
   });
 
-  return { argTypes };
+  return { argTypes, decorators };
+}
+
+/**
+ * Creates a decorator which maps a callback prop to an input prop.
+ * For example: mapping the onChange callback of a Select component to its currentValue prop.
+ * Useful for adding interactivity to stories of controlled components.
+ * Additionally, the callback will trigger a Storybook action, that can be seen on the Actions tab.
+ * @param {string} actionName - the name of the action prop of the component in the story. For example, "setValue" or "onChange".
+ * @param {string} linkToPropName - the name of the prop which should be updated when the prop of "actionName" is called. For example, "value".
+ * @returns A decorate for storybook which updates the {@link linkToPropName} input of the component, whenever {@link actionName} is called.
+ */
+function createMappedActionToInputPropDecorator(actionName, linkToPropName) {
+  return (Story, context) => {
+    const [propValue, setPropValue] = useState(context.initialArgs[linkToPropName]);
+    const createAction = useMemo(() => action(actionName), []);
+
+    const injectedCallback = useCallback(
+      newPropValue => {
+        setPropValue(newPropValue);
+        createAction(newPropValue);
+      },
+      [setPropValue, createAction]
+    );
+
+    context.args[actionName] = injectedCallback;
+    context.args[linkToPropName] = propValue;
+
+    return Story();
+  };
 }

--- a/src/storybook/functions/create-component-story.js
+++ b/src/storybook/functions/create-component-story.js
@@ -45,5 +45,5 @@ export function createStoryMetaSettings({ component, enumPropNamesArray, iconPro
     argTypes[propName] = { action: propName };
   });
 
-  return argTypes;
+  return { argTypes };
 }

--- a/src/storybook/functions/create-component-story.js
+++ b/src/storybook/functions/create-component-story.js
@@ -47,9 +47,9 @@ export function createStoryMetaSettings({ component, enumPropNamesArray, iconPro
   actionPropsArray?.forEach(actionProp => {
     if (typeof actionProp === "string") {
       argTypes[actionProp] = { action: actionProp };
-    } else if (actionProp?.name && actionProp.linkToValueProp) {
+    } else if (actionProp?.name && actionProp.linkedToPropValue) {
       // we assume that actionPropsArray is static. If it changes, things may break, since internally we call React.useState for the story decorator.
-      decorators.push(createMappedActionToInputPropDecorator(actionProp.name, actionProp.linkToValueProp));
+      decorators.push(createMappedActionToInputPropDecorator(actionProp.name, actionProp.linkedToPropValue));
     }
   });
 
@@ -62,12 +62,12 @@ export function createStoryMetaSettings({ component, enumPropNamesArray, iconPro
  * Useful for adding interactivity to stories of controlled components.
  * Additionally, the callback will trigger a Storybook action, that can be seen on the Actions tab.
  * @param {string} actionName - the name of the action prop of the component in the story. For example, "setValue" or "onChange".
- * @param {string} linkToPropName - the name of the prop which should be updated when the prop of "actionName" is called. For example, "value".
- * @returns A decorate for storybook which updates the {@link linkToPropName} input of the component, whenever {@link actionName} is called.
+ * @param {string} linkedToPropValue - the name of the prop which should be updated when the prop of "actionName" is called. For example, "value".
+ * @returns A decorate for storybook which updates the {@link linkedToPropValue} input of the component, whenever {@link actionName} is called.
  */
-function createMappedActionToInputPropDecorator(actionName, linkToPropName) {
+function createMappedActionToInputPropDecorator(actionName, linkedToPropValue) {
   return (Story, context) => {
-    const [propValue, setPropValue] = useState(context.initialArgs[linkToPropName]);
+    const [propValue, setPropValue] = useState(context.initialArgs[linkedToPropValue]);
     const createAction = useMemo(() => action(actionName), []);
 
     const injectedCallback = useCallback(
@@ -79,7 +79,7 @@ function createMappedActionToInputPropDecorator(actionName, linkToPropName) {
     );
 
     context.args[actionName] = injectedCallback;
-    context.args[linkToPropName] = propValue;
+    context.args[linkedToPropValue] = propValue;
 
     return Story();
   };


### PR DESCRIPTION
* As discussed following to [this PR](https://github.com/mondaycom/monday-ui-react-core/pull/451), I've enhanced the existing `createStoryMetaSettings` instead of adding a new function. 
* `createStoryMetaSettings` will now return an object containing `argTypes` and `decorators`. I've aligned the existing usage of all stories.
* As mentioned in the original PR, the new functionality allows adding more interactivity to the stories. I've added the `ColorPicker` story as an example (until now, it was impossible for the user to understand the behavior of the `isMultiselect` option, since changes didn't update the state of the component)

- [x] Optional - we can update the plop storybook (`plop/general/component-stories-mdx.txt`) to include a call to `createStoryMetaSettings`. @hadasfa WDYT?