### PR TITLE
Increase default width of left panel

### DIFF
--- a/.storybook/manager-head.html
+++ b/.storybook/manager-head.html
@@ -39,3 +39,21 @@
     color: #5034ff;
   }
 </style>
+
+<script>
+  //workaround to increase the left panel width just enough to show even the longer story names
+  //based on https://github.com/storybookjs/storybook/issues/9682#issuecomment-983356523
+  const DEFAULT_MINIMUM_LEFT_PANEL_WIDTH = 244; // original default is 230
+  let storybookConfig = JSON.parse(localStorage.getItem('storybook-layout'));
+
+  // we only resize the left panel if it is set to a value lower than DEFAULT_MINIMUM_LEFT_PANEL_WIDTH
+  if (typeof storybookConfig === 'object' && storybookConfig !== null && storybookConfig.resizerNav.x < DEFAULT_MINIMUM_LEFT_PANEL_WIDTH) {
+    storybookConfig.resizerNav.x = DEFAULT_MINIMUM_LEFT_PANEL_WIDTH;
+    localStorage.setItem('storybook-layout', JSON.stringify(storybookConfig));
+    document.location.reload();
+  } else if (storybookConfig === null) {
+    storybookConfig = { resizerNav: { x: DEFAULT_MINIMUM_LEFT_PANEL_WIDTH, y: 0 }, };
+    localStorage.setItem('storybook-layout', JSON.stringify(storybookConfig));
+    document.location.reload();
+  }
+</script>


### PR DESCRIPTION
Preventing longer story names from being cropped.
1. The user is still allowed to resize the panel like before
2. if the user has resized the panel to a larger value than `DEFAULT_MINIMUM_LEFT_PANEL_WIDTH`, it will be saved in the local storage (like it was saved before this PR)
3. if the user decreases the panel width to below `DEFAULT_MINIMUM_LEFT_PANEL_WIDTH`, it will be reset to `DEFAULT_MINIMUM_LEFT_PANEL_WIDTH` on the next reload

| Before | After | 
| - | - | 
| ![image](https://user-images.githubusercontent.com/96776835/159966742-92f78773-73a0-494f-9369-ace9ab0f33ba.png) | ![image](https://user-images.githubusercontent.com/96776835/159966772-3e845696-1908-420e-8e31-f14473c949dd.png) |