### PR TITLE
Add css module support for chips component

### DIFF
--- a/src/components/Chips/Chips.jsx
+++ b/src/components/Chips/Chips.jsx
@@ -1,4 +1,4 @@
-import React, { useRef, forwardRef, useMemo, useCallback } from "react";
+import React, { forwardRef, useCallback, useMemo, useRef } from "react";
 import PropTypes from "prop-types";
 import cx from "classnames";
 import Icon from "../Icon/Icon";
@@ -6,11 +6,11 @@ import useMergeRefs from "../../hooks/useMergeRefs";
 import CloseSmall from "../Icon/Icons/components/CloseSmall";
 import { getCSSVar } from "../../services/themes";
 import { NOOP } from "../../utils/function-utils";
-import "./Chips.scss";
 import { elementColorsNames, getElementColor } from "../../utils/colors-vars-map";
 import Avatar from "../Avatar/Avatar";
 import IconButton from "components/IconButton/IconButton";
 import { ELEMENT_TYPES, getTestId } from "utils/test-utils";
+import styles from "./Chips.module.scss";
 
 const Chips = forwardRef(
   (
@@ -56,11 +56,11 @@ const Chips = forwardRef(
     return (
       <div
         ref={mergedRef}
-        className={cx("chips--wrapper", className, {
+        className={cx(styles.chips, "chips--wrapper", className, {
           disabled,
-          "with-close": hasCloseButton,
-          "no-animation": noAnimation,
-          "with-user-select": allowTextSelection
+          [styles.withClose]: hasCloseButton,
+          [styles.noAnimation]: noAnimation,
+          [styles.withUserSelect]: allowTextSelection
         })}
         id={id}
         style={backgroundColorStyle}
@@ -70,7 +70,7 @@ const Chips = forwardRef(
         {leftAvatar ? (
           <Avatar
             withoutBorder
-            className="chip-avatar left"
+            className={cx(styles.avatar, styles.left)}
             customSize={16}
             src={leftAvatar}
             type={Avatar.types.IMG}
@@ -79,7 +79,7 @@ const Chips = forwardRef(
         ) : null}
         {leftIcon ? (
           <Icon
-            className="chip-icon left"
+            className={cx(styles.icon, styles.left)}
             iconType={Icon.type.ICON_FONT}
             clickable={false}
             icon={leftIcon}
@@ -87,10 +87,10 @@ const Chips = forwardRef(
             ignoreFocusStyle
           />
         ) : null}
-        <div className="label">{label}</div>
+        <div className={styles.label}>{label}</div>
         {rightIcon ? (
           <Icon
-            className="chip-icon right"
+            className={cx(styles.icon, styles.right)}
             iconType={Icon.type.ICON_FONT}
             clickable={false}
             icon={rightIcon}
@@ -101,7 +101,7 @@ const Chips = forwardRef(
         {rightAvatar ? (
           <Avatar
             withoutBorder
-            className="chip-avatar right"
+            className={cx(styles.avatar, styles.right)}
             customSize={16}
             src={rightAvatar}
             type={Avatar.types.IMG}
@@ -112,7 +112,7 @@ const Chips = forwardRef(
           <IconButton
             size={IconButton.sizes.XXS}
             color={IconButton.colors.ON_PRIMARY_COLOR}
-            className="chip-icon close"
+            className={cx(styles.icon, styles.close)}
             aria-label={`Remove ${label}`}
             icon={CloseSmall}
             iconSize={18}

--- a/src/components/Chips/Chips.module.scss
+++ b/src/components/Chips/Chips.module.scss
@@ -2,9 +2,7 @@
 @import "../../styles/typography";
 @import "../../styles/states";
 
-$icon-margin: 4px;
-
-.chips--wrapper {
+.chips {
   display: inline-flex;
   overflow: hidden;
   height: 24px;
@@ -13,10 +11,10 @@ $icon-margin: 4px;
   align-items: center;
   margin: 0 4px;
   user-select: none;
-  animation: chips-enter 100ms;
+  animation: chipsEnter 100ms;
   animation-timing-function: cubic-bezier(0, 0, 0.35, 1);
 
-  &.with-user-select {
+  &.withUserSelect {
     user-select: text;
   }
 
@@ -25,29 +23,29 @@ $icon-margin: 4px;
     @include ellipsis();
   }
 
-  &.no-animation {
+  &.noAnimation {
     animation: none;
   }
 
-  &.with-close {
+  &.withClose {
     padding-right: 4px;
   }
 
-  .chip-icon, .chip-avatar {
+  .icon, .avatar {
     &.left {
-      margin-right: $icon-margin;
+      margin-right: var(--spacing-xs);
     }
     &.right {
-      margin-left: $icon-margin;
+      margin-left: var(--spacing-xs);
     }
     &.close {
-      margin-left: $icon-margin;
+      margin-left: var(--spacing-xs);
       color: var(--primary-text-color);
     }
   }
 
   &.disabled {
-    .chip-icon {
+    .icon {
       @include theme-prop(color, disabled-text-color);
     }
     .label {
@@ -56,7 +54,7 @@ $icon-margin: 4px;
   }
 }
 
-@keyframes chips-enter {
+@keyframes chipsEnter {
   0% {
     transform: scale(0.3);
     opacity: 0;

--- a/src/components/Chips/Chips.module.scss
+++ b/src/components/Chips/Chips.module.scss
@@ -9,7 +9,7 @@
   border-radius: 4px;
   padding: 1px 8px;
   align-items: center;
-  margin: 0 4px;
+  margin: 0 var(--spacing-xs);
   user-select: none;
   animation: chipsEnter 100ms;
   animation-timing-function: cubic-bezier(0, 0, 0.35, 1);
@@ -28,7 +28,7 @@
   }
 
   &.withClose {
-    padding-right: 4px;
+    padding-right: var(--spacing-xs);
   }
 
   .icon, .avatar {

--- a/src/components/Chips/__tests__/__snapshots__/chips-snapshot-tests.jest.js.snap
+++ b/src/components/Chips/__tests__/__snapshots__/chips-snapshot-tests.jest.js.snap
@@ -2,7 +2,7 @@
 
 exports[`Chips renders correctly renders correctly disabled chip 1`] = `
 <div
-  className="chips--wrapper disabled"
+  className="chips chips--wrapper disabled"
   data-testid="chip"
   id=""
   onMouseDown={[Function]}
@@ -22,7 +22,7 @@ exports[`Chips renders correctly renders correctly disabled chip 1`] = `
 
 exports[`Chips renders correctly renders correctly with color 1`] = `
 <div
-  className="chips--wrapper with-close"
+  className="chips chips--wrapper withClose"
   data-testid="chip"
   id=""
   onMouseDown={[Function]}
@@ -39,7 +39,7 @@ exports[`Chips renders correctly renders correctly with color 1`] = `
   </div>
   <button
     aria-disabled={false}
-    className="chip-icon close monday-style-button monday-style-button--size-medium monday-style-button--kind-tertiary monday-style-button--color-on-primary-color monday-style-button--no-side-padding"
+    className="icon close monday-style-button monday-style-button--size-medium monday-style-button--kind-tertiary monday-style-button--color-on-primary-color monday-style-button--no-side-padding"
     data-testid="chip-close"
     onBlur={[Function]}
     onClick={[Function]}
@@ -81,7 +81,7 @@ exports[`Chips renders correctly renders correctly with color 1`] = `
 
 exports[`Chips renders correctly renders correctly with empty props 1`] = `
 <div
-  className="chips--wrapper with-close"
+  className="chips chips--wrapper withClose"
   data-testid="chip"
   id=""
   onMouseDown={[Function]}
@@ -98,7 +98,7 @@ exports[`Chips renders correctly renders correctly with empty props 1`] = `
   </div>
   <button
     aria-disabled={false}
-    className="chip-icon close monday-style-button monday-style-button--size-medium monday-style-button--kind-tertiary monday-style-button--color-on-primary-color monday-style-button--no-side-padding"
+    className="icon close monday-style-button monday-style-button--size-medium monday-style-button--kind-tertiary monday-style-button--color-on-primary-color monday-style-button--no-side-padding"
     data-testid="chip-close"
     onBlur={[Function]}
     onClick={[Function]}
@@ -140,7 +140,7 @@ exports[`Chips renders correctly renders correctly with empty props 1`] = `
 
 exports[`Chips renders correctly renders correctly with left avatar 1`] = `
 <div
-  className="chips--wrapper"
+  className="chips chips--wrapper"
   data-testid="chip"
   id=""
   onMouseDown={[Function]}
@@ -151,7 +151,7 @@ exports[`Chips renders correctly renders correctly with left avatar 1`] = `
   }
 >
   <div
-    className="monday-style-avatar chip-avatar left monday-style-avatar--large"
+    className="monday-style-avatar avatar left monday-style-avatar--large"
     style={
       Object {
         "height": 16,
@@ -181,7 +181,7 @@ exports[`Chips renders correctly renders correctly with left avatar 1`] = `
 
 exports[`Chips renders correctly renders correctly with left icon 1`] = `
 <div
-  className="chips--wrapper"
+  className="chips chips--wrapper"
   data-testid="chip"
   id=""
   onMouseDown={[Function]}
@@ -193,7 +193,7 @@ exports[`Chips renders correctly renders correctly with left icon 1`] = `
 >
   <svg
     aria-hidden={true}
-    className="icon_component chip-icon left icon_component--no-focus-style"
+    className="icon_component icon left icon_component--no-focus-style"
     fill="currentColor"
     height="16"
     onClick={[Function]}
@@ -217,7 +217,7 @@ exports[`Chips renders correctly renders correctly with left icon 1`] = `
 
 exports[`Chips renders correctly renders correctly with right avatar 1`] = `
 <div
-  className="chips--wrapper"
+  className="chips chips--wrapper"
   data-testid="chip"
   id=""
   onMouseDown={[Function]}
@@ -233,7 +233,7 @@ exports[`Chips renders correctly renders correctly with right avatar 1`] = `
     
   </div>
   <div
-    className="monday-style-avatar chip-avatar right monday-style-avatar--large"
+    className="monday-style-avatar avatar right monday-style-avatar--large"
     style={
       Object {
         "height": 16,
@@ -258,7 +258,7 @@ exports[`Chips renders correctly renders correctly with right avatar 1`] = `
 
 exports[`Chips renders correctly renders correctly with right icon 1`] = `
 <div
-  className="chips--wrapper"
+  className="chips chips--wrapper"
   data-testid="chip"
   id=""
   onMouseDown={[Function]}
@@ -275,7 +275,7 @@ exports[`Chips renders correctly renders correctly with right icon 1`] = `
   </div>
   <svg
     aria-hidden={true}
-    className="icon_component chip-icon right icon_component--no-focus-style"
+    className="icon_component icon right icon_component--no-focus-style"
     fill="currentColor"
     height="16"
     onClick={[Function]}
@@ -294,7 +294,7 @@ exports[`Chips renders correctly renders correctly with right icon 1`] = `
 
 exports[`Chips renders correctly renders correctly with text 1`] = `
 <div
-  className="chips--wrapper with-close"
+  className="chips chips--wrapper withClose"
   data-testid="chip"
   id=""
   onMouseDown={[Function]}
@@ -311,7 +311,7 @@ exports[`Chips renders correctly renders correctly with text 1`] = `
   </div>
   <button
     aria-disabled={false}
-    className="chip-icon close monday-style-button monday-style-button--size-medium monday-style-button--kind-tertiary monday-style-button--color-on-primary-color monday-style-button--no-side-padding"
+    className="icon close monday-style-button monday-style-button--size-medium monday-style-button--kind-tertiary monday-style-button--color-on-primary-color monday-style-button--no-side-padding"
     data-testid="chip-close"
     onBlur={[Function]}
     onClick={[Function]}
@@ -353,7 +353,7 @@ exports[`Chips renders correctly renders correctly with text 1`] = `
 
 exports[`Chips renders correctly renders correctly without close button 1`] = `
 <div
-  className="chips--wrapper"
+  className="chips chips--wrapper"
   data-testid="chip"
   id=""
   onMouseDown={[Function]}


### PR DESCRIPTION
https://monday.monday.com/boards/245345663/pulses/2867072856

Module styles to Chips in order to avoid css overrides like in case of Etay Liberman (https://monday.slack.com/archives/C02S6F817JQ/p1656349368074379)
Breaking changes, cause originally css styles naming was not unique (`.label`) and there is no way to support backward compatibility. But probably need to change also known usages of Chips where styles get overriding