### PR TITLE
Support on disabled tabIndex

### DIFF
--- a/src/components/BreadcrumbsBar/BreadcrumbItem/BreadcrumbContent/BreadcrumbContent.jsx
+++ b/src/components/BreadcrumbsBar/BreadcrumbItem/BreadcrumbContent/BreadcrumbContent.jsx
@@ -1,38 +1,55 @@
 /* eslint-disable jsx-a11y/no-noninteractive-tabindex */
-import React, { forwardRef, useCallback } from "react";
+import React, { forwardRef, useCallback, useMemo } from "react";
 import "./BreadcrumbContent.scss";
 
 const ENTER_KEY = "Enter";
 const SPACE_KEY = " ";
 
-export const BreadcrumbContent = forwardRef(({ className, isClickable, link, onClick, text, icon, isCurrent }, ref) => {
-  const Icon = icon;
-  const onKeyDown = useCallback(
-    event => {
-      if (event.key === ENTER_KEY || event.key === SPACE_KEY) {
-        link ? (window.parent.location.href = link) : onClick();
-      }
-    },
-    [onClick, link]
-  );
+export const BreadcrumbContent = forwardRef(
+  ({ className, isClickable, link, onClick, text, icon, isCurrent, disabled = false }, ref) => {
+    const Icon = icon;
+    const onKeyDown = useCallback(
+      event => {
+        if (event.key === ENTER_KEY || event.key === SPACE_KEY) {
+          link ? (window.parent.location.href = link) : onClick();
+        }
+      },
+      [onClick, link]
+    );
 
-  if (isClickable && (link || onClick)) {
-    if (link) {
+    const tabIndex = useMemo(() => (disabled ? "-1" : "0"), [disabled]);
+
+    if (isClickable && (link || onClick)) {
+      if (link) {
+        return (
+          <a className={className} href={link} onKeyDown={onKeyDown} aria-current={isCurrent ? "page" : undefined}>
+            {Icon && <Icon className="breadcrumb-icon" size="14" clickable={false} />}
+            <span ref={ref} className="breadcrumb-text">
+              {text}
+            </span>
+          </a>
+        );
+      }
       return (
-        <a className={className} href={link} onKeyDown={onKeyDown} aria-current={isCurrent ? "page" : undefined}>
+        <span
+          className={className}
+          onClick={onClick}
+          onKeyDown={onKeyDown}
+          tabIndex={tabIndex}
+          aria-current={isCurrent ? "page" : undefined}
+        >
           {Icon && <Icon className="breadcrumb-icon" size="14" clickable={false} />}
           <span ref={ref} className="breadcrumb-text">
             {text}
           </span>
-        </a>
+        </span>
       );
     }
     return (
       <span
         className={className}
-        onClick={onClick}
-        onKeyDown={onKeyDown}
-        tabIndex="0"
+        aria-disabled="true"
+        tabIndex={tabIndex}
         aria-current={isCurrent ? "page" : undefined}
       >
         {Icon && <Icon className="breadcrumb-icon" size="14" clickable={false} />}
@@ -42,12 +59,4 @@ export const BreadcrumbContent = forwardRef(({ className, isClickable, link, onC
       </span>
     );
   }
-  return (
-    <span className={className} aria-disabled="true" tabIndex="0" aria-current={isCurrent ? "page" : undefined}>
-      {Icon && <Icon className="breadcrumb-icon" size="14" clickable={false} />}
-      <span ref={ref} className="breadcrumb-text">
-        {text}
-      </span>
-    </span>
-  );
-});
+);

--- a/src/components/BreadcrumbsBar/BreadcrumbItem/BreadcrumbContent/BreadcrumbContent.jsx
+++ b/src/components/BreadcrumbsBar/BreadcrumbItem/BreadcrumbContent/BreadcrumbContent.jsx
@@ -6,7 +6,7 @@ const ENTER_KEY = "Enter";
 const SPACE_KEY = " ";
 
 export const BreadcrumbContent = forwardRef(
-  ({ className, isClickable, link, onClick, text, icon, isCurrent, disabled = false }, ref) => {
+  ({ className, isClickable, link, onClick, text, icon, isCurrent, overrideDisabled = false }, ref) => {
     const Icon = icon;
     const onKeyDown = useCallback(
       event => {
@@ -17,7 +17,7 @@ export const BreadcrumbContent = forwardRef(
       [onClick, link]
     );
 
-    const tabIndex = useMemo(() => (disabled ? "-1" : "0"), [disabled]);
+    const tabIndex = useMemo(() => (overrideDisabled ? "-1" : "0"), [overrideDisabled]);
 
     if (isClickable && (link || onClick)) {
       if (link) {

--- a/src/components/BreadcrumbsBar/BreadcrumbItem/BreadcrumbContent/BreadcrumbContent.jsx
+++ b/src/components/BreadcrumbsBar/BreadcrumbItem/BreadcrumbContent/BreadcrumbContent.jsx
@@ -6,7 +6,7 @@ const ENTER_KEY = "Enter";
 const SPACE_KEY = " ";
 
 export const BreadcrumbContent = forwardRef(
-  ({ className, isClickable, link, onClick, text, icon, isCurrent, overrideDisabled = false }, ref) => {
+  ({ className, isClickable, link, onClick, text, icon, isCurrent, disabled = false }, ref) => {
     const Icon = icon;
     const onKeyDown = useCallback(
       event => {
@@ -17,7 +17,7 @@ export const BreadcrumbContent = forwardRef(
       [onClick, link]
     );
 
-    const tabIndex = useMemo(() => (overrideDisabled ? "-1" : "0"), [overrideDisabled]);
+    const tabIndex = useMemo(() => (disabled ? "-1" : "0"), [disabled]);
 
     if (isClickable && (link || onClick)) {
       if (link) {

--- a/src/components/BreadcrumbsBar/BreadcrumbItem/BreadcrumbItem.jsx
+++ b/src/components/BreadcrumbsBar/BreadcrumbItem/BreadcrumbItem.jsx
@@ -57,6 +57,7 @@ const BreadcrumbItem = ({
           text={text}
           icon={icon}
           isCurrent={isCurrent}
+          disabled={isDisabled || disabled}
         />
       </li>
     </Tooltip>

--- a/src/components/BreadcrumbsBar/BreadcrumbItem/BreadcrumbItem.jsx
+++ b/src/components/BreadcrumbsBar/BreadcrumbItem/BreadcrumbItem.jsx
@@ -57,7 +57,7 @@ const BreadcrumbItem = ({
           text={text}
           icon={icon}
           isCurrent={isCurrent}
-          overrideDisabled={isDisabled || disabled}
+          disabled={overrideDisabled}
         />
       </li>
     </Tooltip>

--- a/src/components/BreadcrumbsBar/BreadcrumbItem/BreadcrumbItem.jsx
+++ b/src/components/BreadcrumbsBar/BreadcrumbItem/BreadcrumbItem.jsx
@@ -57,7 +57,7 @@ const BreadcrumbItem = ({
           text={text}
           icon={icon}
           isCurrent={isCurrent}
-          disabled={isDisabled || disabled}
+          overrideDisabled={isDisabled || disabled}
         />
       </li>
     </Tooltip>


### PR DESCRIPTION
Breadcrumbs accessibility fixes:
- Add an optional disabled prop to `BreadcrumbContent` according to `disabled || isDisabled` in `BreadcrumbItem`.
- If `BreadcrumbItem` is disabled, sets the tabindex attribute to `-1`.
