### PR TITLE
adding property box-sizing to RadioButton

### DIFF
--- a/src/components/RadioButton/RadioButton.scss
+++ b/src/components/RadioButton/RadioButton.scss
@@ -27,6 +27,7 @@
       width: 1em;
       height: 1em;
       border: 0.1em solid;
+      box-sizing: border-box;
       @include theme-prop(border-color, ui-border-color);
       border-radius: 50%;
       transition: border-width 100ms $expand-animation-timing;


### PR DESCRIPTION
<!--

Please go over the checklist and make sure all conditions are met.

--->
adding `box-sizing: border-box` to RadioButton under `__ radio-control `subclass


#### Basic
- [ ] Used plop (`npm run plop`) to create a new component.
- [ ] PR has description.
- [ ] New component is functional and uses Hooks. 
- [ ] Component defines [`PropTypes`](https://reactjs.org/docs/typechecking-with-proptypes.html).
#### Style
- [ ] Styles are added to `NewComponent.modules.scss` file inside of the `NewComponent` folder.
- [ ] Component uses CSS Modules.
- [ ] Design is compatible with [Monday Design System](https://design.monday.com/).
#### Storybook
- [ ] Stories were added to `/src/NewComponent/__stories__/NewComponent.stories.js` file.
- [ ] Stories include all flows of using the component.
#### Tests
- [ ] Tests are compliant with [TESTING_README.md](TESTING_README.md) instructions.
