### PR TITLE
Fix flex grow loading state size.

### DIFF
--- a/src/components/Button/Button.scss
+++ b/src/components/Button/Button.scss
@@ -49,7 +49,7 @@
     min-width: 0;
     &.has-style-size {
       width: var(--element-height);
-      max-width: var(--element-height);;
+      max-width: var(--element-height);
       height: var(--element-height);
       max-height: var(--element-height);
     }

--- a/src/components/Button/Button.scss
+++ b/src/components/Button/Button.scss
@@ -49,7 +49,9 @@
     min-width: 0;
     &.has-style-size {
       width: var(--element-height);
+      max-width: var(--element-height);;
       height: var(--element-height);
+      max-height: var(--element-height);
     }
     position: relative;
   }

--- a/src/components/Search/__tests__/__snapshots__/search-snapshot-tests.jest.js.snap
+++ b/src/components/Search/__tests__/__snapshots__/search-snapshot-tests.jest.js.snap
@@ -332,6 +332,7 @@ exports[`Search renders correctly with icon 1`] = `
           aria-hidden={true}
           aria-label="Search"
           className="icon_component input-component__icon icon_component--no-focus-style fa fa-star"
+          id="search"
           onClick={[Function]}
           role="img"
         />
@@ -757,6 +758,7 @@ exports[`Search renders correctly with secondaryIconName 1`] = `
           aria-hidden={true}
           aria-label="Clear Search"
           className="icon_component input-component__icon icon_component--no-focus-style fa fa-star"
+          id="search"
           onClick={[Function]}
           role="img"
         />

--- a/src/components/TextField/__tests__/__snapshots__/textField-snapshot-tests.jest.js.snap
+++ b/src/components/TextField/__tests__/__snapshots__/textField-snapshot-tests.jest.js.snap
@@ -588,6 +588,7 @@ exports[`TextField renders correctly with icon 1`] = `
           aria-hidden={true}
           aria-label=""
           className="icon_component input-component__icon icon_component--no-focus-style fa fa-star"
+          id="input"
           onClick={[Function]}
           role="img"
         />
@@ -1004,6 +1005,7 @@ exports[`TextField renders correctly with secondaryIconName 1`] = `
           aria-hidden={true}
           aria-label=""
           className="icon_component input-component__icon icon_component--no-focus-style fa fa-star"
+          id="input"
           onClick={[Function]}
           role="img"
         />


### PR DESCRIPTION
https://monday.monday.com/boards/2861766393/pulses/3258790807

* Add max for width and height to solve dimension grow when under flex parent with child set to grow.


#### Basic
- [ ] Used plop (`npm run plop`) to create a new component.
- [ ] PR has description.
- [ ] New component is functional and uses Hooks. 
- [ ] Component defines [`PropTypes`](https://reactjs.org/docs/typechecking-with-proptypes.html).
#### Style
- [ ] Styles are added to `NewComponent.modules.scss` file inside of the `NewComponent` folder.
- [ ] Component uses CSS Modules.
- [ ] Design is compatible with [Monday Design System](https://design.monday.com/).
#### Storybook
- [ ] Stories were added to `/src/NewComponent/__stories__/NewComponent.stories.js` file.
- [ ] Stories include all flows of using the component.
#### Tests
- [ ] Tests are compliant with [TESTING_README.md](TESTING_README.md) instructions.
