### PR TITLE
Keyboard nav context improvements

### DIFF
--- a/src/components/GridKeyboardNavigationContext/GridKeyboardNavigationContext.js
+++ b/src/components/GridKeyboardNavigationContext/GridKeyboardNavigationContext.js
@@ -1,4 +1,4 @@
-import React, { useRef, useContext, useCallback } from "react";
+import React, { useContext, useCallback, useMemo } from "react";
 import useEventListener from "../../hooks/useEventListener";
 import {
   focusElementWithDirection,
@@ -9,8 +9,13 @@ import {
 
 export const GridKeyboardNavigationContext = React.createContext();
 
+/**
+ * @param {({topElement: React.MutableRefObject, bottomElement: React.MutableRefObject}|
+ * {leftElement: React.MutableRefObject, rightElement: React.MutableRefObject})[]} positions - the positions of the navigable items
+ * @param {*} wrapperRef - a reference for a wrapper element which contains all the referenced elements
+ */
 export const useGridKeyboardNavigationContext = (positions, wrapperRef) => {
-  const directionMaps = useRef(getDirectionMaps(positions));
+  const directionMaps = useMemo(() => getDirectionMaps(positions), [positions]);
   const upperContext = useContext(GridKeyboardNavigationContext);
 
   const onWrapperFocus = useCallback(
@@ -20,7 +25,7 @@ export const useGridKeyboardNavigationContext = (positions, wrapperRef) => {
         return;
       }
       const oppositeDirection = getOppositeDirection(keyboardDirection);
-      const elementToFocus = getOutmostElementInDirection(directionMaps.current, oppositeDirection);
+      const elementToFocus = getOutmostElementInDirection(directionMaps, oppositeDirection);
       focusElementWithDirection(elementToFocus, keyboardDirection);
     },
     [directionMaps]
@@ -29,7 +34,7 @@ export const useGridKeyboardNavigationContext = (positions, wrapperRef) => {
 
   const onOutboundNavigation = useCallback(
     (elementRef, direction) => {
-      const maybeNextElement = directionMaps.current[direction].get(elementRef);
+      const maybeNextElement = directionMaps[direction].get(elementRef);
       if (maybeNextElement?.current) {
         elementRef.current?.blur();
         focusElementWithDirection(maybeNextElement, direction);
@@ -38,7 +43,7 @@ export const useGridKeyboardNavigationContext = (positions, wrapperRef) => {
       // nothing on that direction - try updating the upper context
       upperContext?.onOutboundNavigation(wrapperRef, direction);
     },
-    [upperContext, wrapperRef]
+    [directionMaps, upperContext, wrapperRef]
   );
   return { onOutboundNavigation };
 };

--- a/src/components/GridKeyboardNavigationContext/__tests__/helper.jest.js
+++ b/src/components/GridKeyboardNavigationContext/__tests__/helper.jest.js
@@ -7,11 +7,13 @@ import {
 } from "../helper";
 
 describe("GridKeyboardNavigationContext.helper", () => {
-  const ELEMENT1 = "e1";
-  const ELEMENT2 = "e2";
-  const ELEMENT3 = "e3";
-  const ELEMENT4 = "e4";
-  const ELEMENT5 = "e5";
+  const ELEMENT1 = { current: "e1" };
+  const ELEMENT2 = { current: "e2" };
+  const ELEMENT3 = { current: "e3" };
+  const ELEMENT4 = { current: "e4" };
+  const ELEMENT5 = { current: "e5" };
+  const UNMOUNTED_ELEMENT_1 = { current: null };
+  const UNMOUNTED_ELEMENT_2 = { current: null };
 
   describe("getDirectionMaps", () => {
     it("should return empty direction maps when no positions are supplied", () => {
@@ -246,6 +248,32 @@ describe("GridKeyboardNavigationContext.helper", () => {
       const directionMaps = getDirectionMaps([
         { topElement: ELEMENT1, bottomElement: ELEMENT2 },
         { topElement: ELEMENT2, bottomElement: ELEMENT3 }
+      ]);
+      const direction = NAV_DIRECTIONS.RIGHT;
+      const expected = ELEMENT1;
+
+      const result = getOutmostElementInDirection(directionMaps, direction);
+
+      expect(result).toEqual(expected);
+    });
+
+    it("should skip the bottom-most element when asking for the bottom element, and the bottom-most element is not mounted", () => {
+      const directionMaps = getDirectionMaps([
+        { topElement: ELEMENT1, bottomElement: ELEMENT2 },
+        { topElement: ELEMENT2, bottomElement: UNMOUNTED_ELEMENT_1 }
+      ]);
+      const direction = NAV_DIRECTIONS.DOWN;
+      const expected = ELEMENT2;
+
+      const result = getOutmostElementInDirection(directionMaps, direction);
+
+      expect(result).toEqual(expected);
+    });
+
+    it("should skip the two right-most elements when asking for the right element, and the two right-most elements are not mounted", () => {
+      const directionMaps = getDirectionMaps([
+        { leftElement: ELEMENT1, rightElement: UNMOUNTED_ELEMENT_2 },
+        { leftElement: UNMOUNTED_ELEMENT_2, rightElement: UNMOUNTED_ELEMENT_1 }
       ]);
       const direction = NAV_DIRECTIONS.RIGHT;
       const expected = ELEMENT1;

--- a/src/components/GridKeyboardNavigationContext/helper.js
+++ b/src/components/GridKeyboardNavigationContext/helper.js
@@ -79,10 +79,36 @@ export const getOutmostElementInDirection = (directionMaps, direction) => {
     // there are no registered vertical relations registered, try horizontal relations. Get the left-most element.
     return getOutmostElementInDirection(directionMaps, NAV_DIRECTIONS.LEFT);
   }
-  let result = firstEntry?.[0];
-  while (directionMap.get(result)) {
-    // as long as there's an element which is outward of the keyboard direction, take it.
-    result = directionMap.get(result);
-  }
-  return result;
+  const firstRef = firstEntry[0];
+  return getLastFocusableElementFromElementInDirection(directionMap, firstRef);
 };
+
+function getLastFocusableElementFromElementInDirection(directionMap, initialRef) {
+  let done = false;
+  let currentRef = initialRef;
+
+  while (!done) {
+    // as long as there's a mounted element which in that direction, take it.
+    const nextEligible = getNextEligibleRef(currentRef);
+    if (!nextEligible) {
+      done = true;
+    } else {
+      currentRef = nextEligible;
+    }
+  }
+
+  function getNextEligibleRef(_currentRef) {
+    const next = directionMap.get(_currentRef);
+    if (!next) {
+      // this is the last element on the direction map - there' nothing next
+      return null;
+    }
+    if (!next.current) {
+      // the next element is not mounted, try the next one
+      return getNextEligibleRef(next);
+    }
+    return next;
+  }
+
+  return currentRef;
+}


### PR DESCRIPTION
[Task](https://monday.monday.com/boards/470024321/pulses/2123616392)

The fix prevents cases where a reference to an unmounted component "steals" the focus for the actual element that we want to focus when navigating into an element. For example, when navigating up into a vertical list that has conditional rendering of the items.