### PR TITLE
removed filter options for dropdown rendering

### DIFF
--- a/src/components/Dropdown/Dropdown.jsx
+++ b/src/components/Dropdown/Dropdown.jsx
@@ -205,8 +205,7 @@ const Dropdown = ({
   const additions = {
     ...(!asyncOptions && { options }),
     ...(multi && {
-      isMulti: true,
-      filterOption: option => !selectedOptionsMap[option.value]
+      isMulti: true
     })
   };
 


### PR DESCRIPTION
it cause a bug, when clearing all/removing chips, not showing the options again until re-opening.
@sahariko @hadasfa - if there's a reason for keeping it, please update, so we'll try to mitigate.