### PR TITLE
AttentionBox - close icon button instead of icon

### DIFF
--- a/src/components/AttentionBox/AttentionBox.jsx
+++ b/src/components/AttentionBox/AttentionBox.jsx
@@ -2,12 +2,15 @@ import React, { useMemo } from "react";
 import PropTypes from "prop-types";
 import cx from "classnames";
 import Icon from "../../components/Icon/Icon";
+import IconButton from "../IconButton/IconButton";
 import CloseSmall from "../../components/Icon/Icons/components/CloseSmall";
 import AlertIcon from "../../components/Icon/Icons/components/Alert";
 import { ICON_TYPES } from "../../components/Icon/IconConstants";
 import { backwardCompatibilityForProperties } from "../../helpers/backwardCompatibilityForProperties";
-import { baseClassName, closeClassName, compactClassName, ATTENTION_BOX_TYPES } from "./AttentionBoxConstants";
+import { ATTENTION_BOX_TYPES } from "./AttentionBoxConstants";
 import "./AttentionBox.scss";
+
+const ATTENTION_BOX_CSS_BASE_CLASS = "monday-style-attention-box-component";
 
 const AttentionBox = ({
   className,
@@ -37,42 +40,47 @@ const AttentionBox = ({
   }, [type]);
 
   const overrideClassName = backwardCompatibilityForProperties([className, componentClassName]);
-  const classNameWithType = `${baseClassName}--type-${type}`;
+  const classNameWithType = `${ATTENTION_BOX_CSS_BASE_CLASS}--type-${type}`;
   return (
     <aside
       className={cx(
-        baseClassName,
+        ATTENTION_BOX_CSS_BASE_CLASS,
         classNameWithType,
-        { [compactClassName]: compact },
-        { [closeClassName]: onClose },
+        { compact: compact, "with-close": onClose },
         overrideClassName
       )}
       role="alert"
     >
       {title && (
-        <h2 className={cx(`${baseClassName}__title-container`, `${classNameWithType}__title-container`)}>
+        <h2 className={cx(`${ATTENTION_BOX_CSS_BASE_CLASS}__title-container`, `${classNameWithType}__title-container`)}>
           {!withoutIcon && (
             <Icon
               iconType={iconType}
               ariaHidden
               clickable={false}
               icon={icon}
-              className={cx(`${baseClassName}__title-container__icon`, `${classNameWithType}__title-container__icon`)}
+              className={cx(
+                `${ATTENTION_BOX_CSS_BASE_CLASS}__title-container__icon`,
+                `${classNameWithType}__title-container__icon`
+              )}
               ignoreFocusStyle
               iconSize="24"
               iconLabel={iconLabel}
             />
           )}
           <span
-            className={cx(`${baseClassName}__title-container__title`, `${classNameWithType}__title-container__title`)}
+            className={cx(
+              `${ATTENTION_BOX_CSS_BASE_CLASS}__title-container__title`,
+              `${classNameWithType}__title-container__title`
+            )}
           >
             {title}
           </span>
         </h2>
       )}
       <div
-        className={cx(`${baseClassName}__text`, `${classNameWithType}__text`, {
-          [`${baseClassName}_text--compact`]: compact
+        className={cx(`${ATTENTION_BOX_CSS_BASE_CLASS}__text`, `${classNameWithType}__text`, {
+          [`${ATTENTION_BOX_CSS_BASE_CLASS}_text--compact`]: compact
         })}
       >
         {!title && compact && !withoutIcon && withIconWithoutHeader && (
@@ -82,7 +90,10 @@ const AttentionBox = ({
             ariaHidden
             clickable={false}
             icon={icon}
-            className={cx(`${baseClassName}__title-container__icon`, `${classNameWithType}__title-container__icon`)}
+            className={cx(
+              `${ATTENTION_BOX_CSS_BASE_CLASS}__title-container__icon`,
+              `${classNameWithType}__title-container__icon`
+            )}
             ignoreFocusStyle
             iconLabel={iconLabel}
           />
@@ -90,14 +101,16 @@ const AttentionBox = ({
         {text}
       </div>
       {onClose && (
-        <Icon
-          iconType={Icon.type.SVG}
-          iconLabel="Close"
+        <IconButton
+          size={IconButton.sizes.SMALL}
+          color={IconButton.colors.ON_PRIMARY_COLOR}
+          className={cx(`${ATTENTION_BOX_CSS_BASE_CLASS}__close-icon`, "icon")}
+          wrapperClassName={cx(`${ATTENTION_BOX_CSS_BASE_CLASS}__close-icon`, "wrapper", {
+            compact: compact
+          })}
+          ariaLabel="Close"
           icon={CloseSmall}
-          className={cx(`${baseClassName}__close-icon`, { [compactClassName]: compact })}
-          ignoreFocusStyle
           onClick={onClose}
-          iconSize="24"
         />
       )}
     </aside>

--- a/src/components/AttentionBox/AttentionBox.jsx
+++ b/src/components/AttentionBox/AttentionBox.jsx
@@ -104,9 +104,9 @@ const AttentionBox = ({
         <IconButton
           size={IconButton.sizes.SMALL}
           color={IconButton.colors.ON_PRIMARY_COLOR}
-          className={cx(`${ATTENTION_BOX_CSS_BASE_CLASS}__close-icon`, "icon")}
-          wrapperClassName={cx(`${ATTENTION_BOX_CSS_BASE_CLASS}__close-icon`, "wrapper", {
-            compact: compact
+          className={cx(`${ATTENTION_BOX_CSS_BASE_CLASS}__close-icon`)}
+          wrapperClassName={cx(`${ATTENTION_BOX_CSS_BASE_CLASS}__close-icon--wrapper`, {
+            [`${ATTENTION_BOX_CSS_BASE_CLASS}__close-icon--compact`]: compact
           })}
           ariaLabel="Close"
           icon={CloseSmall}

--- a/src/components/AttentionBox/AttentionBox.scss
+++ b/src/components/AttentionBox/AttentionBox.scss
@@ -81,15 +81,15 @@
   }
 
   &__close-icon {
-    &.wrapper {
+    &.monday-style-attention-box-component__close-icon {
+      color: var(--primary-text-color);
+    }
+    &--wrapper {
       position: absolute;
       top: $spacing-small-medium;
       right: $spacing-small-medium;
     }
-    &.icon {
-      color: var(--primary-text-color);
-    }
-    &.compact {
+    &--compact {
       top: calc(50% - 16px);
     }
   }

--- a/src/components/AttentionBox/AttentionBox.scss
+++ b/src/components/AttentionBox/AttentionBox.scss
@@ -80,13 +80,17 @@
     }
   }
 
-  & &__close-icon {
-    position: absolute;
-    top: $spacing-small-medium;
-    right: $spacing-small-medium;
-
-    &.compact{
-      top: calc(50% - 12px);
+  &__close-icon {
+    &.wrapper {
+      position: absolute;
+      top: $spacing-small-medium;
+      right: $spacing-small-medium;
+    }
+    &.icon {
+      color: var(--primary-text-color);
+    }
+    &.compact {
+      top: calc(50% - 16px);
     }
   }
 }

--- a/src/components/AttentionBox/AttentionBoxConstants.js
+++ b/src/components/AttentionBox/AttentionBoxConstants.js
@@ -1,7 +1,3 @@
-export const baseClassName = "monday-style-attention-box-component";
-export const closeClassName = "with-close";
-export const compactClassName = "compact";
-
 export const ATTENTION_BOX_TYPES = {
   PRIMARY: "primary",
   SUCCESS: "success",

--- a/src/components/AttentionBox/__tests__/__snapshots__/attentionBox-snapshot-tests.jest.js.snap
+++ b/src/components/AttentionBox/__tests__/__snapshots__/attentionBox-snapshot-tests.jest.js.snap
@@ -238,7 +238,7 @@ exports[`AttentionBox renders correctly renders correctly with onClose 1`] = `
     Text
   </div>
   <div
-    className="monday-style-attention-box-component__close-icon wrapper wrapper"
+    className="monday-style-attention-box-component__close-icon--wrapper wrapper"
   >
     <span
       className="referenceWrapper"
@@ -253,7 +253,7 @@ exports[`AttentionBox renders correctly renders correctly with onClose 1`] = `
       <button
         aria-disabled={false}
         aria-label="Close"
-        className="monday-style-attention-box-component__close-icon icon monday-style-button monday-style-button--size-medium monday-style-button--kind-tertiary monday-style-button--color-on-primary-color monday-style-button--no-side-padding"
+        className="monday-style-attention-box-component__close-icon monday-style-button monday-style-button--size-medium monday-style-button--kind-tertiary monday-style-button--color-on-primary-color monday-style-button--no-side-padding"
         data-testid="icon-button"
         onBlur={[Function]}
         onClick={[Function]}

--- a/src/components/AttentionBox/__tests__/__snapshots__/attentionBox-snapshot-tests.jest.js.snap
+++ b/src/components/AttentionBox/__tests__/__snapshots__/attentionBox-snapshot-tests.jest.js.snap
@@ -237,25 +237,59 @@ exports[`AttentionBox renders correctly renders correctly with onClose 1`] = `
   >
     Text
   </div>
-  <svg
-    aria-hidden={false}
-    aria-label="Close"
-    className="icon_component monday-style-attention-box-component__close-icon icon_component--clickable icon_component--no-focus-style"
-    fill="currentColor"
-    height="24"
-    onClick={[Function]}
-    role="button"
-    tabIndex={0}
-    viewBox="0 0 20 20"
-    width="24"
+  <div
+    className="monday-style-attention-box-component__close-icon wrapper wrapper"
   >
-    <path
-      clipRule="evenodd"
-      d="M6.53033 5.46967C6.23744 5.17678 5.76256 5.17678 5.46967 5.46967C5.17678 5.76256 5.17678 6.23744 5.46967 6.53033L8.62562 9.68628L5.47045 12.8415C5.17756 13.1343 5.17756 13.6092 5.47045 13.9021C5.76334 14.195 6.23822 14.195 6.53111 13.9021L9.68628 10.7469L12.8415 13.9021C13.1343 14.195 13.6092 14.195 13.9021 13.9021C14.195 13.6092 14.195 13.1343 13.9021 12.8415L10.7469 9.68628L13.9029 6.53033C14.1958 6.23744 14.1958 5.76256 13.9029 5.46967C13.61 5.17678 13.1351 5.17678 12.8422 5.46967L9.68628 8.62562L6.53033 5.46967Z"
-      fill="currentColor"
-      fillRule="evenodd"
-    />
-  </svg>
+    <span
+      className="referenceWrapper"
+      onBlur={[Function]}
+      onClick={[Function]}
+      onFocus={[Function]}
+      onKeyDown={[Function]}
+      onMouseDown={[Function]}
+      onMouseEnter={[Function]}
+      onMouseLeave={[Function]}
+    >
+      <button
+        aria-disabled={false}
+        aria-label="Close"
+        className="monday-style-attention-box-component__close-icon icon monday-style-button monday-style-button--size-medium monday-style-button--kind-tertiary monday-style-button--color-on-primary-color monday-style-button--no-side-padding"
+        data-testid="icon-button"
+        onBlur={[Function]}
+        onClick={[Function]}
+        onFocus={[Function]}
+        onMouseDown={[Function]}
+        onMouseUp={[Function]}
+        style={
+          Object {
+            "alignItems": "center",
+            "height": "32px",
+            "justifyContent": "center",
+            "padding": 0,
+            "width": "32px",
+          }
+        }
+        type="button"
+      >
+        <svg
+          aria-hidden={true}
+          className="icon_component icon-button-padding icon_component--no-focus-style"
+          fill="currentColor"
+          height="20"
+          onClick={[Function]}
+          viewBox="0 0 20 20"
+          width="20"
+        >
+          <path
+            clipRule="evenodd"
+            d="M6.53033 5.46967C6.23744 5.17678 5.76256 5.17678 5.46967 5.46967C5.17678 5.76256 5.17678 6.23744 5.46967 6.53033L8.62562 9.68628L5.47045 12.8415C5.17756 13.1343 5.17756 13.6092 5.47045 13.9021C5.76334 14.195 6.23822 14.195 6.53111 13.9021L9.68628 10.7469L12.8415 13.9021C13.1343 14.195 13.6092 14.195 13.9021 13.9021C14.195 13.6092 14.195 13.1343 13.9021 12.8415L10.7469 9.68628L13.9029 6.53033C14.1958 6.23744 14.1958 5.76256 13.9029 5.46967C13.61 5.17678 13.1351 5.17678 12.8422 5.46967L9.68628 8.62562L6.53033 5.46967Z"
+            fill="currentColor"
+            fillRule="evenodd"
+          />
+        </svg>
+      </button>
+    </span>
+  </div>
 </aside>
 `;
 


### PR DESCRIPTION
https://monday.monday.com/boards/2861766393/pulses/3086884014

[Chromatic link](https://62037c72e0e4d6004a9a450f-hctauvthuj.chromatic.com/?path=/docs/feedback-attentionbox--overview)

<img width="413" alt="image" src="https://user-images.githubusercontent.com/104433616/185382249-35e702ce-3d27-4f87-b876-6c441940f0a4.png">

- Need to pay attention to Icon size. It's 20 x 20 now, not 24 x 24 as it was before. This happens due to limitations of current IconButton implementation - you can get Icon size = 24 only if `size` prop of `IconButton` equals `undefined`, but that's really not ever going to happen, cause there is a default value for `size: IconButton.sizes.MEDIUM`. So probably need to fix this `IconButton` logic as well
- Should tooltip be displayed on button focus?
- Also some refactor was made to make further css modules automation easier :)