### PR TITLE
docs(accordion): improve storybook (sub-items, props, etc.)

### DIFF
--- a/src/components/Accordion/Accordion/Accordion.jsx
+++ b/src/components/Accordion/Accordion/Accordion.jsx
@@ -98,7 +98,7 @@ Accordion.propTypes = {
    */
   "data-testid": PropTypes.string,
   /**
-   * The value of the expandable section
+   * List of AccordionItems
    */
   children: PropTypes.oneOfType([PropTypes.arrayOf(PropTypes.node), PropTypes.node])
 };

--- a/src/components/Accordion/Accordion/__stories__/accordion.stories.mdx
+++ b/src/components/Accordion/Accordion/__stories__/accordion.stories.mdx
@@ -9,6 +9,17 @@ import { accordionSingleActivePlaySuite, accordionMultiActivePlaySuite } from ".
 <Meta
   title="Data display/Accordion"
   component={ Accordion }
+  subcomponents = {{AccordionItem}}
+  argTypes={{
+    children: { control: false },
+    defaultIndex: { control: false }
+  }}
+  parameters={{
+    controls: {
+      expanded: true,
+      sort: 'requiredFirst'
+    }
+  }}
 />
 
 <!--- Component template -->
@@ -45,14 +56,13 @@ export const accordionTemplate = (args) => {
 Accordion is a vertically stacked list of items. Each item can be "expanded" or "collapsed" to reveal the content within with that item.
 
 <Canvas>
-  <Story name="Overview"
-         args={ {} }>
+  <Story name="Overview" args={ {} }>
     { accordionTemplate.bind({}) }
   </Story>
 </Canvas>
 
 ## Props
-<ArgsTable of={ Accordion } />
+<ArgsTable story="Overview" />
 
 ## Usage
 <UsageGuidelines guidelines={[


### PR DESCRIPTION

 - add ability to change props directly at Storybook
 - minor fixes of props description
 
![improve-accordion-01](https://user-images.githubusercontent.com/96241324/161420576-3616b715-72b3-4c56-90a3-1be34148b8e8.png)


 - add AccordionItem to ArgsTable:
![mprove-accordion-02](https://user-images.githubusercontent.com/96241324/161420582-ff0f6743-24e9-4737-b406-752c30836a98.png)


- ads description to Sandbox Controls:
![mprove-accordion-03](https://user-images.githubusercontent.com/96241324/161420587-80c3d3b3-89fb-4e59-b740-6245a5f390f1.png)


I think as future step we also can add AccordionItem to Controls/Playground using one of this approaches:
- https://storybook.js.org/docs/react/writing-stories/stories-for-multiple-components
- https://storybook.js.org/docs/react/writing-docs/doc-block-argstable#grouping