### PR TITLE
Manually update monday-ui-style version to 0.1.132

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "classnames": "^2.3.1",
         "detect-browser": "^5.3.0",
         "lodash": "^4.17.21",
-        "monday-ui-style": "0.1.131",
+        "monday-ui-style": "0.1.132",
         "prop-types": "^15.8.1",
         "react-inlinesvg": "^2.3.0",
         "react-popper": "^2.3.0",
@@ -24177,9 +24177,9 @@
       }
     },
     "node_modules/monday-ui-style": {
-      "version": "0.1.131",
-      "resolved": "https://registry.npmjs.org/monday-ui-style/-/monday-ui-style-0.1.131.tgz",
-      "integrity": "sha512-XlBznU/DNlwqAmMn9l6BrGWXgp0JIVRrmQS+MPi29F2iWvysgbzJAOnUwqrnsoit0PpEeOA+BLXdT+of5c0xvQ==",
+      "version": "0.1.132",
+      "resolved": "https://registry.npmjs.org/monday-ui-style/-/monday-ui-style-0.1.132.tgz",
+      "integrity": "sha512-4sQiduRTUdsG82BMPST6rHpMmwG4co5kbu2n2BdLG2s57HNcvPjafGP367+53UC59p+HZYU+uhiFC84jiecKew==",
       "dependencies": {
         "postcss": "8.4.4",
         "postcss-scss": "^4.0.3",
@@ -52348,9 +52348,9 @@
       }
     },
     "monday-ui-style": {
-      "version": "0.1.131",
-      "resolved": "https://registry.npmjs.org/monday-ui-style/-/monday-ui-style-0.1.131.tgz",
-      "integrity": "sha512-XlBznU/DNlwqAmMn9l6BrGWXgp0JIVRrmQS+MPi29F2iWvysgbzJAOnUwqrnsoit0PpEeOA+BLXdT+of5c0xvQ==",
+      "version": "0.1.132",
+      "resolved": "https://registry.npmjs.org/monday-ui-style/-/monday-ui-style-0.1.132.tgz",
+      "integrity": "sha512-4sQiduRTUdsG82BMPST6rHpMmwG4co5kbu2n2BdLG2s57HNcvPjafGP367+53UC59p+HZYU+uhiFC84jiecKew==",
       "requires": {
         "postcss": "8.4.4",
         "postcss-scss": "^4.0.3",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "classnames": "^2.3.1",
     "detect-browser": "^5.3.0",
     "lodash": "^4.17.21",
-    "monday-ui-style": "0.1.131",
+    "monday-ui-style": "0.1.132",
     "prop-types": "^15.8.1",
     "react-inlinesvg": "^2.3.0",
     "react-popper": "^2.3.0",


### PR DESCRIPTION
Something went wrong with the `Update monday-ui-style` Github action. It detected the latest version and installed it without errors, but this changes weren't merged to the master. Rerun doesn't help. So doing it manually for now

https://github.com/mondaycom/monday-ui-react-core/runs/7429513118?check_suite_focus=true
![image](https://user-images.githubusercontent.com/104433616/180000643-72e0a83f-2888-49d1-8fd3-c0a1d030228b.png)
