### PR TITLE
Enable brandFont prop for heading within editable heading.

### DIFF
--- a/src/components/EditableHeading/EditableHeading.jsx
+++ b/src/components/EditableHeading/EditableHeading.jsx
@@ -242,6 +242,7 @@ EditableHeading.propTypes = {
   size: PropTypes.oneOf([EditableHeading.sizes.SMALL, EditableHeading.sizes.MEDIUM, EditableHeading.sizes.LARGE]),
   displayPlaceholderInTextMode: PropTypes.bool,
   suggestEditOnHover: PropTypes.bool,
+  /** Custom font flag, use to enable new font family on H1 headers */
   brandFont: PropTypes.bool,
   autoSize: PropTypes.bool,
   inputAriaLabel: PropTypes.string,

--- a/src/components/EditableHeading/EditableHeading.jsx
+++ b/src/components/EditableHeading/EditableHeading.jsx
@@ -24,6 +24,7 @@ const EditableHeading = props => {
     onIgnoreBlurEvent,
     errorClassTimeout,
     style,
+    brandFont,
     customColor,
     onStartEditing,
     contentRenderer,
@@ -128,7 +129,8 @@ const EditableHeading = props => {
       ellipsisMaxLines: props.ellipsisMaxLines,
       nonEllipsisTooltip: props.tooltip,
       size: props.size,
-      highlightTerm
+      highlightTerm,
+      brandFont
     };
   };
   const renderContentComponent = () => {
@@ -159,6 +161,7 @@ const EditableHeading = props => {
       shouldFocusOnMount: props.shouldFocusOnMount,
       selectOnMount: props.selectOnMount,
       inputType,
+      brandFont,
       ignoreBlurClass: props.ignoreBlurClass,
       autoSize: props.autoSize,
       textareaSubmitOnEnter: props.textareaSubmitOnEnter,
@@ -239,6 +242,7 @@ EditableHeading.propTypes = {
   size: PropTypes.oneOf([EditableHeading.sizes.SMALL, EditableHeading.sizes.MEDIUM, EditableHeading.sizes.LARGE]),
   displayPlaceholderInTextMode: PropTypes.bool,
   suggestEditOnHover: PropTypes.bool,
+  brandFont: PropTypes.bool,
   autoSize: PropTypes.bool,
   inputAriaLabel: PropTypes.string,
   placeholder: PropTypes.string,
@@ -277,6 +281,7 @@ EditableHeading.defaultProps = {
   dataTestId: "",
   inputClassName: "",
   insetFocus: false,
+  brandFont: false,
   maxLength: undefined
 };
 

--- a/src/components/EditableHeading/__stories__/EditableHeading.stories.mdx
+++ b/src/components/EditableHeading/__stories__/EditableHeading.stories.mdx
@@ -58,7 +58,7 @@ An extension of Heading component, it allows built in editing capabilities
 
 <Canvas>
   <Story name="Types">
-    <EditableHeading type={EditableHeading.types.h1} value="H1 Header" />
+    <EditableHeading type={EditableHeading.types.h1} value="H1 Header" brandFont={true} />
     <EditableHeading type={EditableHeading.types.h2} value="H2 Header" />
     <EditableHeading type={EditableHeading.types.h3} value="H3 Header" />
     <EditableHeading type={EditableHeading.types.h4} value="H4 Header" />

--- a/src/components/EditableHeading/__stories__/EditableHeading.stories.mdx
+++ b/src/components/EditableHeading/__stories__/EditableHeading.stories.mdx
@@ -1,17 +1,17 @@
 import EditableHeading from "../EditableHeading";
-import { ArgsTable, Story, Canvas, Meta } from "@storybook/addon-docs";
-import { createComponentTemplate, createStoryMetaSettings } from "../../../storybook/functions/create-component-story";
+import {ArgsTable, Story, Canvas, Meta} from "@storybook/addon-docs";
+import {createComponentTemplate, createStoryMetaSettings} from "../../../storybook/functions/create-component-story";
 
 export const metaSettings = createStoryMetaSettings({
-  component: EditableHeading,
-  enumPropNamesArray: ["size", "type"]
+    component: EditableHeading,
+    enumPropNamesArray: ["size", "type"]
 });
 
 <Meta
-  title="Inputs/EditableHeading"
-  component={EditableHeading}
-  argTypes={metaSettings.argTypes}
-  decorators={metaSettings.decorators}
+    title="Inputs/EditableHeading"
+    component={EditableHeading}
+    argTypes={metaSettings.argTypes}
+    decorators={metaSettings.decorators}
 />
 
 <!--- Component template -->
@@ -33,23 +33,23 @@ export const editableHeadingTemplate = createComponentTemplate(EditableHeading);
 An extension of Heading component, it allows built in editing capabilities
 
 <Canvas>
-  <Story name="Overview" args={{ value: "This heading is editable", type: EditableHeading.types.h1 }}>
-    {editableHeadingTemplate.bind({})}
-  </Story>
+    <Story name="Overview" args={{value: "This heading is editable", type: EditableHeading.types.h1, brandFont: true}}>
+        {editableHeadingTemplate.bind({})}
+    </Story>
 </Canvas>
 
 ## Props
 
-<ArgsTable of={EditableHeading} />
+<ArgsTable of={EditableHeading}/>
 
 ## Usage
 
 <UsageGuidelines
-  guidelines={[
-    "Use when the title (Heading) is editable and you want to inline edit it",
-    "Always provide a meaningful placeholder",
-    "The component takes 100% of width and height of its container"
-  ]}
+    guidelines={[
+        "Use when the title (Heading) is editable and you want to inline edit it",
+        "Always provide a meaningful placeholder",
+        "The component takes 100% of width and height of its container"
+    ]}
 />
 
 ## Variants
@@ -57,40 +57,40 @@ An extension of Heading component, it allows built in editing capabilities
 ### Heading types
 
 <Canvas>
-  <Story name="Types">
-    <EditableHeading type={EditableHeading.types.h1} value="H1 Header" brandFont={true} />
-    <EditableHeading type={EditableHeading.types.h2} value="H2 Header" />
-    <EditableHeading type={EditableHeading.types.h3} value="H3 Header" />
-    <EditableHeading type={EditableHeading.types.h4} value="H4 Header" />
-    <EditableHeading type={EditableHeading.types.h5} value="H5 Header" />
-    <EditableHeading type={EditableHeading.types.h6} value="H6 Header" />
-  </Story>
+    <Story name="Types">
+        <EditableHeading type={EditableHeading.types.h1} value="H1 Header" brandFont={true}/>
+        <EditableHeading type={EditableHeading.types.h2} value="H2 Header"/>
+        <EditableHeading type={EditableHeading.types.h3} value="H3 Header"/>
+        <EditableHeading type={EditableHeading.types.h4} value="H4 Header"/>
+        <EditableHeading type={EditableHeading.types.h5} value="H5 Header"/>
+        <EditableHeading type={EditableHeading.types.h6} value="H6 Header"/>
+    </Story>
 </Canvas>
 
 ### Placeholder
 
 <Canvas>
-  <Story name="Placeholder">
-    <EditableHeading type={EditableHeading.types.h1} placeholder="H1 Placeholder" />
-  </Story>
+    <Story name="Placeholder">
+        <EditableHeading type={EditableHeading.types.h1} placeholder="H1 Placeholder" brandFont={true}/>
+    </Story>
 </Canvas>
 
 ### With text highlight
 
 <Canvas>
-  <Story name="Text Highlight">
-    <EditableHeading type={EditableHeading.types.h1} value="H1 Header" highlightTerm="head" />
-    <EditableHeading type={EditableHeading.types.h2} value="H2 Header" highlightTerm="head" />
-    <EditableHeading type={EditableHeading.types.h3} value="H3 Header" highlightTerm="head" />
-  </Story>
+    <Story name="Text Highlight">
+        <EditableHeading type={EditableHeading.types.h1} value="H1 Header" highlightTerm="head" brandFont={true}/>
+        <EditableHeading type={EditableHeading.types.h2} value="H2 Header" highlightTerm="head"/>
+        <EditableHeading type={EditableHeading.types.h3} value="H3 Header" highlightTerm="head"/>
+    </Story>
 </Canvas>
 
 ### With text colors
 
 <Canvas>
-  <Story name="Colors">
-    <EditableHeading type={EditableHeading.types.h1} value="H1 Header" customColor="blue" />
-    <EditableHeading type={EditableHeading.types.h2} value="H2 Header" customColor="red" />
-    <EditableHeading type={EditableHeading.types.h3} value="H3 Header" highlightTerm="head" customColor="#AA33FF" />
-  </Story>
+    <Story name="Colors">
+        <EditableHeading type={EditableHeading.types.h1} value="H1 Header" customColor="blue" brandFont={true}/>
+        <EditableHeading type={EditableHeading.types.h2} value="H2 Header" customColor="red"/>
+        <EditableHeading type={EditableHeading.types.h3} value="H3 Header" highlightTerm="head" customColor="#AA33FF"/>
+    </Story>
 </Canvas>

--- a/src/components/Heading/Heading.jsx
+++ b/src/components/Heading/Heading.jsx
@@ -99,6 +99,7 @@ Heading.propTypes = {
   size: PropTypes.oneOf([Heading.sizes.SMALL, Heading.sizes.MEDIUM, Heading.sizes.LARGE]),
   highlightTerm: PropTypes.string,
   customColor: PropTypes.string,
+  /** Custom font flag, use to enable new font family on H1 headers */
   brandFont: PropTypes.bool
 };
 


### PR DESCRIPTION
https://monday.monday.com/boards/2861766393/pulses/2963392067
* Add brandFont prop
* Edit storybook example

<!--

Please go over the checklist and make sure all conditions are met.

--->

#### Basic
- [ ] Used plop (`npm run plop`) to create a new component.
- [ ] PR has description.
- [ ] New component is functional and uses Hooks. 
- [ ] Component defines [`PropTypes`](https://reactjs.org/docs/typechecking-with-proptypes.html).
#### Style
- [ ] Styles are added to `NewComponent.modules.scss` file inside of the `NewComponent` folder.
- [ ] Component uses CSS Modules.
- [ ] Design is compatible with [Monday Design System](https://design.monday.com/).
#### Storybook
- [ ] Stories were added to `/src/NewComponent/__stories__/NewComponent.stories.js` file.
- [ ] Stories include all flows of using the component.
#### Tests
- [ ] Tests are compliant with [TESTING_README.md](TESTING_README.md) instructions.
