### PR TITLE
add exports to package.json + build icons esm file

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,8 +2,15 @@
   "name": "monday-ui-react-core",
   "version": "1.50.1",
   "description": "Official monday.com UI resources for application development in React.js",
-  "main": "dist/main.js",
-  "module": "dist/esm.js",
+  "main": "./dist/main.js",
+  "exports": {
+    ".": {
+      "import": "./dist/esm.js",
+      "default": "./dist/main.js"
+    },
+    "./dist/": "./dist/",
+    "./icons": "./dist/icons/index.js"
+  },
   "scripts": {
     "auto:bump-patch": "node scripts/autobump_patch.js",
     "auto:bump-minor": "node scripts/autobump_minor.js",

--- a/scripts/build-esm.js
+++ b/scripts/build-esm.js
@@ -4,8 +4,24 @@ const fs = require("fs");
 const path = require("path");
 const { publishedComponents } = require("../webpack/published-components");
 
-const content = Object.keys(publishedComponents)
-  .map(componentName => `export { default as ${componentName} } from "./${componentName}";`)
-  .join("\n");
+function buildComponentsEsmFile() {
+  const content = Object.keys(publishedComponents)
+    .map(componentName => `export { default as ${componentName} } from "./${componentName}";`)
+    .join("\n");
 
-fs.writeFileSync(path.join(__dirname, "../dist/esm.js"), content, "utf8");
+  fs.writeFileSync(path.join(__dirname, "../dist/esm.js"), content, "utf8");
+}
+
+function buildIconsEsmFile() {
+  const icons = fs.readdirSync(path.join(__dirname, "../dist/icons")).filter(file => file !== "index.js");
+  const iconsContent = icons
+    .map(name => {
+      const nameWithoutExtention = name.split(".")[0];
+      return `export { default as ${nameWithoutExtention} } from "./${nameWithoutExtention}";`;
+    })
+    .join("\n");
+  fs.writeFileSync(path.join(__dirname, "../dist/icons/index.js"), iconsContent, "utf8");
+}
+
+buildComponentsEsmFile();
+buildIconsEsmFile();


### PR DESCRIPTION
https://monday.monday.com/boards/245345663/views/62248892/pulses/2970462587

using [exports](https://webpack.js.org/guides/package-exports/) in package json to specify path for icons pointing to a newly created dist/icons/index.js file listing all available icons to support tree shaking.

We can now do `import { Close } from 'monday-ui-react-core/icons';` and tree shaking works fine.  
CommonJs and /dist path mapping still works for backward compatibility but I think we should add a dageroid rule discouraging linking directly into the dist folder