### PR TITLE
fix-typos-in-avatar-story-classnames

### DIFF
--- a/src/components/Avatar/__stories__/avatar.stories.mdx
+++ b/src/components/Avatar/__stories__/avatar.stories.mdx
@@ -125,7 +125,7 @@ Use for non-person avatars, such as a workspace or team.
     {
       positive: {
         component: 
-          <div className="monday-style-story-avatar_multiplue-reverse">
+          <div className="monday-style-story-avatar_multiple-reverse">
             <Avatar size={Avatar.sizes.LARGE} src={person1} type={Avatar.types.IMG} />
             <Avatar size={Avatar.sizes.LARGE} src={person2} type={Avatar.types.IMG} />
             <Avatar size={Avatar.sizes.LARGE} src={person3} type={Avatar.types.IMG} />

--- a/src/components/Avatar/__stories__/avatar.stories.scss
+++ b/src/components/Avatar/__stories__/avatar.stories.scss
@@ -1,5 +1,5 @@
 .monday-style-story-avatar {
-  &_multiplue {
+  &_multiple {
     display: flex;
     align-items: center;
     justify-content: center;
@@ -9,7 +9,7 @@
     }
   }
 
-  &_multiplue-reverse {
+  &_multiple-reverse {
     display: flex;
     align-items: flex-start;
 


### PR DESCRIPTION
Fixed typos in classnames from [previous PR](https://github.com/mondaycom/monday-ui-react-core/pull/598)


| Before | After | 
|  - | -  |
| ![image](https://user-images.githubusercontent.com/96776835/159882713-dc0a865e-359c-4786-a976-f20e30882200.png) | ![image](https://user-images.githubusercontent.com/96776835/159882758-f19531bb-c8c7-4143-98f3-3aa2f789a636.png) |