### PR TITLE
fix: onClose can be undefined when hidding the modal

### DIFF
--- a/src/components/Modal/useShowHideModal.js
+++ b/src/components/Modal/useShowHideModal.js
@@ -7,7 +7,7 @@ export default function useShowHideModal({ instance, show, triggerElement, onClo
 
   const closeDialogIfNeeded = useCallback(() => {
     if (!alertDialog) {
-      onClose();
+      onClose?.();
     }
   }, [alertDialog, onClose]);
 
@@ -43,7 +43,7 @@ export default function useShowHideModal({ instance, show, triggerElement, onClo
 
   // call onClose when modal is hidden
   useEffect(() => {
-    instance?.on("hide", () => onClose());
+    instance?.on("hide", () => onClose?.());
     return () => {
       instance?.off("hide");
     };


### PR DESCRIPTION
Hello,

This PR fixes an issue if the `onClose` callback is undefined when hidding a modal.

#### Basic
- [ ] Used plop (`npm run plop`) to create a new component.
- [ ] PR has description.
- [ ] New component is functional and uses Hooks. 
- [ ] Component defines [`PropTypes`](https://reactjs.org/docs/typechecking-with-proptypes.html).
#### Style
- [ ] Styles are added to `NewComponent.modules.scss` file inside of the `NewComponent` folder.
- [ ] Component uses CSS Modules.
- [ ] Design is compatible with [Monday Design System](https://design.monday.com/).
#### Storybook
- [ ] Stories were added to `/src/NewComponent/__stories__/NewComponent.stories.js` file.
- [ ] Stories include all flows of using the component.
#### Tests
- [ ] Tests are compliant with [TESTING_README.md](TESTING_README.md) instructions.
