### PR TITLE
Fixed menu item hover

### DIFF
--- a/src/components/Menu/MenuItem/MenuItem.jsx
+++ b/src/components/Menu/MenuItem/MenuItem.jsx
@@ -98,7 +98,7 @@ const MenuItem = forwardRef(
     }, [isActive, referenceElement, shouldScrollMenu]);
 
     const isMouseEnter = useMenuItemMouseEvents(
-      ref,
+      referenceElementRef,
       resetOpenSubMenuIndex,
       setSubMenuIsOpenByIndex,
       isActive,


### PR DESCRIPTION
Hovering a sub menu didn't work since the wrong ref was used. 
This bug was introduced in [my previous changes](https://github.com/mondaycom/monday-ui-react-core/pull/492).