### PR TITLE
Fix selection feedback not showing for single item selection of ColorPicker

### DIFF
--- a/src/components/ColorPicker/components/ColorPickerContent/ColorPickerColorsGrid.jsx
+++ b/src/components/ColorPicker/components/ColorPickerContent/ColorPickerColorsGrid.jsx
@@ -51,7 +51,7 @@ export const ColorPickerColorsGrid = React.forwardRef(
               colorStyle={colorStyle}
               ColorIndicatorIcon={ColorIndicatorIcon}
               SelectedIndicatorIcon={SelectedIndicatorIcon}
-              isSelected={isMultiselect ? value.includes(color) : value === color}
+              isSelected={Array.isArray(value) ? value.includes(color) : value === color}
               isActive={index === activeIndex}
               isMultiselect={isMultiselect}
               colorSize={colorSize}


### PR DESCRIPTION
[Task](https://monday.monday.com/boards/245345663/pulses/2224399090)
The issue was that the value can be an array even if `isMultiselect === false`, so the comparison didn't work properly
![image](https://user-images.githubusercontent.com/96776835/151986871-454d42bd-b56e-4354-aa8b-4be3eb630feb.png)
