### PR TITLE
Allow non-monday colors picker

### DIFF
--- a/src/components/ColorPicker/ColorPicker.jsx
+++ b/src/components/ColorPicker/ColorPicker.jsx
@@ -29,7 +29,8 @@ const ColorPicker = forwardRef(
       colorSize,
       numberOfColorsInLine,
       focusOnMount,
-      colorShape
+      colorShape,
+      forceUseRawColorList
     },
     ref
   ) => {
@@ -64,6 +65,7 @@ const ColorPicker = forwardRef(
           numberOfColorsInLine={numberOfColorsInLine}
           focusOnMount={focusOnMount}
           colorShape={colorShape}
+          forceUseRawColorList={forceUseRawColorList}
         />
       </DialogContentContainer>
     );
@@ -94,7 +96,8 @@ ColorPicker.propTypes = {
   colorSize: PropTypes.oneOf([ColorPicker.sizes.SMALL, ColorPicker.sizes.MEDIUM, ColorPicker.sizes.LARGE]),
   numberOfColorsInLine: PropTypes.number,
   focusOnMount: PropTypes.bool,
-  colorShape: PropTypes.oneOf(Object.values(ColorPicker.colorShapes))
+  colorShape: PropTypes.oneOf(Object.values(ColorPicker.colorShapes)),
+  forceUseRawColorList: PropTypes.bool
 };
 
 ColorPicker.defaultProps = {
@@ -113,7 +116,12 @@ ColorPicker.defaultProps = {
   colorSize: ColorPicker.sizes.MEDIUM,
   numberOfColorsInLine: DEFAULT_NUMBER_OF_COLORS_IN_LINE,
   focusOnMount: false,
-  colorShape: ColorPicker.colorShapes.SQUARE
+  colorShape: ColorPicker.colorShapes.SQUARE,
+  /**
+   * Used to force the component render the colorList prop as is. Usually, this flag should not be used. It's intended only for edge cases.
+   * Usually, only "monday colors" will be rendered (unless blacklist mode is used). This flag will override this behavior.
+   */
+  forceUseRawColorList: false
 };
 
 export default ColorPicker;

--- a/src/components/ColorPicker/__tests__/colorPicker.jest.js
+++ b/src/components/ColorPicker/__tests__/colorPicker.jest.js
@@ -86,4 +86,24 @@ describe("Click", () => {
 
     expect(whiteListColorsElements.length).toBe(whiteListColors.length);
   });
+
+  it("should render all colors if forceUseRawColorList is true and isBlackListMode is false", () => {
+    const colorList = ["#abcdef", "#123456", "#234567"];
+    const { getByLabelText } = render(<ColorPicker colorsList={colorList} forceUseRawColorList={true} />);
+
+    const colorsElements = colorList.map(color => getByLabelText(color));
+
+    expect(colorsElements.length).toBe(colorsElements.length);
+  });
+
+  it("should render all colors if forceUseRawColorList is true, even if isBlackListMode is true", () => {
+    const colorList = ["#abcdef", "#123456", "#234567"];
+    const { getByLabelText } = render(
+      <ColorPicker colorsList={colorList} forceUseRawColorList={true} isBlackListMode={true} />
+    );
+
+    const colorsElements = colorList.map(color => getByLabelText(color));
+
+    expect(colorsElements.length).toBe(colorsElements.length);
+  });
 });

--- a/src/components/ColorPicker/__tests__/colorPicker.jest.js
+++ b/src/components/ColorPicker/__tests__/colorPicker.jest.js
@@ -12,7 +12,7 @@ it("renders correctly with empty props", () => {
 
 jest.useFakeTimers();
 
-describe("Click", () => {
+describe("ColorPicker", () => {
   it("Should call onSave with color clicked value", () => {
     const colorToClick = contentColors[0];
     let clickedColorValue;

--- a/src/components/ColorPicker/components/ColorPickerContent/ColorPickerContentComponent.jsx
+++ b/src/components/ColorPicker/components/ColorPickerContent/ColorPickerContentComponent.jsx
@@ -35,7 +35,8 @@ const ColorPickerContentComponent = forwardRef(
       numberOfColorsInLine,
       tooltipContentByColor,
       focusOnMount,
-      colorShape
+      colorShape,
+      forceUseRawColorList
     },
     ref
   ) => {
@@ -47,8 +48,11 @@ const ColorPickerContentComponent = forwardRef(
     const buttonRef = useRef(null);
 
     const colorsToRender = useMemo(() => {
+      if (forceUseRawColorList) {
+        return colorsList;
+      }
       return isBlackListMode ? _difference(contentColors, colorsList) : _intersection(contentColors, colorsList);
-    }, [isBlackListMode, colorsList]);
+    }, [forceUseRawColorList, isBlackListMode, colorsList]);
 
     const onColorClicked = useCallback(
       color => {
@@ -129,7 +133,8 @@ ColorPickerContentComponent.propTypes = {
   tooltipContentByColor: PropTypes.object,
   focusOnMount: PropTypes.bool,
   colorShape: PropTypes.oneOf(Object.values(ColorPickerContentComponent.colorShapes)),
-  isMultiselect: PropTypes.bool
+  isMultiselect: PropTypes.bool,
+  forceUseRawColorList: PropTypes.bool
 };
 
 ColorPickerContentComponent.defaultProps = {
@@ -149,7 +154,12 @@ ColorPickerContentComponent.defaultProps = {
   tooltipContentByColor: {},
   focusOnMount: false,
   colorShape: ColorPickerContentComponent.colorShapes.SQUARE,
-  isMultiselect: false
+  isMultiselect: false,
+  /**
+   * Used to force the component render the colorList prop as is. Usually, this flag should not be used. It's intended only for edge cases.
+   * Usually, only "monday colors" will be rendered (unless blacklist mode is used). This flag will override this behavior.
+   */
+  forceUseRawColorList: false
 };
 
 export default ColorPickerContentComponent;

--- a/src/components/ColorPicker/components/ColorPickerItemComponent/ColorPickerItemComponent.jsx
+++ b/src/components/ColorPicker/components/ColorPickerItemComponent/ColorPickerItemComponent.jsx
@@ -1,8 +1,8 @@
-import React, { useRef, useCallback, useEffect } from "react";
+import React, { useRef, useCallback, useEffect, useMemo } from "react";
 import PropTypes from "prop-types";
 import cx from "classnames";
 import NOOP from "lodash/noop";
-import { COLOR_STYLES } from "../../../../general-stories/colors/colors-vars-map";
+import { COLOR_STYLES, contentColors } from "../../../../general-stories/colors/colors-vars-map";
 import ColorUtils from "../../../../utils/colors-utils";
 import "./ColorPickerItemComponent.scss";
 import Icon from "../../../Icon/Icon";
@@ -23,14 +23,15 @@ const ColorPickerItemComponent = ({
   isActive,
   colorShape
 }) => {
-  const colorAsStyle = ColorUtils.getMondayColorAsStyle(color, colorStyle);
+  const isMondayColor = useMemo(() => contentColors.includes(color), [color]);
+  const colorAsStyle = isMondayColor ? ColorUtils.getMondayColorAsStyle(color, colorStyle) : color;
   const itemRef = useRef(null);
 
   const onMouseDown = useCallback(e => e.preventDefault(), []);
   const onClick = useCallback(() => onValueChange(color), [onValueChange, color]);
 
   useEffect(() => {
-    if (!itemRef || !itemRef.current || shouldRenderIndicatorWithoutBackground) return;
+    if (!itemRef?.current || shouldRenderIndicatorWithoutBackground || !isMondayColor) return;
     const item = itemRef.current;
     const onHover = e => {
       if (colorStyle === COLOR_STYLES.SELECTED) {
@@ -49,7 +50,7 @@ const ColorPickerItemComponent = ({
       item.removeEventListener("mouseenter", onHover, false);
       item.removeEventListener("mouseleave", onMouseLeave, false);
     };
-  }, [color, colorAsStyle, colorStyle, itemRef, shouldRenderIndicatorWithoutBackground]);
+  }, [color, colorAsStyle, colorStyle, isMondayColor, itemRef, shouldRenderIndicatorWithoutBackground]);
 
   const shouldRenderIcon = isSelected || ColorIndicatorIcon;
   const colorIndicatorWrapperStyle = shouldRenderIndicatorWithoutBackground ? { color: colorAsStyle } : {};


### PR DESCRIPTION
[Task](https://monday.monday.com/boards/245345663/pulses/2123616491)
Allows non-monday colors to be rendered in the color picker. 
Why? Since sometimes we need to color picker for existing colors, that aren't part of our "official" palette.  (e.g. on the workspace color picker).
![image](https://user-images.githubusercontent.com/96776835/152345682-d5a69a7c-75bd-4051-8d23-03b6691af4d4.png)
I want to discourage the usage of this flag, so I named it in accordingly (the word "force.." always makes you think twice 😄 ). 
Also, I intentionally didn't add a story, since I don't want it to be too familiar.

