### PR TITLE
Feature/sergeyro/ts infra css modules

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -58,10 +58,25 @@ const commonExtends = ["plugin:react/recommended", "plugin:react-hooks/recommend
 module.exports = {
   overrides: [
     {
-      files: ["*.jest.js"],
+      files: ["*.jest.js", "jest.setup.js", "jest.init.js"],
       env: {
         jest: true,
         "jest/globals": true
+      }
+    },
+    {
+      files: [
+        "webpack.config.js",
+        "plopfile.js",
+        "babel.config.js",
+        ".eslintrc.js",
+        "scripts/**/*.js",
+        "webpack/**/*.js",
+        "__mocks__/**/*.js",
+        "plop/**/*.js"
+      ],
+      env: {
+        node: true
       }
     },
     {

--- a/src/helpers/typesciptCssModulesHelper.ts
+++ b/src/helpers/typesciptCssModulesHelper.ts
@@ -3,6 +3,6 @@
  * @param styles modular styles object
  * @param key string classname
  */
-export function getStyle<StylesType>(styles: StylesType, key: string): StylesType[keyof StylesType] | undefined {
+export function getStyle<StylesType>(styles: StylesType, key: string) {
   return styles[key as keyof typeof styles];
 }

--- a/src/helpers/typesciptCssModulesHelper.ts
+++ b/src/helpers/typesciptCssModulesHelper.ts
@@ -1,0 +1,8 @@
+/**
+ * Return style by key - solves to fix noImplicitAny errors when referencing modular styles from ts files via index accessor
+ * @param styles modular styles object
+ * @param key string classname
+ */
+export function getStyle<StylesType>(styles: StylesType, key: string): StylesType[keyof StylesType] | undefined {
+  return styles[key as keyof typeof styles];
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,7 @@
 {
-  "include": ["./dist/ts-esm.js", "types/styles.d.ts"],
+  // including src/* is a temp solution to fix 'TS2307: Cannot find module './*.module.scss' or its corresponding type declarations.'
+  // error when importing .modules.scss in ts files
+  "include": ["src/**/*", "./dist/ts-esm.js", "types/*"],
   "compilerOptions": {
     "rootDir": "./src",
     "lib": ["esnext", "dom"],

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,7 @@
     "allowJs": true,
     "target": "es6",
     "module": "commonjs",
-    "sourceMap": true,
+    "sourceMap": false,
     "moduleResolution": "node",
     "resolveJsonModule": true,
     "declarationDir": "dist/types",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,7 @@
     "allowJs": true,
     "target": "es6",
     "module": "commonjs",
-    "sourceMap": false,
+    "sourceMap": true,
     "moduleResolution": "node",
     "resolveJsonModule": true,
     "declarationDir": "dist/types",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   // including src/* is a temp solution to fix 'TS2307: Cannot find module './*.module.scss' or its corresponding type declarations.'
   // error when importing .modules.scss in ts files
-  "include": ["src/**/*", "./dist/ts-esm.js", "types/*"],
+  "include": ["src/**/*", "./dist/ts-esm.js", "types/**/*"],
   "compilerOptions": {
     "rootDir": "./src",
     "lib": ["esnext", "dom"],

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,5 @@
 {
-  // including src/* is a temp solution to fix 'TS2307: Cannot find module './*.module.scss' or its corresponding type declarations.'
-  // error when importing .modules.scss in ts files
-  "include": ["src/**/*", "./dist/ts-esm.js", "types/**/*"],
+  "include": ["src/**/*", "types/**/*"],
   "compilerOptions": {
     "rootDir": "./src",
     "lib": ["esnext", "dom"],

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,6 +18,7 @@
     "baseUrl": ".",
     "allowSyntheticDefaultImports": true,
     "jsx": "react-jsx",
-    "plugins": [{ "name": "typescript-plugin-css-modules" }]
+    "plugins": [{ "name": "typescript-plugin-css-modules" }],
+    "esModuleInterop": true
   }
 }


### PR DESCRIPTION
1) Fix jest errors which happened due to `esModuleInterop` absence
2) tsconfig: include src/* to fix TS2307: Module not found "./*.module.scss"
3) Fix `noImplicitlyAny` on modular styles string index accessors in typescript files - via helper getStyle function
4) Fix eslint errors about using node global variables in js files
5) tsconfig: remove `ts-esm.js` from included