### PR TITLE
When click on checkbox with shift pressed, shift key is not true in the manual all checkbox events (even if it was true in the original event)

### DIFF
--- a/src/components/Checkbox/Checkbox.js
+++ b/src/components/Checkbox/Checkbox.js
@@ -7,7 +7,8 @@ import Icon from "../Icon/Icon";
 import Check from "../Icon/Icons/components/Check";
 import Remove from "../Icon/Icons/components/Remove";
 import { backwardCompatibilityForProperties } from "../../helpers/backwardCompatibilityForProperties";
-import { isFirefox } from "../../utils/user-agent-utils";
+import { useSupportFirefoxLabelClick } from "./hooks/useSupportFirefoxLabelClick";
+
 import "./Checkbox.scss";
 
 const BASE_CLASS_NAME = "monday-style-checkbox";
@@ -30,17 +31,6 @@ export const Checkbox = ({
 }) => {
   const iconContainerRef = useRef(null);
   const inputRef = useRef(null);
-
-  // fix for known bug firefox bug: firefox does not support checking or unchecking checkbox by its label when shift pressed
-  const onClickCaptureLabel = useCallback(
-    e => {
-      if (e.shiftKey && isFirefox() && inputRef?.current?.click) {
-        e.preventDefault();
-        inputRef.current.click();
-      }
-    },
-    [inputRef]
-  );
   const overrideClassName = backwardCompatibilityForProperties([className, componentClassName]);
   const onMouseUpCallback = useCallback(() => {
     const input = inputRef.current;
@@ -67,6 +57,8 @@ export const Checkbox = ({
       inputRef.current.indeterminate = indeterminate;
     }
   }, [inputRef, indeterminate]);
+
+  const { onClickCapture: onClickCaptureLabel } = useSupportFirefoxLabelClick({inputRef});
 
   return (
     // eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions

--- a/src/components/Checkbox/Checkbox.js
+++ b/src/components/Checkbox/Checkbox.js
@@ -58,7 +58,7 @@ export const Checkbox = ({
     }
   }, [inputRef, indeterminate]);
 
-  const { onClickCapture: onClickCaptureLabel } = useSupportFirefoxLabelClick({inputRef});
+  const { onClickCapture: onClickCaptureLabel } = useSupportFirefoxLabelClick({ inputRef });
 
   return (
     // eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions

--- a/src/components/Checkbox/__stories__/checkbox.stories.mdx
+++ b/src/components/Checkbox/__stories__/checkbox.stories.mdx
@@ -60,7 +60,7 @@ Checkboxes allow users to select one or more items from a set of options.
 Has 4 states: regular, hover, selected, and disabled.
 <Canvas>
   <Story name="States">
-    <Checkbox label="Regular" onC/>
+    <Checkbox label="Regular"/>
     <Checkbox label="Selected" checked />
     <Checkbox label="Disabled" disabled />
     <Checkbox label="Indeterminate" indeterminate />

--- a/src/components/Checkbox/__stories__/checkbox.stories.mdx
+++ b/src/components/Checkbox/__stories__/checkbox.stories.mdx
@@ -60,7 +60,7 @@ Checkboxes allow users to select one or more items from a set of options.
 Has 4 states: regular, hover, selected, and disabled.
 <Canvas>
   <Story name="States">
-    <Checkbox label="Regular"/>
+    <Checkbox label="Regular" />
     <Checkbox label="Selected" checked />
     <Checkbox label="Disabled" disabled />
     <Checkbox label="Indeterminate" indeterminate />

--- a/src/components/Checkbox/__stories__/checkbox.stories.mdx
+++ b/src/components/Checkbox/__stories__/checkbox.stories.mdx
@@ -60,7 +60,7 @@ Checkboxes allow users to select one or more items from a set of options.
 Has 4 states: regular, hover, selected, and disabled.
 <Canvas>
   <Story name="States">
-    <Checkbox label="Regular" />
+    <Checkbox label="Regular" onC/>
     <Checkbox label="Selected" checked />
     <Checkbox label="Disabled" disabled />
     <Checkbox label="Indeterminate" indeterminate />

--- a/src/components/Checkbox/__tests__/checkbox-tests.jest.js
+++ b/src/components/Checkbox/__tests__/checkbox-tests.jest.js
@@ -174,10 +174,12 @@ describe("Checkbox tests", () => {
       isFirefox.mockImplementation(() => true);
     });
 
+    let onChangeMock1, onChangeMock2, onChangeMock3;
+
     beforeEach(() => {
-      const onChangeMock1 = jest.fn();
-      const onChangeMock2 = jest.fn();
-      const onChangeMock3 = jest.fn();
+      onChangeMock1 = jest.fn();
+      onChangeMock2 = jest.fn();
+      onChangeMock3 = jest.fn();
       renderCheckboxes({
         formName,
         onChangeMock1,
@@ -197,6 +199,16 @@ describe("Checkbox tests", () => {
 
     it("should unselect  1st option (with firefox browser - check workaround for known firefox bug", () => {
       testUnselectFirstOption(option1Text, option2Text, option3Text, { shiftKey: true });
+    });
+
+    it("should call on change with shiftKey true when unselect option with shift key (with firefox browser - check workaround for known firefox bug", () => {
+      let isShift = false;
+      onChangeMock1.mockImplementation(e => {
+        isShift = e.nativeEvent.shiftKey;
+      });
+      const option1 = screen.getByLabelText(option1Text);
+      fireEvent.click(option1, { shiftKey: true });
+      expect(isShift).toBeTruthy();
     });
   });
 });

--- a/src/components/Checkbox/hooks/useSupportFirefoxLabelClick.jsx
+++ b/src/components/Checkbox/hooks/useSupportFirefoxLabelClick.jsx
@@ -2,26 +2,31 @@ import { useCallback, useRef } from "react";
 import { isFirefox } from "../../../utils/user-agent-utils";
 
 export function useSupportFirefoxLabelClick({ inputRef }) {
-  // we handle the custom event create state as ref because this variable should not be depend on the component renders
-  // and it should be unique per checkbox
+  // The purpose of this variable is to make sure that the captured event is a checkbox's label click event and not a manual event
+  // that we actually created in this hook.
+  // We handle the custom event create state as ref because this variable should not be depend on the component renders
+  // and it should be unique per checkbox.
   const customEventCreated = useRef(false);
 
   // fix for known bug firefox bug: firefox does not support checking or unchecking checkbox by its label when shift pressed
   const onClickCapture = useCallback(
     e => {
+      // We would like to dispatch a manual event to click on the input only for cases where there is a bug in supporting this capability -
+      // firefox browsers when the shift key is pressed.
+      // In addition we make sure here that the captured event is not a manually generated event created by this code because we want to prevent
+      // an infinite loop in recursion here.
       if (!customEventCreated.current && e.shiftKey && isFirefox() && inputRef?.current?.dispatchEvent) {
         e.preventDefault();
-        const evt = new MouseEvent("click", {
+        const manualClickEvent = new MouseEvent("click", {
           shiftKey: true,
+          // After dispatch this event we will want it to be captured by all the relevant event listeners which registered to this checkbox input.
           bubbles: true,
           cancelable: true
         });
 
         customEventCreated.current = true;
-        inputRef.current.dispatchEvent(evt);
-      }
-
-      if (customEventCreated.current) {
+        inputRef.current.dispatchEvent(manualClickEvent);
+      } else if (customEventCreated.current) {
         customEventCreated.current = false;
       }
     },

--- a/src/components/Checkbox/hooks/useSupportFirefoxLabelClick.jsx
+++ b/src/components/Checkbox/hooks/useSupportFirefoxLabelClick.jsx
@@ -1,0 +1,35 @@
+import { useCallback, useRef } from "react";
+import { isFirefox } from "../../../utils/user-agent-utils";
+
+export function useSupportFirefoxLabelClick({ inputRef }) {
+  // we handle the custom event create state as ref because this variable should not be depend on the component renders
+  // and it should be unique per checkbox
+  const customEventCreated = useRef(true);
+
+  // fix for known bug firefox bug: firefox does not support checking or unchecking checkbox by its label when shift pressed
+  const onClickCapture = useCallback(
+    e => {
+      if (!customEventCreated.current && e.shiftKey && isFirefox() && inputRef?.current?.dispatchEvent) {
+        e.preventDefault();
+        // Create a synthetic click MouseEvent
+        const evt = new MouseEvent("click", {
+          shiftKey: true,
+          bubbles: true,
+          cancelable: true
+        });
+
+        customEventCreated.current = true;
+
+        // Send the event to the checkbox element
+        inputRef.current.dispatchEvent(evt);
+      }
+
+      if (customEventCreated.current) {
+        customEventCreated.current = false;
+      }
+    },
+    [customEventCreated, inputRef]
+  );
+
+  return { onClickCapture };
+}

--- a/src/components/Checkbox/hooks/useSupportFirefoxLabelClick.jsx
+++ b/src/components/Checkbox/hooks/useSupportFirefoxLabelClick.jsx
@@ -11,7 +11,6 @@ export function useSupportFirefoxLabelClick({ inputRef }) {
     e => {
       if (!customEventCreated.current && e.shiftKey && isFirefox() && inputRef?.current?.dispatchEvent) {
         e.preventDefault();
-        // Create a synthetic click MouseEvent
         const evt = new MouseEvent("click", {
           shiftKey: true,
           bubbles: true,
@@ -19,8 +18,6 @@ export function useSupportFirefoxLabelClick({ inputRef }) {
         });
 
         customEventCreated.current = true;
-
-        // Send the event to the checkbox element
         inputRef.current.dispatchEvent(evt);
       }
 

--- a/src/components/Checkbox/hooks/useSupportFirefoxLabelClick.jsx
+++ b/src/components/Checkbox/hooks/useSupportFirefoxLabelClick.jsx
@@ -4,7 +4,7 @@ import { isFirefox } from "../../../utils/user-agent-utils";
 export function useSupportFirefoxLabelClick({ inputRef }) {
   // we handle the custom event create state as ref because this variable should not be depend on the component renders
   // and it should be unique per checkbox
-  const customEventCreated = useRef(true);
+  const customEventCreated = useRef(false);
 
   // fix for known bug firefox bug: firefox does not support checking or unchecking checkbox by its label when shift pressed
   const onClickCapture = useCallback(


### PR DESCRIPTION
<!--

Please go over the checklist and make sure all conditions are met.

--->

#### Basic
- [ ] Used plop (`npm run plop`) to create a new component.
- [ ] PR has description.
- [ ] New component is functional and uses Hooks. 
- [ ] Component defines [`PropTypes`](https://reactjs.org/docs/typechecking-with-proptypes.html).
#### Style
- [ ] Styles are added to `NewComponent.modules.scss` file inside of the `NewComponent` folder.
- [ ] Component uses CSS Modules.
- [ ] Design is compatible with [Monday Design System](https://design.monday.com/).
#### Storybook
- [ ] Stories were added to `/src/NewComponent/__stories__/NewComponent.stories.js` file.
- [ ] Stories include all flows of using the component.
#### Tests
- [ ] Tests are compliant with [TESTING_README.md](TESTING_README.md) instructions.
