### PR TITLE
Fix typo of the work Multiple

### DIFF
--- a/src/components/Avatar/__stories__/avatar.stories.mdx
+++ b/src/components/Avatar/__stories__/avatar.stories.mdx
@@ -134,7 +134,7 @@ Use for non-person avatars, such as a workspace or team.
       },
       negative: {
         component:
-          <div className="monday-style-story-avatar_multiplue-reverse">
+          <div className="monday-style-story-avatar_multiple-reverse">
             <Avatar size={Avatar.sizes.SMALL} src={person1} type={Avatar.types.IMG} />
             <Avatar size={Avatar.sizes.MEDIUM} src={person2} type={Avatar.types.IMG} />
             <Avatar size={Avatar.sizes.LARGE} src={person3} type={Avatar.types.IMG} />
@@ -156,11 +156,11 @@ Use for non-person avatars, such as a workspace or team.
 />
 
 ## Use cases and examples
-### Multiplue avatars
+### Multiple avatars
 When there is more than one avatar, use an -8 margin between avatars.
 <Canvas>
-  <Story name="Multiplue avatars" >
-    <MultipleStoryElementsWrapper className="monday-style-story-avatar_multiplue">
+  <Story name="Multiple avatars" >
+    <MultipleStoryElementsWrapper className="monday-style-story-avatar_multiple">
       <Avatar size={Avatar.sizes.LARGE} type={Avatar.types.IMG} src={person1}  />
       <Avatar size={Avatar.sizes.LARGE} type={Avatar.types.IMG} src={person2} />
       <Avatar size={Avatar.sizes.LARGE} type={Avatar.types.IMG} src={person3} />


### PR DESCRIPTION
This fixes typos of the word "multiple" in reference to multiple avatars. The typo read `Multiplue` in a few instances