### PR TITLE
Fix/omri/fix grid keyboard nav story

### DIFF
--- a/src/__tests__/interactions-helper.js
+++ b/src/__tests__/interactions-helper.js
@@ -91,6 +91,11 @@ export function delay(timeout) {
   });
 }
 
+export async function resetFocus() {
+  const focusTrap = document.querySelector("[data-testid=focusTrap");
+  await userEvent.click(focusTrap);
+}
+
 export const waitForElementVisible = getterFunc => {
   return new Promise(resolve => {
     let element;

--- a/src/components/Flex/Flex.jsx
+++ b/src/components/Flex/Flex.jsx
@@ -22,7 +22,8 @@ const Flex = forwardRef(
       onClick,
       style,
       ariaLabelledby,
-      ariaLabel
+      ariaLabel,
+      tabIndex
     },
     ref
   ) => {
@@ -50,6 +51,7 @@ const Flex = forwardRef(
             [classes.wrap]: wrap
           }
         )}
+        tabIndex={tabIndex}
         onClick={onClick}
         style={overrideStyle}
         aria-label={ariaLabel}
@@ -96,7 +98,8 @@ Flex.propTypes = {
     PropTypes.oneOf([Flex.gaps.NONE, Flex.gaps.SMALL, Flex.gaps.MEDIUM, Flex.gaps.LARGE]),
     PropTypes.number
   ]),
-  ariaLabel: PropTypes.string
+  ariaLabel: PropTypes.string,
+  tabIndex: PropTypes.number
 };
 
 Flex.defaultProps = {
@@ -110,7 +113,8 @@ Flex.defaultProps = {
   justify: Flex.justify.START,
   align: Flex.align.CENTER,
   gap: Flex.gaps.NONE,
-  ariaLabel: undefined
+  ariaLabel: undefined,
+  tabIndex: undefined
 };
 
 export default Flex;

--- a/src/components/GridKeyboardNavigationContext/__stories__/interactions.js
+++ b/src/components/GridKeyboardNavigationContext/__stories__/interactions.js
@@ -1,0 +1,48 @@
+import { userEvent } from "@storybook/testing-library";
+import { expect } from "@storybook/jest";
+import { getByText, interactionSuite, clickElement } from "../../../__tests__/interactions-helper";
+
+//NOTE: this test may fail if it runs when the storybook page isn't focused. (For example, during an HMR refresh without focusing the storybook tab)
+const multiGridLayoutKeyboardNavigation = async canvas => {
+  const topLeft3Item = await getByText(canvas, "TL 3");
+  clickElement(topLeft3Item);
+
+  await keyboardMultipleTimes("{arrowRight}", 2);
+  await assertElementWithTextToBeActive("TL 5");
+
+  await keyboardMultipleTimes("{arrowRight}", 2);
+  await assertElementWithTextToBeActive("TR 1");
+
+  await keyboardMultipleTimes("{arrowDown}", 2);
+  await assertElementWithTextToBeActive("TR 5");
+
+  await keyboardMultipleTimes("{arrowLeft}", 3);
+  await assertElementWithTextToBeActive("TL 1");
+
+  await keyboardMultipleTimes("{arrowDown}", 4);
+  await assertElementWithTextToBeActive("TB 5");
+
+  await keyboardMultipleTimes("{arrowDown}", 1);
+  await assertElementWithTextToBeActive("BL 1");
+
+  await keyboardMultipleTimes("{arrowUp}", 1);
+  await assertElementWithTextToBeActive("TB 5");
+
+  await keyboardMultipleTimes("{arrowUp}", 3);
+  await assertElementWithTextToBeActive("TL 4");
+};
+
+export const useGridContextMultipleDepthsPlaySuite = interactionSuite({
+  tests: [multiGridLayoutKeyboardNavigation]
+});
+
+async function keyboardMultipleTimes(text, times) {
+  text = text.repeat(times);
+  await userEvent.keyboard(text, { delay: 70 });
+}
+
+async function assertElementWithTextToBeActive(text) {
+  const activeElements = document.getElementsByClassName("active-item");
+  expect(activeElements).toHaveLength(1);
+  expect(activeElements[0]).toHaveTextContent(text);
+}

--- a/src/components/GridKeyboardNavigationContext/__stories__/interactions.js
+++ b/src/components/GridKeyboardNavigationContext/__stories__/interactions.js
@@ -1,6 +1,6 @@
 import { userEvent } from "@storybook/testing-library";
 import { expect } from "@storybook/jest";
-import { getByText, interactionSuite, clickElement } from "../../../__tests__/interactions-helper";
+import { getByText, interactionSuite, clickElement, resetFocus } from "../../../__tests__/interactions-helper";
 
 //NOTE: this test may fail if it runs when the storybook page isn't focused. (For example, during an HMR refresh without focusing the storybook tab)
 const multiGridLayoutKeyboardNavigation = async canvas => {
@@ -33,7 +33,10 @@ const multiGridLayoutKeyboardNavigation = async canvas => {
 };
 
 export const useGridContextMultipleDepthsPlaySuite = interactionSuite({
-  tests: [multiGridLayoutKeyboardNavigation]
+  tests: [multiGridLayoutKeyboardNavigation],
+  afterEach: async () => {
+    await resetFocus();
+  }
 });
 
 async function keyboardMultipleTimes(text, times) {

--- a/src/components/GridKeyboardNavigationContext/__stories__/useGridKeyboardNavigationContext.stories.js
+++ b/src/components/GridKeyboardNavigationContext/__stories__/useGridKeyboardNavigationContext.stories.js
@@ -50,7 +50,7 @@ export const DummyNavigableGrid = forwardRef(
   }
 );
 
-export const LayoutWithInnerKeyboardNavigation = forwardRef((_ignored, ref) => {
+export const LayoutWithInnerKeyboardNavigation = forwardRef(({ id }, ref) => {
   const leftElRef = useRef(null);
   const rightElRef = useRef(null);
   const bottomElRef = useRef(null);
@@ -65,15 +65,17 @@ export const LayoutWithInnerKeyboardNavigation = forwardRef((_ignored, ref) => {
     <GridKeyboardNavigationContext.Provider value={keyboardContext}>
       <Flex
         ref={ref}
+        id={id}
         direction={Flex.directions.COLUMN}
         align={Flex.align.START}
         className="use-grid-keyboard-dummy-grid-wrapper"
+        tabIndex={-1}
       >
         <Flex>
-          <DummyNavigableGrid ref={leftElRef} itemsCount={6} numberOfItemsInLine={3} itemPrefix="L " />
-          <DummyNavigableGrid ref={rightElRef} itemsCount={6} numberOfItemsInLine={2} itemPrefix="R " />
+          <DummyNavigableGrid ref={leftElRef} itemsCount={6} numberOfItemsInLine={3} itemPrefix="L" />
+          <DummyNavigableGrid ref={rightElRef} itemsCount={6} numberOfItemsInLine={2} itemPrefix="R" />
         </Flex>
-        <DummyNavigableGrid ref={bottomElRef} itemsCount={6} numberOfItemsInLine={2} itemPrefix="B " />
+        <DummyNavigableGrid ref={bottomElRef} itemsCount={6} numberOfItemsInLine={2} itemPrefix="B" />
       </Flex>
     </GridKeyboardNavigationContext.Provider>
   );

--- a/src/components/GridKeyboardNavigationContext/__stories__/useGridKeyboardNavigationContext.stories.js
+++ b/src/components/GridKeyboardNavigationContext/__stories__/useGridKeyboardNavigationContext.stories.js
@@ -50,7 +50,7 @@ export const DummyNavigableGrid = forwardRef(
   }
 );
 
-export const LayoutWithInnerKeyboardNavigation = forwardRef(({ id }, ref) => {
+export const LayoutWithInnerKeyboardNavigation = forwardRef(({ id, itemPrefix }, ref) => {
   const leftElRef = useRef(null);
   const rightElRef = useRef(null);
   const bottomElRef = useRef(null);
@@ -61,6 +61,7 @@ export const LayoutWithInnerKeyboardNavigation = forwardRef(({ id }, ref) => {
     ],
     ref
   );
+  const innerPrefix = itemPrefix || "";
   return (
     <GridKeyboardNavigationContext.Provider value={keyboardContext}>
       <Flex
@@ -72,10 +73,10 @@ export const LayoutWithInnerKeyboardNavigation = forwardRef(({ id }, ref) => {
         tabIndex={-1}
       >
         <Flex>
-          <DummyNavigableGrid ref={leftElRef} itemsCount={6} numberOfItemsInLine={3} itemPrefix="L" />
-          <DummyNavigableGrid ref={rightElRef} itemsCount={6} numberOfItemsInLine={2} itemPrefix="R" />
+          <DummyNavigableGrid ref={leftElRef} itemsCount={6} numberOfItemsInLine={3} itemPrefix={`${innerPrefix}L`} />
+          <DummyNavigableGrid ref={rightElRef} itemsCount={6} numberOfItemsInLine={2} itemPrefix={`${innerPrefix}R`} />
         </Flex>
-        <DummyNavigableGrid ref={bottomElRef} itemsCount={6} numberOfItemsInLine={2} itemPrefix="B" />
+        <DummyNavigableGrid ref={bottomElRef} itemsCount={6} numberOfItemsInLine={2} itemPrefix={`${innerPrefix}B`} />
       </Flex>
     </GridKeyboardNavigationContext.Provider>
   );

--- a/src/components/GridKeyboardNavigationContext/__stories__/useGridKeyboardNavigationContext.stories.mdx
+++ b/src/components/GridKeyboardNavigationContext/__stories__/useGridKeyboardNavigationContext.stories.mdx
@@ -43,8 +43,8 @@ A hook used to specify a connection between multiple navigable components, which
       return (
         <GridKeyboardNavigationContext.Provider value={keyboardContext}>
           <Flex ref={wrapperRef}>
-            <DummyNavigableGrid ref={leftElRef} itemsCount={15} numberOfItemsInLine={4} itemPrefix="L " />
-            <DummyNavigableGrid ref={rightElRef} itemsCount={7} numberOfItemsInLine={2} itemPrefix="R " />
+            <DummyNavigableGrid ref={leftElRef} itemsCount={15} numberOfItemsInLine={4} itemPrefix="L" />
+            <DummyNavigableGrid ref={rightElRef} itemsCount={7} numberOfItemsInLine={2} itemPrefix="R" />
           </Flex>
         </GridKeyboardNavigationContext.Provider>
       );
@@ -127,9 +127,9 @@ Disabled components can be skipped by adding a `disabled` (or `data-disabled`) t
             justify={Flex.align.CENTER}
             className="use-grid-keyboard-dummy-grid-wrapper"
           >
-            <DummyNavigableGrid ref={topElRef} itemsCount={3} numberOfItemsInLine={3} itemPrefix="T " />
-            <DummyNavigableGrid ref={middleElRef} itemsCount={3} numberOfItemsInLine={3} itemPrefix="M " disabled />
-            <DummyNavigableGrid ref={bottomElRef} itemsCount={3} numberOfItemsInLine={3} itemPrefix="B " />
+            <DummyNavigableGrid ref={topElRef} itemsCount={3} numberOfItemsInLine={3} itemPrefix="T" />
+            <DummyNavigableGrid ref={middleElRef} itemsCount={3} numberOfItemsInLine={3} itemPrefix="M" disabled />
+            <DummyNavigableGrid ref={bottomElRef} itemsCount={3} numberOfItemsInLine={3} itemPrefix="B" />
           </Flex>
         </GridKeyboardNavigationContext.Provider>
       );
@@ -153,9 +153,9 @@ The hook can be used inside multiple depths, in more complex layout requirements
       );
       return (
         <GridKeyboardNavigationContext.Provider value={keyboardContext}>
-          <Flex ref={wrapperRef} direction={Flex.directions.COLUMN}>
-            <LayoutWithInnerKeyboardNavigation ref={topElRef} />
-            <LayoutWithInnerKeyboardNavigation ref={bottomElRef} />
+          <Flex id="twoGridLayoutsWrapper" ref={wrapperRef} direction={Flex.directions.COLUMN} tabIndex={-1}>
+            <LayoutWithInnerKeyboardNavigation id="gridLayoutTop" ref={topElRef} />
+            <LayoutWithInnerKeyboardNavigation id="gridLayoutBottom" ref={bottomElRef} />
           </Flex>
         </GridKeyboardNavigationContext.Provider>
       );

--- a/src/components/GridKeyboardNavigationContext/__stories__/useGridKeyboardNavigationContext.stories.mdx
+++ b/src/components/GridKeyboardNavigationContext/__stories__/useGridKeyboardNavigationContext.stories.mdx
@@ -4,6 +4,7 @@ import { ArgsTable, Story, Canvas, Meta } from "@storybook/addon-docs";
 import { createStoryMetaSettings } from "../../../storybook/functions/create-component-story";
 import { DummyNavigableGrid, LayoutWithInnerKeyboardNavigation } from "./useGridKeyboardNavigationContext.stories";
 import { Flex } from "../..";
+import { useGridContextMultipleDepthsPlaySuite } from "./interactions"
 
 export const metaSettings = createStoryMetaSettings({
   component: useGridKeyboardNavigationContext
@@ -142,7 +143,7 @@ Disabled components can be skipped by adding a `disabled` (or `data-disabled`) t
 The hook can be used inside multiple depths, in more complex layout requirements.
 
 <Canvas>
-  <Story name="Multiple Depths">
+  <Story name="Multiple Depths" play={useGridContextMultipleDepthsPlaySuite}>
     {() => {
       const wrapperRef = useRef(null);
       const topElRef = useRef(null);
@@ -154,8 +155,8 @@ The hook can be used inside multiple depths, in more complex layout requirements
       return (
         <GridKeyboardNavigationContext.Provider value={keyboardContext}>
           <Flex id="twoGridLayoutsWrapper" ref={wrapperRef} direction={Flex.directions.COLUMN} tabIndex={-1}>
-            <LayoutWithInnerKeyboardNavigation id="gridLayoutTop" ref={topElRef} />
-            <LayoutWithInnerKeyboardNavigation id="gridLayoutBottom" ref={bottomElRef} />
+            <LayoutWithInnerKeyboardNavigation id="gridLayoutTop" itemPrefix="T" ref={topElRef} />
+            <LayoutWithInnerKeyboardNavigation id="gridLayoutBottom" itemPrefix="B" ref={bottomElRef} />
           </Flex>
         </GridKeyboardNavigationContext.Provider>
       );

--- a/src/storybook/components/multiple-story-elements-wrapper/multiple-story-elements-wrapper.jsx
+++ b/src/storybook/components/multiple-story-elements-wrapper/multiple-story-elements-wrapper.jsx
@@ -2,5 +2,10 @@ import cx from "classnames";
 import "./multiple-story-elements-wrapper.scss";
 
 export const MultipleStoryElementsWrapper = ({ className, children }) => {
-  return <div className={cx("monday-storybook_multiple-story-elements-wrapper", className)}> {children} </div>;
+  return (
+    <div className={cx("monday-storybook_multiple-story-elements-wrapper", className)}>
+      <div data-testid="focusTrap" className="monday-storybook_focus-trap" />
+      {children}
+    </div>
+  );
 };

--- a/src/storybook/components/multiple-story-elements-wrapper/multiple-story-elements-wrapper.scss
+++ b/src/storybook/components/multiple-story-elements-wrapper/multiple-story-elements-wrapper.scss
@@ -7,3 +7,11 @@
     margin-right: $spacing-medium;
   }
 }
+
+.monday-storybook_focus-trap {
+  position: fixed;
+  top: -2000px;
+  left: -2000px;
+  width: 2px;
+  height: 2px;
+}


### PR DESCRIPTION
Fixed the story of `useGridKeyboardNavigationContext` - outbound navigation from upper layout grid didn't "wrap" into the lower layout grid.
I took the opportunity to add an interaction test to prevent regression, and enhance our testing abilities (with the `focusTrap` element)