### PR TITLE
fix: Remove Tip box

### DIFF
--- a/src/components/Search/__stories__/Search.stories.mdx
+++ b/src/components/Search/__stories__/Search.stories.mdx
@@ -73,8 +73,6 @@ There are three sizes available: Small (32px), Medium (40px), and Large (48px).
   </Story>
 </Canvas>
 
-<Tip title="Missing something?">If you’re looking for search states, go to<Link href="/?path=/story/components-canvas--overview" size={Link.sizes.SMALL}>Canvas</Link>and play with the controls.</Tip>
-
 ## Use cases and examples
 ### Filter in combobox
 <Canvas>


### PR DESCRIPTION
The link referred on the Tip box is broken. Suggestion to remove it unless there is a new Canvas component with a different name. 
Sorry for putting my nose in 😅   just find out the bug and Orr told me this is open source.