### PR TITLE
feat/Chris/ make Avatar initials text styling customisable

### DIFF
--- a/src/components/Avatar/Avatar.jsx
+++ b/src/components/Avatar/Avatar.jsx
@@ -21,7 +21,6 @@ const Avatar = ({
   src,
   icon,
   text,
-  textSize,
   role,
   ariaLabel,
   backgroundColor,
@@ -117,7 +116,6 @@ const Avatar = ({
         <AvatarContent
           type={type}
           size={size}
-          textSize={textSize}
           textClassName={textClassName}
           src={src}
           icon={icon}

--- a/src/components/Avatar/Avatar.jsx
+++ b/src/components/Avatar/Avatar.jsx
@@ -5,7 +5,7 @@ import cx from "classnames";
 import { BEMClass } from "helpers/bem-helper";
 import { backwardCompatibilityForProperties } from "helpers/backwardCompatibilityForProperties";
 import { getElementColor, elementColorsNames } from "utils/colors-vars-map";
-import { AVATAR_SIZES, AVATAR_TEXT_SIZES, AVATAR_TYPES } from "./AvatarConstants";
+import { AVATAR_SIZES, AVATAR_TYPES } from "./AvatarConstants";
 import { AvatarBadge } from "./AvatarBadge";
 import { AvatarContent } from "./AvatarContent";
 import "./Avatar.scss";
@@ -133,7 +133,6 @@ const Avatar = ({
 
 Avatar.types = AVATAR_TYPES;
 Avatar.sizes = AVATAR_SIZES;
-Avatar.textSizes = AVATAR_TEXT_SIZES;
 Avatar.colors = elementColorsNames;
 Avatar.backgroundColors = elementColorsNames;
 

--- a/src/components/Avatar/Avatar.jsx
+++ b/src/components/Avatar/Avatar.jsx
@@ -5,7 +5,7 @@ import cx from "classnames";
 import { BEMClass } from "helpers/bem-helper";
 import { backwardCompatibilityForProperties } from "helpers/backwardCompatibilityForProperties";
 import { getElementColor, elementColorsNames } from "utils/colors-vars-map";
-import { AVATAR_SIZES, AVATAR_TYPES } from "./AvatarConstants";
+import { AVATAR_SIZES, AVATAR_TEXT_SIZES, AVATAR_TYPES } from "./AvatarConstants";
 import { AvatarBadge } from "./AvatarBadge";
 import { AvatarContent } from "./AvatarContent";
 import "./Avatar.scss";
@@ -16,10 +16,12 @@ const bemHelper = BEMClass(AVATAR_CSS_BASE_CLASS);
 const Avatar = ({
   type,
   className,
+  textClassName,
   size,
   src,
   icon,
   text,
+  textSize,
   role,
   ariaLabel,
   backgroundColor,
@@ -112,7 +114,17 @@ const Avatar = ({
         tabIndex={tabIndex}
         style={{ ...backgroundColorStyle, ...sizeStyle }}
       >
-        <AvatarContent type={type} size={size} src={src} icon={icon} text={text} ariaLabel={ariaLabel} role={role} />
+        <AvatarContent
+          type={type}
+          size={size}
+          textSize={textSize}
+          textClassName={textClassName}
+          src={src}
+          icon={icon}
+          text={text}
+          ariaLabel={ariaLabel}
+          role={role}
+        />
       </div>
       {badgesContainer}
     </div>
@@ -121,6 +133,7 @@ const Avatar = ({
 
 Avatar.types = AVATAR_TYPES;
 Avatar.sizes = AVATAR_SIZES;
+Avatar.textSizes = AVATAR_TEXT_SIZES;
 Avatar.colors = elementColorsNames;
 Avatar.backgroundColors = elementColorsNames;
 
@@ -130,6 +143,7 @@ Avatar.propTypes = {
   icon: PropTypes.oneOfType([PropTypes.string, PropTypes.func]),
   type: PropTypes.oneOf([Avatar.types.TEXT, Avatar.types.ICON, Avatar.types.IMG]),
   className: PropTypes.string,
+  textClassName: PropTypes.string,
   backgroundColor: PropTypes.oneOf(Object.values(Avatar.colors)),
   customBackgroundColor: PropTypes.string,
   role: PropTypes.string,
@@ -150,6 +164,7 @@ Avatar.propTypes = {
 Avatar.defaultProps = {
   src: undefined,
   className: "",
+  textClassName: "",
   icon: undefined,
   text: undefined,
   type: AVATAR_TYPES.TEXT,

--- a/src/components/Avatar/AvatarContent.jsx
+++ b/src/components/Avatar/AvatarContent.jsx
@@ -8,7 +8,7 @@ import "./AvatarContent.scss";
 
 const AVATAR_CONTENT_CSS_BASE_CLASS = "monday-style-avatar-content";
 const bemHelper = BEMClass(AVATAR_CONTENT_CSS_BASE_CLASS);
-export const AvatarContent = ({ type, src, icon, text, ariaLabel, role, size }) => {
+export const AvatarContent = ({ type, src, icon, text, ariaLabel, role, size, textClassName }) => {
   const className = cx(bemHelper({ element: type }), bemHelper({ element: type, state: size }));
   switch (type) {
     case AVATAR_TYPES.IMG:
@@ -26,7 +26,7 @@ export const AvatarContent = ({ type, src, icon, text, ariaLabel, role, size }) 
       );
     case AVATAR_TYPES.TEXT:
       return (
-        <span aria-label={ariaLabel} role={role} className={className}>
+        <span aria-label={ariaLabel} role={role} className={cx(className, textClassName)}>
           {text}
         </span>
       );
@@ -46,6 +46,7 @@ AvatarContent.propTypes = {
   ariaLabel: PropTypes.string,
   /** we support two types of icons - SVG and FONT (classname) so this prop is either the name of the icon or the component */
   icon: PropTypes.oneOfType([PropTypes.string, PropTypes.func]),
+  textClassName: PropTypes.string,
   text: PropTypes.string
 };
 
@@ -56,5 +57,6 @@ AvatarContent.defaultProps = {
   role: undefined,
   ariaLabel: undefined,
   size: AVATAR_SIZES.LARGE,
+  textClassName: "",
   text: undefined
 };

--- a/src/components/Avatar/__stories__/avatar.stories.mdx
+++ b/src/components/Avatar/__stories__/avatar.stories.mdx
@@ -91,6 +91,16 @@ Use when a user’s image is not available, use their initials.
   </Story>
 </Canvas>
 
+### Initials avatar custom text format
+While Default initials typography sizes and styles do not suit the design use this custom class to customize it.
+<Canvas>
+  <Story name="Avatar with formatted text">
+    <Avatar size={Avatar.sizes.SMALL} type={Avatar.types.TEXT} text="RM" backgroundColor={Avatar.colors.BRIGHT_BLUE} textClassName="text-formatted--small" />
+    <Avatar size={Avatar.sizes.MEDIUM} type={Avatar.types.TEXT} text="RM" backgroundColor={Avatar.colors.LIPSTICK} textClassName="text-formatted--medium" />
+    <Avatar size={Avatar.sizes.LARGE} type={Avatar.types.TEXT} text="RM" backgroundColor={Avatar.colors.DONE_GREEN} textClassName="text-formatted--large" />
+  </Story>
+</Canvas>
+
 ### Square avatar with icon or text
 Use for non-person avatars, such as a workspace or team.
 <Canvas>

--- a/src/components/Avatar/__stories__/avatar.stories.scss
+++ b/src/components/Avatar/__stories__/avatar.stories.scss
@@ -24,3 +24,18 @@
     }
   }
 }
+
+.text-formatted--large {
+  font-size: 26px;
+  font-weight: normal;
+}
+
+.text-formatted--medium {
+  font-size: 18px;
+  font-weight: 100;
+}
+
+.text-formatted--small {
+  font-size: 10px;
+  font-weight: bold;
+}


### PR DESCRIPTION
<!--

Please go over the checklist and make sure all conditions are met.

--->

We needed Avatar custom initials text styling in New Automation Store. To achieve it I added class property for text to be able to override default styling.

![image](https://user-images.githubusercontent.com/103023946/172368617-14a95fca-19d6-47c9-b96d-0f165afe280f.png)


#### Basic
- [ ] Used plop (`npm run plop`) to create a new component.
- [x] PR has description.
- [ ] New component is functional and uses Hooks. 
- [x] Component defines [`PropTypes`](https://reactjs.org/docs/typechecking-with-proptypes.html).
#### Style
- [ ] Styles are added to `NewComponent.modules.scss` file inside of the `NewComponent` folder.
- [ ] Component uses CSS Modules.
- [ ] Design is compatible with [Monday Design System](https://design.monday.com/).
#### Storybook
- [x] Stories were added to `/src/NewComponent/__stories__/NewComponent.stories.js` file.
- [x] Stories include all flows of using the component.
#### Tests
- [ ] Tests are compliant with [TESTING_README.md](TESTING_README.md) instructions.
