### PR TITLE
feat(accordion): add data-testid, improve ids, add interaction tests

### DIFF
--- a/src/components/Accordion/Accordion/Accordion.jsx
+++ b/src/components/Accordion/Accordion/Accordion.jsx
@@ -4,6 +4,18 @@ import cx from "classnames";
 import useMergeRefs from "../../../hooks/useMergeRefs";
 import "./Accordion.scss";
 
+const COMPONENT_ID = "monday-accordion";
+
+function defineChildId(index, props, accordionId) {
+  if (props.id) {
+    return props.id;
+  }
+  if (accordionId) {
+    return `${accordionId}--item-${index}`;
+  }
+  return `${COMPONENT_ID}--item-${index}`;
+}
+
 const Accordion = forwardRef(
   ({ children: originalChildren, allowMultiple, "data-testid": dataTestId, defaultIndex, className, id }, ref) => {
     const componentRef = useRef(null);
@@ -43,15 +55,18 @@ const Accordion = forwardRef(
 
     const renderChildElements = useMemo(() => {
       return React.Children.map(children, (child, itemIndex) => {
+        const originalProps = { ...child?.props };
+        const childId = defineChildId(itemIndex, originalProps, id);
         return React.cloneElement(child, {
-          ...child?.props,
+          ...originalProps,
+          id: childId,
           onClickAccordionCallback: () => {
             onChildClick(itemIndex);
           },
           open: isChildExpanded(itemIndex)
         });
       });
-    }, [isChildExpanded, onChildClick, children]);
+    }, [children, id, isChildExpanded, onChildClick]);
 
     return (
       <div ref={mergedRef} className={cx("accordion", className)} data-testid={dataTestId} id={id}>
@@ -93,7 +108,7 @@ Accordion.defaultProps = {
   id: undefined,
   allowMultiple: false,
   children: null,
-  "data-testid": "monday-accordion",
+  "data-testid": COMPONENT_ID,
   defaultIndex: []
 };
 

--- a/src/components/Accordion/Accordion/Accordion.jsx
+++ b/src/components/Accordion/Accordion/Accordion.jsx
@@ -4,62 +4,64 @@ import cx from "classnames";
 import useMergeRefs from "../../../hooks/useMergeRefs";
 import "./Accordion.scss";
 
-const Accordion = forwardRef(({ children: originalChildren, allowMultiple, defaultIndex, className, id }, ref) => {
-  const componentRef = useRef(null);
-  const mergedRef = useMergeRefs({ refs: [ref, componentRef] });
+const Accordion = forwardRef(
+  ({ children: originalChildren, allowMultiple, "data-testid": dataTestId, defaultIndex, className, id }, ref) => {
+    const componentRef = useRef(null);
+    const mergedRef = useMergeRefs({ refs: [ref, componentRef] });
 
-  const [expandedItems, setExpandedItems] = useState(defaultIndex);
+    const [expandedItems, setExpandedItems] = useState(defaultIndex);
 
-  const children = useMemo(() => React.Children.toArray(originalChildren), [originalChildren]);
+    const children = useMemo(() => React.Children.toArray(originalChildren), [originalChildren]);
 
-  const isChildExpanded = useCallback(
-    itemIndex => {
-      return expandedItems.includes(itemIndex);
-    },
-    [expandedItems]
-  );
+    const isChildExpanded = useCallback(
+      itemIndex => {
+        return expandedItems.includes(itemIndex);
+      },
+      [expandedItems]
+    );
 
-  const onChildClick = useCallback(
-    itemIndex => {
-      if (allowMultiple) {
-        const newExpandedItems = [...expandedItems];
-        if (isChildExpanded(itemIndex)) {
-          const index = newExpandedItems.indexOf(itemIndex);
-          if (index > -1) {
-            newExpandedItems.splice(index, 1);
+    const onChildClick = useCallback(
+      itemIndex => {
+        if (allowMultiple) {
+          const newExpandedItems = [...expandedItems];
+          if (isChildExpanded(itemIndex)) {
+            const index = newExpandedItems.indexOf(itemIndex);
+            if (index > -1) {
+              newExpandedItems.splice(index, 1);
+            }
+          } else {
+            newExpandedItems.push(itemIndex);
           }
-        } else {
-          newExpandedItems.push(itemIndex);
+          setExpandedItems(newExpandedItems);
+          return;
         }
-        setExpandedItems(newExpandedItems);
-        return;
-      }
 
-      setExpandedItems([itemIndex]);
-    },
-    [isChildExpanded, expandedItems, allowMultiple]
-  );
+        setExpandedItems([itemIndex]);
+      },
+      [isChildExpanded, expandedItems, allowMultiple]
+    );
 
-  const renderChildElements = useMemo(() => {
-    const childElements = React.Children.map(children, (child, itemIndex) => {
-      return React.cloneElement(child, {
-        ...child?.props,
-        onClickAccordionCallback: () => {
-          onChildClick(itemIndex);
-        },
-        open: isChildExpanded(itemIndex)
+    const renderChildElements = useMemo(() => {
+      const childElements = React.Children.map(children, (child, itemIndex) => {
+        return React.cloneElement(child, {
+          ...child?.props,
+          onClickAccordionCallback: () => {
+            onChildClick(itemIndex);
+          },
+          open: isChildExpanded(itemIndex)
+        });
       });
-    });
 
-    return childElements;
-  }, [isChildExpanded, onChildClick, children]);
+      return childElements;
+    }, [isChildExpanded, onChildClick, children]);
 
-  return (
-    <div ref={mergedRef} className={cx("accordion", className)} id={id}>
-      {children && renderChildElements}
-    </div>
-  );
-});
+    return (
+      <div ref={mergedRef} className={cx("accordion", className)} data-testid={dataTestId} id={id}>
+        {children && renderChildElements}
+      </div>
+    );
+  }
+);
 
 Accordion.propTypes = {
   /**
@@ -79,6 +81,10 @@ Accordion.propTypes = {
    */
   defaultIndex: PropTypes.array,
   /**
+   * Unique TestId - can be used as Selector for integration tests and other needs (tracking, etc.)
+   */
+  "data-testid": PropTypes.string,
+  /**
    * The value of the expandable section
    */
   children: PropTypes.oneOfType([PropTypes.arrayOf(PropTypes.node), PropTypes.node])
@@ -89,6 +95,7 @@ Accordion.defaultProps = {
   id: undefined,
   allowMultiple: false,
   children: null,
+  "data-testid": "monday-accordion",
   defaultIndex: []
 };
 

--- a/src/components/Accordion/Accordion/Accordion.jsx
+++ b/src/components/Accordion/Accordion/Accordion.jsx
@@ -42,7 +42,7 @@ const Accordion = forwardRef(
     );
 
     const renderChildElements = useMemo(() => {
-      const childElements = React.Children.map(children, (child, itemIndex) => {
+      return React.Children.map(children, (child, itemIndex) => {
         return React.cloneElement(child, {
           ...child?.props,
           onClickAccordionCallback: () => {
@@ -51,8 +51,6 @@ const Accordion = forwardRef(
           open: isChildExpanded(itemIndex)
         });
       });
-
-      return childElements;
     }, [isChildExpanded, onChildClick, children]);
 
     return (

--- a/src/components/Accordion/Accordion/__stories__/accordion.stories.mdx
+++ b/src/components/Accordion/Accordion/__stories__/accordion.stories.mdx
@@ -1,10 +1,10 @@
 import Accordion from "../Accordion";
 import AccordionItem from "../../AccordionItem/AccordionItem";
 import { ArgsTable, Story, Canvas, Meta } from "@storybook/addon-docs";
-import { createComponentTemplate } from "../../../../storybook/functions/create-component-story";
 import Checkbox from "../../../Checkbox/Checkbox.js";
 import { WIZARD, BREADCRUBMS, STEPPER } from "../../../../storybook/components/related-components/component-description-map";
 import "./accordion.stories.scss";
+import { accordionSingleActivePlaySuite } from "../__tests__/accordion.interactions"
 
 <Meta
   title="Data display/Accordion"
@@ -80,7 +80,7 @@ Each section can be expanded without closing the others
 ### Single active
 Only one section can be open at the time
 <Canvas>
-  <Story name="Single active">
+  <Story name="Single active" play={accordionSingleActivePlaySuite}>
     <Accordion className="monday-storybook-accordion_small-wrapepr" defaultIndex={[1]}>
       <AccordionItem title="Notifications"><div className="monday-storybook-accordion_small-box" /></AccordionItem>
       <AccordionItem title="Setting"><div className="monday-storybook-accordion_small-box" /></AccordionItem>

--- a/src/components/Accordion/Accordion/__tests__/accordion.interactions.js
+++ b/src/components/Accordion/Accordion/__tests__/accordion.interactions.js
@@ -1,0 +1,54 @@
+import { expect } from "@storybook/jest";
+import { userEvent, within } from "@storybook/testing-library";
+import { delay, interactionSuite, resetFocus } from "../../../../__tests__/interactions-helper";
+
+const CHANGES_DELAY = 1;
+
+function getAccordionHeadingBtText(canvas, title) {
+  return canvas.getByText(title)?.closest("button");
+}
+
+function getOpenedAccordionItem(canvas) {
+  const elPanel = canvas.getByRole("region");
+  const elHeading = within(elPanel.parentNode).getByRole("button");
+  return { elPanel, elHeading };
+}
+
+const openCloseAccordionSingleActiveTests = async canvas => {
+  // prepare: take sizes of slider and waiting for render
+  let elHeading, elPanel;
+  await delay(CHANGES_DELAY);
+
+  // try to click on already selected Accordion Item heading
+  ({ elHeading, elPanel } = getOpenedAccordionItem(canvas));
+  const before = elPanel.id;
+  userEvent.click(elHeading);
+  ({ elHeading, elPanel } = getOpenedAccordionItem(canvas));
+  const after = elPanel.id;
+  // what was opened should be still opened
+  await expect(before).toBe(after);
+  // panel and heading aria controls are the same
+  await expect(elHeading.getAttribute("aria-controls")).toBe(elPanel.id);
+
+  // select first (0) AccordionItem
+  elHeading = getAccordionHeadingBtText(canvas, "Notifications");
+  userEvent.click(elHeading);
+  elPanel = canvas.getByRole("region");
+  await expect(elHeading.getAttribute("aria-expanded")).toBe("true");
+  await expect(elHeading.getAttribute("aria-controls")).toBe(elPanel.id);
+  await delay(CHANGES_DELAY);
+
+  // select back second (1) AccordionItem
+  elHeading = getAccordionHeadingBtText(canvas, "Setting");
+  userEvent.click(elHeading);
+  elPanel = canvas.getByRole("region");
+  await expect(elHeading.getAttribute("aria-expanded")).toBe("true");
+  await expect(elHeading.getAttribute("aria-controls")).toBe(elPanel.id);
+};
+
+export const accordionSingleActivePlaySuite = interactionSuite({
+  tests: [openCloseAccordionSingleActiveTests],
+  afterEach: async () => {
+    await resetFocus();
+  }
+});

--- a/src/components/Accordion/AccordionItem/AccordionItem.jsx
+++ b/src/components/Accordion/AccordionItem/AccordionItem.jsx
@@ -17,7 +17,13 @@ const AccordionItem = forwardRef(
 
     return (
       <div ref={mergedRef} className={cx("accordion-item", className)} id={id}>
-        <ExpandCollapse title={title} iconSize={iconSize} open={open} onClick={onClickCallback}>
+        <ExpandCollapse
+          iconSize={iconSize}
+          id={`expand-collapse--${id}`}
+          onClick={onClickCallback}
+          open={open}
+          title={title}
+        >
           {children}
         </ExpandCollapse>
       </div>


### PR DESCRIPTION
Add data-testid (reformat component)

Minor code conventions (lint) refactoring (remove redundant const)
 
 Improve AccordionItem/ExpandCollapse ids
 - ExpandCollapse component have to get prop id
   for correct A11y (aria-controls)
 - AccordionItem now getting id on base of Accordion-Id and Index
 - If Accordion-Id not specified we are taking default COMPONENT_ID

Add interaction tests for single-active mode
 - add interactions tests
 - connect tests to storybook
 - minor fix: remove unused import
