### PR TITLE
feat(checkbox): add ability to render component without label

### DIFF
--- a/src/components/Checkbox/Checkbox.js
+++ b/src/components/Checkbox/Checkbox.js
@@ -99,7 +99,7 @@ export const Checkbox = forwardRef(
             iconSize="16"
           />
         </div>
-        <span className={`${BASE_CLASS_NAME}__label`}>{label}</span>
+        {label === false ? null : <span className={`${BASE_CLASS_NAME}__label`}>{label}</span>}
       </label>
     );
   }
@@ -108,7 +108,7 @@ export const Checkbox = forwardRef(
 Checkbox.propTypes = {
   id: PropTypes.string,
   className: PropTypes.string,
-  label: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
+  label: PropTypes.oneOfType([PropTypes.string, PropTypes.element, PropTypes.bool]),
   ariaLabelledBy: PropTypes.string,
   onChange: PropTypes.func,
   checked: PropTypes.bool,

--- a/src/components/Checkbox/__stories__/checkbox.stories.mdx
+++ b/src/components/Checkbox/__stories__/checkbox.stories.mdx
@@ -1,9 +1,9 @@
 import { ArgsTable, Story, Canvas, Meta } from "@storybook/addon-docs";
 import Checkbox from "../Checkbox";
-import { createComponentTemplate } from "../../../storybook/functions/create-component-story";
+import { Link, UnstyledList, UnstyledListItem, createComponentTemplate } from "../../../storybook";
+import { Calendar } from "../../Icon/Icons";
 import { RADIO_BUTTON, TOGGLE, DROPDOWN } from "../../../storybook/components/related-components/component-description-map";
 import DialogContentContainer from "../../DialogContentContainer/DialogContentContainer";
-import { Link } from "../../../storybook/components";
 import "./checkbox.stories.scss";
 
 <Meta
@@ -66,6 +66,25 @@ Has 4 states: regular, hover, selected, and disabled.
     <Checkbox label="Disabled" disabled />
     <Checkbox label="Disabled checked" disabled checked />
     <Checkbox label="Disabled indeterminate" disabled indeterminate />
+  </Story>
+</Canvas>
+
+### Variants of Checkboxes' Labels
+Component have ability to render with:
+<UnstyledList>
+  <UnstyledListItem>with text label</UnstyledListItem>
+  <UnstyledListItem>with component label</UnstyledListItem>
+  <UnstyledListItem>with empty label (empty DOM element will be rendered)</UnstyledListItem>
+  <UnstyledListItem>without label (DOM element for label will not be rendered).</UnstyledListItem>
+</UnstyledList>
+Check React source and rendered HTML.
+
+<Canvas>
+  <Story name="Labels">
+    <Checkbox ariaLabel="With Label" label="With label" />
+    <Checkbox ariaLabel="With Component Label" label={<span class="custom-component-label"><Calendar size={12}/>Component Label</span>} />
+    <Checkbox ariaLabel="With Empty Label" label="" />
+    <Checkbox ariaLabel="Without Label" label={false} />
   </Story>
 </Canvas>
 

--- a/src/components/Checkbox/__stories__/checkbox.stories.mdx
+++ b/src/components/Checkbox/__stories__/checkbox.stories.mdx
@@ -82,7 +82,7 @@ Check React source and rendered HTML.
 <Canvas>
   <Story name="Labels">
     <Checkbox ariaLabel="With Label" label="With label" />
-    <Checkbox ariaLabel="With Component Label" label={<span class="custom-component-label"><Calendar size={12}/>Component Label</span>} />
+    <Checkbox ariaLabel="With Component Label" label={<span class="custom-component-label"><Calendar size="12" />Component Label</span>} />
     <Checkbox ariaLabel="With Empty Label" label="" />
     <Checkbox ariaLabel="Without Label" label={false} />
   </Story>

--- a/src/components/Checkbox/__tests__/__snapshots__/checkbox-snapshot-tests.jest.js.snap
+++ b/src/components/Checkbox/__tests__/__snapshots__/checkbox-snapshot-tests.jest.js.snap
@@ -372,3 +372,42 @@ exports[`Checkbox renders correctly with value 1`] = `
   />
 </label>
 `;
+
+exports[`Checkbox renders correctly without label 1`] = `
+<label
+  className="monday-style-checkbox"
+  onClickCapture={[Function]}
+  onMouseUp={[Function]}
+>
+  <input
+    aria-label={false}
+    className="monday-style-checkbox__input"
+    defaultChecked={false}
+    disabled={false}
+    name=""
+    onChange={[Function]}
+    type="checkbox"
+    value=""
+  />
+  <div
+    className="monday-style-checkbox__checkbox monday-style-checkbox__prevent-animation"
+  >
+    <svg
+      aria-hidden={true}
+      className="icon_component monday-style-checkbox__icon icon_component--no-focus-style"
+      fill="currentColor"
+      height="16"
+      onClick={[Function]}
+      viewBox="0 0 20 20"
+      width="16"
+    >
+      <path
+        clipRule="evenodd"
+        d="M8.53033 14.2478L8 13.7175L7.46967 14.2478C7.76256 14.5407 8.23744 14.5407 8.53033 14.2478ZM8 12.6569L4.53033 9.18718C4.23744 8.89429 3.76256 8.89429 3.46967 9.18718C3.17678 9.48008 3.17678 9.95495 3.46967 10.2478L7.46967 14.2478L8 13.7175L8.53033 14.2478L16.2478 6.53033C16.5407 6.23743 16.5407 5.76256 16.2478 5.46967C15.955 5.17677 15.4801 5.17677 15.1872 5.46967L8 12.6569Z"
+        fill="currentColor"
+        fillRule="evenodd"
+      />
+    </svg>
+  </div>
+</label>
+`;

--- a/src/components/Checkbox/__tests__/checkbox-snapshot-tests.jest.js
+++ b/src/components/Checkbox/__tests__/checkbox-snapshot-tests.jest.js
@@ -49,4 +49,9 @@ describe("Checkbox renders correctly", () => {
     const tree = renderer.create(<Checkbox ariaLabelledBy="aria" />).toJSON();
     expect(tree).toMatchSnapshot();
   });
+
+  it("without label", () => {
+    const tree = renderer.create(<Checkbox label={false} />).toJSON();
+    expect(tree).toMatchSnapshot();
+  });
 });


### PR DESCRIPTION
 - as part of effort to reduce number DOM nodes
 - for some repeated elements (ex.: cells in table)
   it is important to remove unneeded DOM elements
   
#### Basic
- [x] PR has description.
- [x] Component defines [`PropTypes`](https://reactjs.org/docs/typechecking-with-proptypes.html).
#### Storybook
- [x] Stories include all flows of using the component.
#### Tests
- [x] Tests are compliant with [TESTING_README.md](TESTING_README.md) instructions.


![Screen Shot 2022-09-06 at 12 48 28](https://user-images.githubusercontent.com/96241324/188604292-8f722f9c-65c0-4890-9cdc-66299592b7fc.png)
