### PR TITLE
Fixes a typo to the word "hover"

### DIFF
--- a/src/hooks/useEventListener/__stories__/useEventListener.stories.mdx
+++ b/src/hooks/useEventListener/__stories__/useEventListener.stories.mdx
@@ -29,7 +29,7 @@ Attaches a listener to any DOM event on a specific element, firing a provided ca
       useEventListener({ ref, callback, eventName: "mouseenter" });
       return (
         <div ref={ref} className="hooks-reference-element">
-          Hoover me {hovered ? "Boom!" : undefined}
+          Hover me {hovered ? "Boom!" : undefined}
         </div>
       );
     }}


### PR DESCRIPTION
This corrects a typo to the word "hover". Previously it read "Hoover"