### PR TITLE
tooltip: removing border from tooltip arrow + adding themes to storybook

### DIFF
--- a/src/components/Tooltip/Tooltip.scss
+++ b/src/components/Tooltip/Tooltip.scss
@@ -37,7 +37,6 @@ $tooltip-z-index: 9999999999999999;
   background-color: $white-theme-bg-color;
   color: $white-theme-font-color;
   @include theme-prop(box-shadow, box-shadow-medium);
-  border: $white-theme-border;
 }
 
 .monday-style-tooltip-primary,

--- a/src/components/Tooltip/TooltipConstants.js
+++ b/src/components/Tooltip/TooltipConstants.js
@@ -5,7 +5,8 @@ export const TOOLTIP_THEMES = {
   Share: "share",
   Private: "private",
   Surface: "surface",
-  Primary: "primary"
+  Primary: "primary",
+  White: "white"
 };
 
 export const TOOLTIP_JUSTIFY_TYPES = {

--- a/src/components/Tooltip/TooltipConstants.js
+++ b/src/components/Tooltip/TooltipConstants.js
@@ -5,8 +5,7 @@ export const TOOLTIP_THEMES = {
   Share: "share",
   Private: "private",
   Surface: "surface",
-  Primary: "primary",
-  White: "white"
+  Primary: "primary"
 };
 
 export const TOOLTIP_JUSTIFY_TYPES = {

--- a/src/components/Tooltip/__stories__/tooltip.stories.mdx
+++ b/src/components/Tooltip/__stories__/tooltip.stories.mdx
@@ -1,22 +1,20 @@
 import Tooltip from "../Tooltip";
 import TooltipReference from "./TooltipReference";
 import { ArgsTable, Story, Canvas, Meta } from "@storybook/addon-docs";
-import { Hide, Subitems, Bolt } from "../../Icon/Icons"
-import Icon from "../../Icon/Icon.jsx"
+import { Hide, Subitems, Bolt } from "../../Icon/Icons";
+import Icon from "../../Icon/Icon.jsx";
 import Button from "../../Button/Button";
 import { modifiers } from "./helper";
 import { Link } from "../../../storybook/components";
 import { CHIP, LABEL, TIPSEEN } from "../../../storybook/components/related-components/component-description-map";
-import "./tooltip.stories.scss"; import {TOOLTIP_THEMES} from "components/Tooltip/TooltipConstants";
+import { TOOLTIP_THEMES } from "components/Tooltip/TooltipConstants";
+import "./tooltip.stories.scss";
 
-<Meta
-  title="Popover/Tooltip"
-  component={ Tooltip }
-/>
+<Meta title="Popover/Tooltip" component={Tooltip} />
 
 <!--- Component template -->
 
-export const tooltipTemplate = (args) => {
+export const tooltipTemplate = args => {
   return (
     <div className="monday-storybook-tooltip_overview">
       <Tooltip
@@ -28,12 +26,13 @@ export const tooltipTemplate = (args) => {
         <div />
       </Tooltip>
     </div>
-  )
-}
+  );
+};
 
 <!--- Component documentation -->
 
 # Tooltip
+
 - [Overview](#overview)
 - [Props](#props)
 - [Usage](#usage)
@@ -45,31 +44,46 @@ export const tooltipTemplate = (args) => {
 - [Feedback](#feedback)
 
 ## Overview
+
 Tooltips show contextual help or information about specific components when a user hovers on them.
+
 <Canvas>
-  <Story name="Overview"
-         args={ {shouldShowOnMount: true, content: "I’m a tooltip"} }>
-    { tooltipTemplate.bind({}) }
+  <Story name="Overview" args={{ shouldShowOnMount: true, content: "I’m a tooltip" }}>
+    {tooltipTemplate.bind({})}
   </Story>
 </Canvas>
 
 ## Props
-<ArgsTable of={ Tooltip } />
+
+<ArgsTable of={Tooltip} />
 
 ## Usage
-<UsageGuidelines guidelines={[
-  "Should never contain critical information that a user would absolutely need to proceed.",
-  "Use when the description content would be too much information to include inline or create too much clutter. For example, when expert users have seen it many times.",
-]}/>
 
-<Tip>As tooltips only surface from a hover, never include links or buttons in the copy. If your tooltip requires either of these, considers putting your content in a
-  <Link href="/?path=/docs/popover-tipseen--overview" size={Link.sizes.SMALL} withoutSpacing>Tipseen</Link> or
-   <Link href="/?path=/docs/feedback-attentionbox--overview" size={Link.sizes.SMALL}>Attention box.</Link>
+<UsageGuidelines
+  guidelines={[
+    "Should never contain critical information that a user would absolutely need to proceed.",
+    "Use when the description content would be too much information to include inline or create too much clutter. For example, when expert users have seen it many times."
+  ]}
+/>
+
+<Tip>
+  As tooltips only surface from a hover, never include links or buttons in the copy. If your tooltip requires either of
+  these, considers putting your content in a
+  <Link href="/?path=/docs/popover-tipseen--overview" size={Link.sizes.SMALL} withoutSpacing>
+    Tipseen
+  </Link>{" "}
+  or
+  <Link href="/?path=/docs/feedback-attentionbox--overview" size={Link.sizes.SMALL}>
+    Attention box.
+  </Link>
 </Tip>
 
 ## Variants
+
 ### Positions
+
 Tooltip’s arrow can appear from top, bottom, left or right.
+
 <Canvas>
   <Story name="Positions">
     <div className="monday-storybook-tooltip_top">
@@ -127,159 +141,163 @@ Tooltip’s arrow can appear from top, bottom, left or right.
 </Canvas>
 
 ### Themes
+
 Tooltip’s arrow can appear from top, bottom, left or right.
+
 <Canvas>
-    <Story name="Themes">
-        <div className="monday-storybook-tooltip_top">
-            <Tooltip
-                modifiers={modifiers}
-                content="Dark"
-                shouldShowOnMount
-                position={Tooltip.positions.BOTTOM}
-                animationType="expand"
-                theme={TOOLTIP_THEMES.Dark}
-            >
-                <div />
-            </Tooltip>
-        </div>
-        <div className="monday-storybook-tooltip_top">
-            <Tooltip
-                modifiers={modifiers}
-                content="Success"
-                shouldShowOnMount
-                position={Tooltip.positions.BOTTOM}
-                animationType="expand"
-                theme={TOOLTIP_THEMES.Success}
-            >
-                <div />
-            </Tooltip>
-        </div>
-        <div className="monday-storybook-tooltip_top">
-            <Tooltip
-                modifiers={modifiers}
-                content="Error"
-                shouldShowOnMount
-                position={Tooltip.positions.BOTTOM}
-                animationType="expand"
-                theme={TOOLTIP_THEMES.Error}
-            >
-                <div />
-            </Tooltip>
-        </div>
-        <div className="monday-storybook-tooltip_top">
-            <Tooltip
-                modifiers={modifiers}
-                content="Share"
-                shouldShowOnMount
-                position={Tooltip.positions.BOTTOM}
-                animationType="expand"
-                theme={TOOLTIP_THEMES.Share}
-            >
-                <div />
-            </Tooltip>
-        </div>
-        <div className="monday-storybook-tooltip_top">
-            <Tooltip
-                modifiers={modifiers}
-                content="Private"
-                shouldShowOnMount
-                position={Tooltip.positions.BOTTOM}
-                animationType="expand"
-                theme={TOOLTIP_THEMES.Private}
-            >
-                <div />
-            </Tooltip>
-        </div>
-        <div className="monday-storybook-tooltip_top">
-            <Tooltip
-                modifiers={modifiers}
-                content="Surface"
-                shouldShowOnMount
-                position={Tooltip.positions.BOTTOM}
-                animationType="expand"
-                theme={TOOLTIP_THEMES.Surface}
-            >
-                <div />
-            </Tooltip>
-        </div>
-        <div className="monday-storybook-tooltip_top">
-            <Tooltip
-                modifiers={modifiers}
-                content="Primary"
-                shouldShowOnMount
-                position={Tooltip.positions.BOTTOM}
-                animationType="expand"
-                theme={TOOLTIP_THEMES.Primary}
-            >
-                <div />
-            </Tooltip>
-        </div>
-        <div className="monday-storybook-tooltip_top">
-            <Tooltip
-                modifiers={modifiers}
-                content="White"
-                shouldShowOnMount
-                position={Tooltip.positions.BOTTOM}
-                animationType="expand"
-                theme={TOOLTIP_THEMES.White}
-            >
-                <div />
-            </Tooltip>
-        </div>
-    </Story>
+  <Story name="Themes">
+    <div className="monday-storybook-tooltip_top">
+      <Tooltip
+        modifiers={modifiers}
+        content="Dark"
+        shouldShowOnMount
+        position={Tooltip.positions.BOTTOM}
+        animationType="expand"
+        theme={TOOLTIP_THEMES.Dark}
+      >
+        <div />
+      </Tooltip>
+    </div>
+    <div className="monday-storybook-tooltip_top">
+      <Tooltip
+        modifiers={modifiers}
+        content="Success"
+        shouldShowOnMount
+        position={Tooltip.positions.BOTTOM}
+        animationType="expand"
+        theme={TOOLTIP_THEMES.Success}
+      >
+        <div />
+      </Tooltip>
+    </div>
+    <div className="monday-storybook-tooltip_top">
+      <Tooltip
+        modifiers={modifiers}
+        content="Error"
+        shouldShowOnMount
+        position={Tooltip.positions.BOTTOM}
+        animationType="expand"
+        theme={TOOLTIP_THEMES.Error}
+      >
+        <div />
+      </Tooltip>
+    </div>
+    <div className="monday-storybook-tooltip_top">
+      <Tooltip
+        modifiers={modifiers}
+        content="Share"
+        shouldShowOnMount
+        position={Tooltip.positions.BOTTOM}
+        animationType="expand"
+        theme={TOOLTIP_THEMES.Share}
+      >
+        <div />
+      </Tooltip>
+    </div>
+    <div className="monday-storybook-tooltip_top">
+      <Tooltip
+        modifiers={modifiers}
+        content="Private"
+        shouldShowOnMount
+        position={Tooltip.positions.BOTTOM}
+        animationType="expand"
+        theme={TOOLTIP_THEMES.Private}
+      >
+        <div />
+      </Tooltip>
+    </div>
+    <div className="monday-storybook-tooltip_top">
+      <Tooltip
+        modifiers={modifiers}
+        content="Surface"
+        shouldShowOnMount
+        position={Tooltip.positions.BOTTOM}
+        animationType="expand"
+        theme={TOOLTIP_THEMES.Surface}
+      >
+        <div />
+      </Tooltip>
+    </div>
+    <div className="monday-storybook-tooltip_top">
+      <Tooltip
+        modifiers={modifiers}
+        content="Primary"
+        shouldShowOnMount
+        position={Tooltip.positions.BOTTOM}
+        animationType="expand"
+        theme={TOOLTIP_THEMES.Primary}
+      >
+        <div />
+      </Tooltip>
+    </div>
+    <div className="monday-storybook-tooltip_top">
+      <Tooltip
+        modifiers={modifiers}
+        content="White"
+        shouldShowOnMount
+        position={Tooltip.positions.BOTTOM}
+        animationType="expand"
+        theme={TOOLTIP_THEMES.White}
+      >
+        <div />
+      </Tooltip>
+    </div>
+  </Story>
 </Canvas>
 
 ## Do’s and Don’ts
+
 <ComponentRules
   rules={[
     {
       positive: {
-        component:
-        <Tooltip
-          shouldShowOnMount
-          content="Open quick search  + B"
-        >
-          <div className="monday-storybook-tooltip_icon-box"><Icon icon={Bolt} iconSize="32" /></div>
-        </Tooltip>,
-        description:"Use tooltips for adding alternative textual purpose for buttons which do not include any text."
+        component: (
+          <Tooltip shouldShowOnMount content="Open quick search  + B">
+            <div className="monday-storybook-tooltip_icon-box">
+              <Icon icon={Bolt} iconSize="32" />
+            </div>
+          </Tooltip>
+        ),
+        description: "Use tooltips for adding alternative textual purpose for buttons which do not include any text."
       },
       negative: {
-        component:
-        <Tooltip
-          shouldShowOnMount
-          content="Open quick search  + B"
-        >
-          <Button>Quick search</Button>
-        </Tooltip>,
-        description:"Don't use a tooltip to display information already written on the button text."
+        component: (
+          <Tooltip shouldShowOnMount content="Open quick search  + B">
+            <Button>Quick search</Button>
+          </Tooltip>
+        ),
+        description: "Don't use a tooltip to display information already written on the button text."
       }
     }
   ]}
 />
 
 ## Use cases and examples
+
 ### Icon tooltip
+
 An icon tooltip is used to clarify the action or name of an interactive icon button. Provide tooltips for all unlabelled icons.
+
 <Canvas>
   <Story name="Icon tooltip">
     <div className="monday-storybook-tooltip_box">
-      <Tooltip
-        content="Hidden columns"
-      >
-        <div className="monday-storybook-tooltip_icon-wrapper"><Icon icon={Hide} /></div>
+      <Tooltip content="Hidden columns">
+        <div className="monday-storybook-tooltip_icon-wrapper">
+          <Icon icon={Hide} />
+        </div>
       </Tooltip>
     </div>
   </Story>
 </Canvas>
 
 ### Definition tooltip
+
 The definition tooltip provides additional help or defines an item or term. It may be used on the label of a UI element, or on a word embedded in a paragraph.
+
 <Canvas>
   <Story name="Definition tooltip">
     <div className="monday-storybook-tooltip_box">
-      <Tooltip
-        content="Item name: Bottom sheets"
-      >
+      <Tooltip content="Item name: Bottom sheets">
         <div className="monday-storybook-tooltip_icon-wrapper">
           <Icon icon={Subitems} />
           <span>Subitem</span>
@@ -290,25 +308,19 @@ The definition tooltip provides additional help or defines an item or term. It m
 </Canvas>
 
 ### Immediate tooltips
+
 Immediately show when another is shown. The two left tooltips uses the immediate show prop, the right one ignores it and should always have show delay.
+
 <Canvas>
   <Story name="Immediate tooltips">
     <div className="monday-storybook-tooltip_box">
-      <Tooltip
-        immediateShowDelay={0}
-        content="I'm a tooltip"
-      >
+      <Tooltip immediateShowDelay={0} content="I'm a tooltip">
         <TooltipReference />
       </Tooltip>
-      <Tooltip
-        immediateShowDelay={0}
-        content="I'm a tooltip"
-      >
+      <Tooltip immediateShowDelay={0} content="I'm a tooltip">
         <TooltipReference />
       </Tooltip>
-      <Tooltip
-        content="I'm a tooltip"
-      >
+      <Tooltip content="I'm a tooltip">
         <TooltipReference />
       </Tooltip>
     </div>
@@ -316,4 +328,5 @@ Immediately show when another is shown. The two left tooltips uses the immediate
 </Canvas>
 
 ## Related components
-<RelatedComponents componentsNames={[CHIP, LABEL, TIPSEEN ]} />
+
+<RelatedComponents componentsNames={[CHIP, LABEL, TIPSEEN]} />

--- a/src/components/Tooltip/__stories__/tooltip.stories.mdx
+++ b/src/components/Tooltip/__stories__/tooltip.stories.mdx
@@ -1,4 +1,5 @@
 import Tooltip from "../Tooltip";
+import { capitalize } from "lodash";
 import TooltipReference from "./TooltipReference";
 import { ArgsTable, Story, Canvas, Meta } from "@storybook/addon-docs";
 import { Hide, Subitems, Bolt } from "../../Icon/Icons";
@@ -71,7 +72,7 @@ Tooltips show contextual help or information about specific components when a us
   these, considers putting your content in a
   <Link href="/?path=/docs/popover-tipseen--overview" size={Link.sizes.SMALL} withoutSpacing>
     Tipseen
-  </Link>{" "}
+  </Link>
   or
   <Link href="/?path=/docs/feedback-attentionbox--overview" size={Link.sizes.SMALL}>
     Attention box.
@@ -142,106 +143,24 @@ Tooltip’s arrow can appear from top, bottom, left or right.
 
 ### Themes
 
-Tooltip’s arrow can appear from top, bottom, left or right.
+Tooltip’s arrow can have various themes.
 
 <Canvas>
   <Story name="Themes">
-    <div className="monday-storybook-tooltip_top">
-      <Tooltip
-        modifiers={modifiers}
-        content="Dark"
-        shouldShowOnMount
-        position={Tooltip.positions.BOTTOM}
-        animationType="expand"
-        theme={TOOLTIP_THEMES.Dark}
-      >
-        <div />
-      </Tooltip>
-    </div>
-    <div className="monday-storybook-tooltip_top">
-      <Tooltip
-        modifiers={modifiers}
-        content="Success"
-        shouldShowOnMount
-        position={Tooltip.positions.BOTTOM}
-        animationType="expand"
-        theme={TOOLTIP_THEMES.Success}
-      >
-        <div />
-      </Tooltip>
-    </div>
-    <div className="monday-storybook-tooltip_top">
-      <Tooltip
-        modifiers={modifiers}
-        content="Error"
-        shouldShowOnMount
-        position={Tooltip.positions.BOTTOM}
-        animationType="expand"
-        theme={TOOLTIP_THEMES.Error}
-      >
-        <div />
-      </Tooltip>
-    </div>
-    <div className="monday-storybook-tooltip_top">
-      <Tooltip
-        modifiers={modifiers}
-        content="Share"
-        shouldShowOnMount
-        position={Tooltip.positions.BOTTOM}
-        animationType="expand"
-        theme={TOOLTIP_THEMES.Share}
-      >
-        <div />
-      </Tooltip>
-    </div>
-    <div className="monday-storybook-tooltip_top">
-      <Tooltip
-        modifiers={modifiers}
-        content="Private"
-        shouldShowOnMount
-        position={Tooltip.positions.BOTTOM}
-        animationType="expand"
-        theme={TOOLTIP_THEMES.Private}
-      >
-        <div />
-      </Tooltip>
-    </div>
-    <div className="monday-storybook-tooltip_top">
-      <Tooltip
-        modifiers={modifiers}
-        content="Surface"
-        shouldShowOnMount
-        position={Tooltip.positions.BOTTOM}
-        animationType="expand"
-        theme={TOOLTIP_THEMES.Surface}
-      >
-        <div />
-      </Tooltip>
-    </div>
-    <div className="monday-storybook-tooltip_top">
-      <Tooltip
-        modifiers={modifiers}
-        content="Primary"
-        shouldShowOnMount
-        position={Tooltip.positions.BOTTOM}
-        animationType="expand"
-        theme={TOOLTIP_THEMES.Primary}
-      >
-        <div />
-      </Tooltip>
-    </div>
-    <div className="monday-storybook-tooltip_top">
-      <Tooltip
-        modifiers={modifiers}
-        content="White"
-        shouldShowOnMount
-        position={Tooltip.positions.BOTTOM}
-        animationType="expand"
-        theme={TOOLTIP_THEMES.White}
-      >
-        <div />
-      </Tooltip>
-    </div>
+    {Object.values(TOOLTIP_THEMES).map(theme => (
+      <div className="monday-storybook-tooltip_top" key={theme}>
+        <Tooltip
+          modifiers={modifiers}
+          content={capitalize(theme)}
+          shouldShowOnMount
+          position={Tooltip.positions.BOTTOM}
+          animationType="expand"
+          theme={theme}
+        >
+          <div />
+        </Tooltip>
+      </div>
+    ))}
   </Story>
 </Canvas>
 

--- a/src/components/Tooltip/__stories__/tooltip.stories.mdx
+++ b/src/components/Tooltip/__stories__/tooltip.stories.mdx
@@ -7,7 +7,7 @@ import Button from "../../Button/Button";
 import { modifiers } from "./helper";
 import { Link } from "../../../storybook/components";
 import { CHIP, LABEL, TIPSEEN } from "../../../storybook/components/related-components/component-description-map";
-import "./tooltip.stories.scss";
+import "./tooltip.stories.scss"; import {TOOLTIP_THEMES} from "components/Tooltip/TooltipConstants";
 
 <Meta
   title="Popover/Tooltip"
@@ -38,6 +38,7 @@ export const tooltipTemplate = (args) => {
 - [Props](#props)
 - [Usage](#usage)
 - [Variants](#variants)
+- [Themes](#themes)
 - [Do’s and don’ts](#dos-and-donts)
 - [Use cases and examples](#use-cases-and-examples)
 - [Related components](#related-components)
@@ -123,6 +124,109 @@ Tooltip’s arrow can appear from top, bottom, left or right.
       </Tooltip>
     </div>
   </Story>
+</Canvas>
+
+### Themes
+Tooltip’s arrow can appear from top, bottom, left or right.
+<Canvas>
+    <Story name="Themes">
+        <div className="monday-storybook-tooltip_top">
+            <Tooltip
+                modifiers={modifiers}
+                content="Dark"
+                shouldShowOnMount
+                position={Tooltip.positions.BOTTOM}
+                animationType="expand"
+                theme={TOOLTIP_THEMES.Dark}
+            >
+                <div />
+            </Tooltip>
+        </div>
+        <div className="monday-storybook-tooltip_top">
+            <Tooltip
+                modifiers={modifiers}
+                content="Success"
+                shouldShowOnMount
+                position={Tooltip.positions.BOTTOM}
+                animationType="expand"
+                theme={TOOLTIP_THEMES.Success}
+            >
+                <div />
+            </Tooltip>
+        </div>
+        <div className="monday-storybook-tooltip_top">
+            <Tooltip
+                modifiers={modifiers}
+                content="Error"
+                shouldShowOnMount
+                position={Tooltip.positions.BOTTOM}
+                animationType="expand"
+                theme={TOOLTIP_THEMES.Error}
+            >
+                <div />
+            </Tooltip>
+        </div>
+        <div className="monday-storybook-tooltip_top">
+            <Tooltip
+                modifiers={modifiers}
+                content="Share"
+                shouldShowOnMount
+                position={Tooltip.positions.BOTTOM}
+                animationType="expand"
+                theme={TOOLTIP_THEMES.Share}
+            >
+                <div />
+            </Tooltip>
+        </div>
+        <div className="monday-storybook-tooltip_top">
+            <Tooltip
+                modifiers={modifiers}
+                content="Private"
+                shouldShowOnMount
+                position={Tooltip.positions.BOTTOM}
+                animationType="expand"
+                theme={TOOLTIP_THEMES.Private}
+            >
+                <div />
+            </Tooltip>
+        </div>
+        <div className="monday-storybook-tooltip_top">
+            <Tooltip
+                modifiers={modifiers}
+                content="Surface"
+                shouldShowOnMount
+                position={Tooltip.positions.BOTTOM}
+                animationType="expand"
+                theme={TOOLTIP_THEMES.Surface}
+            >
+                <div />
+            </Tooltip>
+        </div>
+        <div className="monday-storybook-tooltip_top">
+            <Tooltip
+                modifiers={modifiers}
+                content="Primary"
+                shouldShowOnMount
+                position={Tooltip.positions.BOTTOM}
+                animationType="expand"
+                theme={TOOLTIP_THEMES.Primary}
+            >
+                <div />
+            </Tooltip>
+        </div>
+        <div className="monday-storybook-tooltip_top">
+            <Tooltip
+                modifiers={modifiers}
+                content="White"
+                shouldShowOnMount
+                position={Tooltip.positions.BOTTOM}
+                animationType="expand"
+                theme={TOOLTIP_THEMES.White}
+            >
+                <div />
+            </Tooltip>
+        </div>
+    </Story>
 </Canvas>
 
 ## Do’s and Don’ts


### PR DESCRIPTION
1. removing the border from the tooltip's arrow as it added some weird border around it.
from
![image](https://user-images.githubusercontent.com/17691874/153875039-d98ac93b-6098-4dd7-8492-42dc967fcb54.png)
to
![image](https://user-images.githubusercontent.com/17691874/153875082-18f4fcd3-2fed-434c-b8ea-3570bfe2d8cb.png)

2. adding tooltip themes to storybook
3. exposing white theme

![image](https://user-images.githubusercontent.com/17691874/153874922-72c22bee-1d00-4d7a-9e46-9b86b5692d7f.png)


