### PR TITLE
feat: adding a flag to ColorPicker for showing color name tooltips

### DIFF
--- a/src/components/ColorPicker/ColorPicker.jsx
+++ b/src/components/ColorPicker/ColorPicker.jsx
@@ -31,7 +31,7 @@ const ColorPicker = forwardRef(
       focusOnMount,
       colorShape,
       forceUseRawColorList,
-      showColorNameTooltip: showColorNameTooltip
+      showColorNameTooltip
     },
     ref
   ) => {

--- a/src/components/ColorPicker/ColorPicker.jsx
+++ b/src/components/ColorPicker/ColorPicker.jsx
@@ -125,6 +125,11 @@ ColorPicker.defaultProps = {
    * Usually, only "monday colors" will be rendered (unless blacklist mode is used). This flag will override this behavior.
    */
   forceUseRawColorList: false,
+  /**
+   * Used to enable color name tooltip on each color in the component. it's incompatible with forceUseRawColorList flag.
+   * When "tooltipContentByColor" is supplied, it will override the color name tooltip.
+   *
+   */
   showColorNameTooltip: false
 };
 

--- a/src/components/ColorPicker/ColorPicker.jsx
+++ b/src/components/ColorPicker/ColorPicker.jsx
@@ -30,7 +30,8 @@ const ColorPicker = forwardRef(
       numberOfColorsInLine,
       focusOnMount,
       colorShape,
-      forceUseRawColorList
+      forceUseRawColorList,
+      showColorNameTooltip: showColorNameTooltip
     },
     ref
   ) => {
@@ -66,6 +67,7 @@ const ColorPicker = forwardRef(
           focusOnMount={focusOnMount}
           colorShape={colorShape}
           forceUseRawColorList={forceUseRawColorList}
+          showColorNameTooltip={showColorNameTooltip}
         />
       </DialogContentContainer>
     );
@@ -97,7 +99,8 @@ ColorPicker.propTypes = {
   numberOfColorsInLine: PropTypes.number,
   focusOnMount: PropTypes.bool,
   colorShape: PropTypes.oneOf(Object.values(ColorPicker.colorShapes)),
-  forceUseRawColorList: PropTypes.bool
+  forceUseRawColorList: PropTypes.bool,
+  showColorNameTooltip: PropTypes.bool
 };
 
 ColorPicker.defaultProps = {
@@ -121,7 +124,8 @@ ColorPicker.defaultProps = {
    * Used to force the component render the colorList prop as is. Usually, this flag should not be used. It's intended only for edge cases.
    * Usually, only "monday colors" will be rendered (unless blacklist mode is used). This flag will override this behavior.
    */
-  forceUseRawColorList: false
+  forceUseRawColorList: false,
+  showColorNameTooltip: false
 };
 
 export default ColorPicker;

--- a/src/components/ColorPicker/__tests__/colorPicker.jest.js
+++ b/src/components/ColorPicker/__tests__/colorPicker.jest.js
@@ -1,9 +1,10 @@
 import React from "react";
 import renderer from "react-test-renderer";
-import { render, fireEvent, act } from "@testing-library/react";
+import { render, fireEvent, act, screen } from "@testing-library/react";
 import _difference from "lodash/difference";
 import ColorPicker from "../ColorPicker";
 import { contentColors } from "../../../utils/colors-vars-map";
+import { ColorPickerColorsGrid } from "components/ColorPicker/components/ColorPickerContent/ColorPickerColorsGrid";
 
 it("renders correctly with empty props", () => {
   const tree = renderer.create(<ColorPicker />).toJSON();
@@ -105,5 +106,57 @@ describe("ColorPicker", () => {
     const colorsElements = colorList.map(color => getByLabelText(color));
 
     expect(colorsElements.length).toBe(colorsElements.length);
+  });
+
+  it("should render tooltip with color name if showColorNameTooltip is true", () => {
+    const colorPicker = render(<ColorPicker showColorNameTooltip />);
+    const colorName = "done-green";
+    const colorNameTooltip = "Done Green";
+
+    const component = colorPicker.getByLabelText(colorName);
+    act(() => {
+      fireEvent.mouseOver(component);
+    });
+    jest.advanceTimersByTime(1000);
+    const content = screen.getByText(colorNameTooltip);
+    expect(content).toBeTruthy();
+  });
+
+  it("should not render tooltip with the color name if showColorNameTooltip is true and forceUseRawColorList is true", () => {
+    const colorName = "done-green";
+    const colorNameTooltip = "Done Green";
+    const colorList = [colorName];
+    const colorPicker = render(<ColorPicker colorsList={colorList} showColorNameTooltip forceUseRawColorList />);
+
+    const component = colorPicker.getByLabelText(colorName);
+    act(() => {
+      fireEvent.mouseOver(component);
+    });
+    jest.advanceTimersByTime(1000);
+    const content = screen.queryByText(colorNameTooltip);
+    expect(content).toBeNull();
+  });
+
+  it("should render tooltip with tooltipContentByColor value if tooltipContentByColor of the color exist", () => {
+    const colorName = "done-green";
+    const colorNameTooltip = "Done Green";
+    const contentByColorTooltip = "Custom tooltip";
+    const tooltipContentByColor = { "done-green": contentByColorTooltip };
+    const colorsToRender = [colorName];
+
+    const colorPicker = render(
+      <ColorPickerColorsGrid colorsToRender = {colorsToRender} tooltipContentByColor={tooltipContentByColor} showColorNameTooltip />
+    );
+
+    const component = colorPicker.getByLabelText(colorName);
+    act(() => {
+      fireEvent.mouseOver(component);
+    });
+    jest.advanceTimersByTime(1000);
+    const contentByName = screen.queryByText(colorNameTooltip);
+    const expected = screen.getByText(contentByColorTooltip);
+
+    expect(contentByName).toBeNull();
+    expect(expected).toBeTruthy();
   });
 });

--- a/src/components/ColorPicker/components/ColorPickerContent/ColorPickerColorsGrid.jsx
+++ b/src/components/ColorPicker/components/ColorPickerContent/ColorPickerColorsGrid.jsx
@@ -31,7 +31,7 @@ export const ColorPickerColorsGrid = React.forwardRef(
     const calculateColorTooltip = color => {
       if (tooltipContentByColor && tooltipContentByColor[color]) return tooltipContentByColor[color];
       else {
-        return showColorNameTooltip ? formatColorNameForTooltip(color) : {};
+        return showColorNameTooltip ? formatColorNameForTooltip(color) : undefined;
       }
     };
 

--- a/src/components/ColorPicker/components/ColorPickerContent/ColorPickerColorsGrid.jsx
+++ b/src/components/ColorPicker/components/ColorPickerContent/ColorPickerColorsGrid.jsx
@@ -21,11 +21,25 @@ export const ColorPickerColorsGrid = React.forwardRef(
       SelectedIndicatorIcon,
       colorSize,
       tooltipContentByColor,
-      colorShape
+      colorShape,
+      showColorNameTooltip: showColorNameTooltip
     },
     ref
   ) => {
     const getItemByIndex = useCallback(index => colorsToRender[index], [colorsToRender]);
+
+    const calculateColorTooltip = color => {
+      if (tooltipContentByColor && tooltipContentByColor[color]) return tooltipContentByColor[color];
+      else {
+        return showColorNameTooltip ? formatColorNameForTooltip(color) : {};
+      }
+    };
+
+    const formatColorNameForTooltip = color => {
+      return color.replace(/-|_/g, " ").replace(/(?:^|\s)\S/g, function (a) {
+        return a.toUpperCase();
+      });
+    };
 
     const { activeIndex, onSelectionAction } = useGridKeyboardNavigation({
       focusOnMount,
@@ -53,7 +67,7 @@ export const ColorPickerColorsGrid = React.forwardRef(
               isSelected={Array.isArray(value) ? value.includes(color) : value === color}
               isActive={index === activeIndex}
               colorSize={colorSize}
-              tooltipContent={tooltipContentByColor[color]}
+              tooltipContent={calculateColorTooltip(color)}
               colorShape={colorShape}
             />
           );
@@ -86,7 +100,8 @@ ColorPickerColorsGrid.propTypes = {
   numberOfColorsInLine: PropTypes.number,
   tooltipContentByColor: PropTypes.object,
   focusOnMount: PropTypes.bool,
-  colorShape: PropTypes.oneOf(Object.values(ColorPickerColorsGrid.colorShapes))
+  colorShape: PropTypes.oneOf(Object.values(ColorPickerColorsGrid.colorShapes)),
+  showColorNameTooltip: PropTypes.bool
 };
 
 ColorPickerColorsGrid.defaultProps = {
@@ -101,5 +116,6 @@ ColorPickerColorsGrid.defaultProps = {
   numberOfColorsInLine: DEFAULT_NUMBER_OF_COLORS_IN_LINE,
   tooltipContentByColor: {},
   focusOnMount: false,
-  colorShape: ColorPickerColorsGrid.colorShapes.SQUARE
+  colorShape: ColorPickerColorsGrid.colorShapes.SQUARE,
+  showColorNameTooltip: false
 };

--- a/src/components/ColorPicker/components/ColorPickerContent/ColorPickerContentComponent.jsx
+++ b/src/components/ColorPicker/components/ColorPickerContent/ColorPickerContentComponent.jsx
@@ -36,7 +36,8 @@ const ColorPickerContentComponent = forwardRef(
       tooltipContentByColor,
       focusOnMount,
       colorShape,
-      forceUseRawColorList
+      forceUseRawColorList,
+      showColorNameTooltip
     },
     ref
   ) => {
@@ -95,6 +96,7 @@ const ColorPickerContentComponent = forwardRef(
             colorSize={colorSize}
             tooltipContentByColor={tooltipContentByColor}
             colorShape={colorShape}
+            showColorNameTooltip={showColorNameTooltip && !forceUseRawColorList}
           />
           {noColorText && (
             <ColorPickerClearButton Icon={NoColorIcon} onClick={onClearButton} text={noColorText} ref={buttonRef} />
@@ -134,7 +136,8 @@ ColorPickerContentComponent.propTypes = {
   focusOnMount: PropTypes.bool,
   colorShape: PropTypes.oneOf(Object.values(ColorPickerContentComponent.colorShapes)),
   isMultiselect: PropTypes.bool,
-  forceUseRawColorList: PropTypes.bool
+  forceUseRawColorList: PropTypes.bool,
+  showColorNameTooltip: PropTypes.bool
 };
 
 ColorPickerContentComponent.defaultProps = {
@@ -159,7 +162,8 @@ ColorPickerContentComponent.defaultProps = {
    * Used to force the component render the colorList prop as is. Usually, this flag should not be used. It's intended only for edge cases.
    * Usually, only "monday colors" will be rendered (unless blacklist mode is used). This flag will override this behavior.
    */
-  forceUseRawColorList: false
+  forceUseRawColorList: false,
+  showColorNameTooltip: false
 };
 
 export default ColorPickerContentComponent;

--- a/src/components/ColorPicker/components/ColorPickerContent/ColorPickerContentComponent.jsx
+++ b/src/components/ColorPicker/components/ColorPickerContent/ColorPickerContentComponent.jsx
@@ -163,6 +163,11 @@ ColorPickerContentComponent.defaultProps = {
    * Usually, only "monday colors" will be rendered (unless blacklist mode is used). This flag will override this behavior.
    */
   forceUseRawColorList: false,
+  /**
+   * Used to enable color name tooltip on each color in the component. it's incompatible with forceUseRawColorList flag.
+   * When "tooltipContentByColor" is supplied, it will override the color name tooltip.
+   *
+   */
   showColorNameTooltip: false
 };
 


### PR DESCRIPTION
Description: adding a flag to ColorPicker for showing color name tooltips
<!--

Please go over the checklist and make sure all conditions are met.

--->

#### Basic
- [x] Used plop (`npm run plop`) to create a new component.
- [x] PR has description.
- [x] New component is functional and uses Hooks. 
- [x] Component defines [`PropTypes`](https://reactjs.org/docs/typechecking-with-proptypes.html).
#### Style
- [x] Styles are added to `NewComponent.modules.scss` file inside of the `NewComponent` folder.
- [x] Component uses CSS Modules.
- [x] Design is compatible with [Monday Design System](https://design.monday.com/).
#### Storybook
- [x] Stories were added to `/src/NewComponent/__stories__/NewComponent.stories.js` file.
- [x] Stories include all flows of using the component.
#### Tests
- [x] Tests are compliant with [TESTING_README.md](TESTING_README.md) instructions.
