### PR TITLE
Feature/sergeyro/disable styleint rule for global pseudo class

### DIFF
--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -2,6 +2,7 @@
   "extends": "stylelint-config-recommended-scss",
   "rules": {
     "no-descending-specificity": null,
-    "no-duplicate-selectors": null
+    "no-duplicate-selectors": null,
+    "selector-pseudo-class-no-unknown": ["global"]
   }
 }

--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -3,6 +3,11 @@
   "rules": {
     "no-descending-specificity": null,
     "no-duplicate-selectors": null,
-    "selector-pseudo-class-no-unknown": ["global"]
+    "selector-pseudo-class-no-unknown": [
+      true,
+      {
+        "ignorePseudoClasses": ["global"]
+      }
+    ]
   }
 }

--- a/src/components/Chips/Chips.module.scss
+++ b/src/components/Chips/Chips.module.scss
@@ -2,7 +2,7 @@
 @import "../../styles/typography";
 @import "../../styles/states";
 
-.chips {
+:global(.chips) {
   display: inline-flex;
   overflow: hidden;
   height: 24px;

--- a/src/components/Chips/Chips.module.scss
+++ b/src/components/Chips/Chips.module.scss
@@ -2,7 +2,7 @@
 @import "../../styles/typography";
 @import "../../styles/states";
 
-:global(.chips) {
+.chips {
   display: inline-flex;
   overflow: hidden;
   height: 24px;
@@ -30,7 +30,8 @@
     padding-right: var(--spacing-xs);
   }
 
-  .icon, .avatar {
+  .icon,
+  .avatar {
     &.left {
       margin-right: var(--spacing-xs);
     }


### PR DESCRIPTION
Disable this kind of errors
<img width="768" alt="image" src="https://user-images.githubusercontent.com/104433616/187077683-8eef2273-9dbd-4eaf-945c-5b548f099d44.png">
I'm using `:global` pseudo class name in css-modules migration for overriding classes of another components directly through css. Perhaps after the migration we might want to refactor it and to make it work through props passing, but not now, cause it'll make the validation of the migration more difficult
