### PR TITLE
Disabling activeIndex after a non-keyboard interaction

### DIFF
--- a/src/hooks/useGridKeyboardNavigation/useGridKeyboardNavigation.js
+++ b/src/hooks/useGridKeyboardNavigation/useGridKeyboardNavigation.js
@@ -107,7 +107,7 @@ export default function useGridKeyboardNavigation({
 
   useEffect(() => {
     if (activeIndex > -1) {
-      ref?.current?.focus();
+      ref.current?.focus();
     }
   }, [activeIndex, ref]);
 

--- a/src/hooks/useGridKeyboardNavigation/useGridKeyboardNavigation.js
+++ b/src/hooks/useGridKeyboardNavigation/useGridKeyboardNavigation.js
@@ -10,13 +10,6 @@ import useEventListener from "../useEventListener";
 const NO_ACTIVE_INDEX = -1;
 
 /**
- * @typedef useGridKeyboardNavigationResult
- * @property {number} activeIndex - the currently active index
- * @property {boolean} isInitialActiveState - if true, the currently active element was due to an initial mounting index option. See "options.focusItemIndexOnMount".
- * @property {function} onSelectionAction - the callback which should be used to select an item. It should be called with the selected item's index. Use this callback for onClick handlers, for example.
- */
-
-/**
  * A hook which is used for accessible keyboard navigation. Useful for components rendering a list of items that can be navigated and selected with a keyboard.
  * @param {Object} options
  * @param {React.MutableRefObject} options.ref - the reference for the component that listens to keyboard
@@ -28,6 +21,13 @@ const NO_ACTIVE_INDEX = -1;
  * @param {number=} options.focusItemIndexOnMount - optional item index to focus when mounted. Only works with "options.focusOnMount".
  * @param {number[]=} options.disabledIndexes - optional array of disabled indices, which will be skipped while navigating.
  * @returns {useGridKeyboardNavigationResult}
+ *
+ * @typedef useGridKeyboardNavigationResult
+ * @property {number} activeIndex - the currently active index
+ * @property {boolean} isInitialActiveState - if true, the currently active element was due to an initial mounting index option. See "options.focusItemIndexOnMount".
+ * @property {(index: number, isKeyboardAction?: boolean) => void} onSelectionAction - the callback which should be used to select an item.
+ * It should be called with the selected item's index. Use this callback for onClick handlers, for example.
+ * The "isKeyboardAction" can be used to indicate a keyboard selection, which will affect the currently active index.
  */
 export default function useGridKeyboardNavigation({
   ref,
@@ -44,10 +44,12 @@ export default function useGridKeyboardNavigation({
   );
   const skippedInitialActiveIndexChange = useRef(false);
   const [activeIndex, setActiveIndex] = useState(isInitialActiveState ? focusItemIndexOnMount : NO_ACTIVE_INDEX);
+  const [isUsingKeyboardNav, setIsUsingKeyboardNav] = useState(focusOnMount);
 
   const keyboardContext = useContext(GridKeyboardNavigationContext);
 
   const onArrowNavigation = direction => {
+    setIsUsingKeyboardNav(true);
     if (activeIndex === NO_ACTIVE_INDEX) {
       setActiveIndex(0);
       return;
@@ -68,12 +70,6 @@ export default function useGridKeyboardNavigation({
   };
 
   useEffect(() => {
-    if (activeIndex > -1) {
-      ref?.current?.focus();
-    }
-  }, [activeIndex, ref]);
-
-  useEffect(() => {
     if (!skippedInitialActiveIndexChange.current) {
       skippedInitialActiveIndexChange.current = true;
       return;
@@ -92,6 +88,7 @@ export default function useGridKeyboardNavigation({
       }
       const direction = e.detail?.keyboardDirection;
       if (direction) {
+        setIsUsingKeyboardNav(true);
         const newIndex = getActiveIndexFromInboundNavigation({ direction, numberOfItemsInLine, itemsCount });
         setActiveIndex(newIndex);
         return;
@@ -108,15 +105,27 @@ export default function useGridKeyboardNavigation({
   useEventListener({ eventName: "focus", callback: onFocus, ref });
   useEventListener({ eventName: "blur", callback: onBlur, ref });
 
+  useEffect(() => {
+    if (activeIndex > -1) {
+      ref?.current?.focus();
+    }
+  }, [activeIndex, ref]);
+
   const onSelectionAction = useCallback(
-    index => {
+    (index, isKeyboardAction = false) => {
+      setIsUsingKeyboardNav(isKeyboardAction);
       setActiveIndex(index);
       onItemClicked(getItemByIndex(index), index);
     },
     [setActiveIndex, onItemClicked, getItemByIndex]
   );
 
-  const onKeyboardSelection = useCallback(() => onSelectionAction(activeIndex), [onSelectionAction, activeIndex]);
+  const onKeyboardSelection = useCallback(() => {
+    if (!isUsingKeyboardNav) {
+      return;
+    }
+    return onSelectionAction(activeIndex, true);
+  }, [isUsingKeyboardNav, onSelectionAction, activeIndex]);
 
   useFullKeyboardListeners({
     ref,
@@ -126,8 +135,10 @@ export default function useGridKeyboardNavigation({
     focusOnMount
   });
 
+  // if the user is not using keyboard nav, the consumers should not treat the index as active
+  const externalActiveIndex = isUsingKeyboardNav ? activeIndex : NO_ACTIVE_INDEX;
   return {
-    activeIndex,
+    activeIndex: externalActiveIndex,
     onSelectionAction,
     isInitialActiveState
   };


### PR DESCRIPTION
[Task](https://monday.monday.com/boards/245345663/pulses/2213226987)

(Evgeniy's request)
Previously, the keyboard's activeIndex feedback appeared even after selecting items with the mouse. This caused "noise", since mouse-users didn't actually need to see the feedback.
This change shouldn't have any functional effect. 