### PR TITLE
ColorPicker - white selected icon, even not on multi selection

### DIFF
--- a/src/components/ColorPicker/components/ColorPickerContent/ColorPickerColorsGrid.jsx
+++ b/src/components/ColorPicker/components/ColorPickerContent/ColorPickerColorsGrid.jsx
@@ -18,7 +18,6 @@ export const ColorPickerColorsGrid = React.forwardRef(
       colorStyle,
       ColorIndicatorIcon,
       shouldRenderIndicatorWithoutBackground,
-      isMultiselect,
       SelectedIndicatorIcon,
       colorSize,
       tooltipContentByColor,

--- a/src/components/ColorPicker/components/ColorPickerContent/ColorPickerColorsGrid.jsx
+++ b/src/components/ColorPicker/components/ColorPickerContent/ColorPickerColorsGrid.jsx
@@ -53,7 +53,6 @@ export const ColorPickerColorsGrid = React.forwardRef(
               SelectedIndicatorIcon={SelectedIndicatorIcon}
               isSelected={Array.isArray(value) ? value.includes(color) : value === color}
               isActive={index === activeIndex}
-              isMultiselect={isMultiselect}
               colorSize={colorSize}
               tooltipContent={tooltipContentByColor[color]}
               colorShape={colorShape}
@@ -88,8 +87,7 @@ ColorPickerColorsGrid.propTypes = {
   numberOfColorsInLine: PropTypes.number,
   tooltipContentByColor: PropTypes.object,
   focusOnMount: PropTypes.bool,
-  colorShape: PropTypes.oneOf(Object.values(ColorPickerColorsGrid.colorShapes)),
-  isMultiselect: PropTypes.bool
+  colorShape: PropTypes.oneOf(Object.values(ColorPickerColorsGrid.colorShapes))
 };
 
 ColorPickerColorsGrid.defaultProps = {
@@ -104,6 +102,5 @@ ColorPickerColorsGrid.defaultProps = {
   numberOfColorsInLine: DEFAULT_NUMBER_OF_COLORS_IN_LINE,
   tooltipContentByColor: {},
   focusOnMount: false,
-  colorShape: ColorPickerColorsGrid.colorShapes.SQUARE,
-  isMultiselect: false
+  colorShape: ColorPickerColorsGrid.colorShapes.SQUARE
 };

--- a/src/components/ColorPicker/components/ColorPickerContent/ColorPickerContentComponent.jsx
+++ b/src/components/ColorPicker/components/ColorPickerContent/ColorPickerContentComponent.jsx
@@ -87,7 +87,6 @@ const ColorPickerContentComponent = forwardRef(
             colorStyle={colorStyle}
             ColorIndicatorIcon={ColorIndicatorIcon}
             shouldRenderIndicatorWithoutBackground={shouldRenderIndicatorWithoutBackground}
-            isMultiselect={isMultiselect}
             SelectedIndicatorIcon={SelectedIndicatorIcon}
             colorSize={colorSize}
             tooltipContentByColor={tooltipContentByColor}

--- a/src/components/ColorPicker/components/ColorPickerItemComponent/ColorPickerItemComponent.jsx
+++ b/src/components/ColorPicker/components/ColorPickerItemComponent/ColorPickerItemComponent.jsx
@@ -78,7 +78,7 @@ const ColorPickerItemComponent = ({
             {shouldRenderIcon && (
               <Icon
                 icon={isSelected ? SelectedIndicatorIcon : ColorIndicatorIcon}
-                className="color-icon"
+                className={cx({ "color-icon-white": !shouldRenderIndicatorWithoutBackground })}
                 ignoreFocusStyle
               />
             )}

--- a/src/components/ColorPicker/components/ColorPickerItemComponent/ColorPickerItemComponent.jsx
+++ b/src/components/ColorPicker/components/ColorPickerItemComponent/ColorPickerItemComponent.jsx
@@ -52,8 +52,7 @@ const ColorPickerItemComponent = ({
     };
   }, [color, colorAsStyle, colorStyle, itemRef, shouldRenderIndicatorWithoutBackground]);
 
-  const shouldRenderSelectedIcon = isSelected && isMultiselect;
-  const shouldRenderIcon = shouldRenderSelectedIcon || ColorIndicatorIcon;
+  const shouldRenderIcon = isSelected || ColorIndicatorIcon;
   const colorIndicatorWrapperStyle = shouldRenderIndicatorWithoutBackground ? { color: colorAsStyle } : {};
   return (
     <Tooltip content={tooltipContent}>
@@ -78,7 +77,11 @@ const ColorPickerItemComponent = ({
         >
           <div className="color-indicator-wrapper" style={colorIndicatorWrapperStyle}>
             {shouldRenderIcon && (
-              <Icon icon={shouldRenderSelectedIcon ? SelectedIndicatorIcon : ColorIndicatorIcon} ignoreFocusStyle />
+              <Icon
+                icon={isSelected ? SelectedIndicatorIcon : ColorIndicatorIcon}
+                className="color-icon"
+                ignoreFocusStyle
+              />
             )}
           </div>
         </Clickable>

--- a/src/components/ColorPicker/components/ColorPickerItemComponent/ColorPickerItemComponent.jsx
+++ b/src/components/ColorPicker/components/ColorPickerItemComponent/ColorPickerItemComponent.jsx
@@ -17,7 +17,6 @@ const ColorPickerItemComponent = ({
   shouldRenderIndicatorWithoutBackground,
   ColorIndicatorIcon,
   SelectedIndicatorIcon,
-  isMultiselect,
   isSelected,
   colorSize,
   tooltipContent,

--- a/src/components/ColorPicker/components/ColorPickerItemComponent/ColorPickerItemComponent.scss
+++ b/src/components/ColorPicker/components/ColorPickerItemComponent/ColorPickerItemComponent.scss
@@ -98,4 +98,8 @@
   .color-item-text-mode:hover {
     background-color: var(--primary-background-hover-color) !important;
   }
+
+  .color-icon {
+    color: var(--color-snow_white);
+  }
 }

--- a/src/components/ColorPicker/components/ColorPickerItemComponent/ColorPickerItemComponent.scss
+++ b/src/components/ColorPicker/components/ColorPickerItemComponent/ColorPickerItemComponent.scss
@@ -99,7 +99,7 @@
     background-color: var(--primary-background-hover-color) !important;
   }
 
-  .color-icon {
+  .color-icon-white {
     color: var(--color-snow_white);
   }
 }


### PR DESCRIPTION
[Task](https://monday.monday.com/boards/245345663/pulses/2213221889)
Came as a request from Evgeniy: previously, the icon was black - looking bad on darker colors. The white icons look good on all colors.
Also, the icon will now show even when isMultiSelection is false.
![image](https://user-images.githubusercontent.com/96776835/151999605-06271036-3c5b-40d9-869b-0be8e959d927.png)
