### PR TITLE
Fix bug: scroll inside dropdown in overflow mode

### DIFF
--- a/src/components/Dropdown/Dropdown.jsx
+++ b/src/components/Dropdown/Dropdown.jsx
@@ -68,8 +68,6 @@ const Dropdown = ({
   transformContainerRef,
   ref
 }) => {
-  const overrideId = id | DROPDOWN_ID;
-
   const controlRef = useRef();
   const overrideDefaultValue = useMemo(() => {
     if (defaultValue) {
@@ -235,11 +233,11 @@ const Dropdown = ({
   const closeMenuOnScroll = useCallback(
     event => {
       const scrolledElement = event.target;
-      const dropdownContainer = document.getElementById(overrideId);
+      const dropdownContainer = document.getElementById(id);
       if (dropdownContainer?.contains(scrolledElement)) return false;
       return insideOverflowContainer;
     },
-    [insideOverflowContainer, overrideId]
+    [insideOverflowContainer, id]
   );
 
   return (
@@ -286,7 +284,7 @@ const Dropdown = ({
       menuPlacement={menuPlacement}
       menuIsOpen={menuIsOpen}
       tabIndex={tabIndex}
-      id={overrideId}
+      id={id}
       autoFocus={autoFocus}
       closeMenuOnSelect={closeMenuOnSelect}
       ref={ref}
@@ -320,7 +318,7 @@ Dropdown.defaultProps = {
   extraStyles: defaultCustomStyles,
   tabIndex: "0",
   onOptionRemove: undefined,
-  id: undefined,
+  id: DROPDOWN_ID,
   autoFocus: false,
   closeMenuOnSelect: undefined,
   ref: undefined,

--- a/src/components/Dropdown/Dropdown.jsx
+++ b/src/components/Dropdown/Dropdown.jsx
@@ -15,10 +15,10 @@ import ClearIndicatorComponent from "./components/ClearIndicator/ClearIndicator"
 import ValueContainer from "./components/ValueContainer/ValueContainer";
 import { ADD_AUTO_HEIGHT_COMPONENTS, defaultCustomStyles, DROPDOWN_ID } from "./DropdownConstants";
 import generateBaseStyles, { customTheme } from "./Dropdown.styles";
-import "./Dropdown.scss";
 import Control from "./components/Control/Control";
 import { DROPDOWN_CHIP_COLORS } from "./dropdown-constants";
 import useMergeRefs from "../../hooks/useMergeRefs";
+import "./Dropdown.scss";
 
 const Dropdown = forwardRef(
   (

--- a/src/components/Dropdown/Dropdown.jsx
+++ b/src/components/Dropdown/Dropdown.jsx
@@ -1,6 +1,6 @@
 /* eslint-disable react/require-default-props,react/forbid-prop-types */
 import { SIZES } from "../../constants/sizes";
-import React, { useCallback, useMemo, useRef, useState } from "react";
+import React, { useCallback, useMemo, useRef, useState, forwardRef } from "react";
 import Select, { components } from "react-select";
 import AsyncSelect from "react-select/async";
 import NOOP from "lodash/noop";
@@ -13,280 +13,296 @@ import OptionComponent from "./components/option/option";
 import SingleValueComponent from "./components/singleValue/singleValue";
 import ClearIndicatorComponent from "./components/ClearIndicator/ClearIndicator";
 import ValueContainer from "./components/ValueContainer/ValueContainer";
-import { ADD_AUTO_HEIGHT_COMPONENTS, defaultCustomStyles } from "./DropdownConstants";
+import { ADD_AUTO_HEIGHT_COMPONENTS, defaultCustomStyles, DROPDOWN_ID } from "./DropdownConstants";
 import generateBaseStyles, { customTheme } from "./Dropdown.styles";
 import "./Dropdown.scss";
 import Control from "./components/Control/Control";
 import { DROPDOWN_CHIP_COLORS } from "./dropdown-constants";
+import useMergeRefs from "../../hooks/useMergeRefs";
 
-const Dropdown = ({
-  className,
-  placeholder,
-  disabled,
-  onMenuOpen,
-  onMenuClose,
-  onFocus,
-  onBlur,
-  onChange: customOnChange,
-  searchable,
-  options,
-  defaultValue,
-  value: customValue,
-  noOptionsMessage,
-  openMenuOnFocus,
-  openMenuOnClick,
-  clearable,
-  OptionRenderer,
-  optionRenderer,
-  ValueRenderer,
-  valueRenderer,
-  menuRenderer,
-  menuPlacement,
-  rtl,
-  size,
-  asyncOptions,
-  cacheOptions,
-  defaultOptions,
-  isVirtualized,
-  menuPortalTarget,
-  extraStyles,
-  maxMenuHeight,
-  menuIsOpen,
-  tabIndex,
-  id,
-  autoFocus,
-  multi = false,
-  multiline = false,
-  onOptionRemove: customOnOptionRemove,
-  onOptionSelect,
-  onClear,
-  onInputChange,
-  closeMenuOnSelect = !multi,
-  ref,
-  withMandatoryDefaultOptions,
-  isOptionSelected,
-  insideOverflowContainer,
-  transformContainerRef
-}) => {
-  const controlRef = useRef();
-  const overrideDefaultValue = useMemo(() => {
-    if (defaultValue) {
-      return Array.isArray(defaultValue)
-        ? defaultValue.map(df => ({ ...df, isMandatory: true }))
-        : { ...defaultValue, isMandatory: true };
-    }
-
-    return defaultValue;
-  }, [defaultValue]);
-
-  const [selected, setSelected] = useState(overrideDefaultValue || []);
-  const [isDialogShown, setIsDialogShown] = useState(false);
-  const finalOptionRenderer = optionRenderer || OptionRenderer;
-  const finalValueRenderer = valueRenderer || ValueRenderer;
-  const isControlled = !!customValue;
-  const selectedOptions = customValue ?? selected;
-  const selectedOptionsMap = useMemo(() => {
-    if (Array.isArray(selectedOptions)) {
-      return selectedOptions.reduce((acc, option) => ({ ...acc, [option.value]: option }), {});
-    }
-    return {};
-  }, [selectedOptions]);
-
-  const value = multi ? selectedOptions : customValue;
-
-  const styles = useMemo(() => {
-    // We first want to get the default stylized groups (e.g. "container", "menu").
-    const baseStyles = generateBaseStyles({
-      size,
+const Dropdown = forwardRef(
+  (
+    {
+      className,
+      placeholder,
+      disabled,
+      onMenuOpen,
+      onMenuClose,
+      onFocus,
+      onBlur,
+      onChange: customOnChange,
+      searchable,
+      options,
+      defaultValue,
+      value: customValue,
+      noOptionsMessage,
+      openMenuOnFocus,
+      openMenuOnClick,
+      clearable,
+      OptionRenderer,
+      optionRenderer,
+      ValueRenderer,
+      valueRenderer,
+      menuRenderer,
+      menuPlacement,
       rtl,
+      size,
+      asyncOptions,
+      cacheOptions,
+      defaultOptions,
+      isVirtualized,
+      menuPortalTarget,
+      extraStyles,
+      maxMenuHeight,
+      menuIsOpen,
+      tabIndex,
+      id,
+      autoFocus,
+      multi = false,
+      multiline = false,
+      onOptionRemove: customOnOptionRemove,
+      onOptionSelect,
+      onClear,
+      onInputChange,
+      closeMenuOnSelect = !multi,
+      withMandatoryDefaultOptions,
+      isOptionSelected,
       insideOverflowContainer,
-      controlRef,
       transformContainerRef
-    });
+    },
+    ref
+  ) => {
+    const overrideId = id | DROPDOWN_ID;
+    const componentRef = useRef(null);
+    const mergedRef = useMergeRefs({ refs: [ref, componentRef] });
+    const controlRef = useRef();
+    const overrideDefaultValue = useMemo(() => {
+      if (defaultValue) {
+        return Array.isArray(defaultValue)
+          ? defaultValue.map(df => ({ ...df, isMandatory: true }))
+          : { ...defaultValue, isMandatory: true };
+      }
 
-    // Then we want to run the consumer's root-level custom styles with our "base" override groups.
-    const customStyles = extraStyles(baseStyles);
+      return defaultValue;
+    }, [defaultValue]);
 
-    // Lastly, we create a style groups object that makes sure we run each custom group with our basic overrides.
-    const mergedStyles = Object.entries(customStyles).reduce((accumulator, [stylesGroup, stylesFn]) => {
-      return {
-        ...accumulator,
-        [stylesGroup]: (defaultStyles, state) => {
-          const provided = baseStyles[stylesGroup] ? baseStyles[stylesGroup](defaultStyles, state) : defaultStyles;
+    const [selected, setSelected] = useState(overrideDefaultValue || []);
+    const [isDialogShown, setIsDialogShown] = useState(false);
+    const finalOptionRenderer = optionRenderer || OptionRenderer;
+    const finalValueRenderer = valueRenderer || ValueRenderer;
+    const isControlled = !!customValue;
+    const selectedOptions = customValue ?? selected;
+    const selectedOptionsMap = useMemo(() => {
+      if (Array.isArray(selectedOptions)) {
+        return selectedOptions.reduce((acc, option) => ({ ...acc, [option.value]: option }), {});
+      }
+      return {};
+    }, [selectedOptions]);
 
-          return stylesFn(provided, state);
-        }
-      };
-    }, {});
+    const value = multi ? selectedOptions : customValue;
 
-    if (multi) {
-      if (multiline) {
-        ADD_AUTO_HEIGHT_COMPONENTS.forEach(component => {
-          const original = mergedStyles[component];
-          mergedStyles[component] = (provided, state) => ({
-            ...original(provided, state),
-            height: "auto"
+    const styles = useMemo(() => {
+      // We first want to get the default stylized groups (e.g. "container", "menu").
+      const baseStyles = generateBaseStyles({
+        size,
+        rtl,
+        insideOverflowContainer,
+        controlRef,
+        transformContainerRef
+      });
+
+      // Then we want to run the consumer's root-level custom styles with our "base" override groups.
+      const customStyles = extraStyles(baseStyles);
+
+      // Lastly, we create a style groups object that makes sure we run each custom group with our basic overrides.
+      const mergedStyles = Object.entries(customStyles).reduce((accumulator, [stylesGroup, stylesFn]) => {
+        return {
+          ...accumulator,
+          [stylesGroup]: (defaultStyles, state) => {
+            const provided = baseStyles[stylesGroup] ? baseStyles[stylesGroup](defaultStyles, state) : defaultStyles;
+
+            return stylesFn(provided, state);
+          }
+        };
+      }, {});
+
+      if (multi) {
+        if (multiline) {
+          ADD_AUTO_HEIGHT_COMPONENTS.forEach(component => {
+            const original = mergedStyles[component];
+            mergedStyles[component] = (provided, state) => ({
+              ...original(provided, state),
+              height: "auto"
+            });
           });
+        }
+
+        const originalValueContainer = mergedStyles.valueContainer;
+        mergedStyles.valueContainer = (provided, state) => ({
+          ...originalValueContainer(provided, state),
+          paddingLeft: 6
         });
       }
 
-      const originalValueContainer = mergedStyles.valueContainer;
-      mergedStyles.valueContainer = (provided, state) => ({
-        ...originalValueContainer(provided, state),
-        paddingLeft: 6
-      });
-    }
+      return mergedStyles;
+    }, [size, rtl, insideOverflowContainer, transformContainerRef, extraStyles, multi, multiline]);
 
-    return mergedStyles;
-  }, [size, rtl, insideOverflowContainer, transformContainerRef, extraStyles, multi, multiline]);
+    const Menu = useCallback(props => <MenuComponent {...props} Renderer={menuRenderer} />, [menuRenderer]);
 
-  const Menu = useCallback(props => <MenuComponent {...props} Renderer={menuRenderer} />, [menuRenderer]);
+    const DropdownIndicator = useCallback(props => <DropdownIndicatorComponent {...props} size={size} />, [size]);
 
-  const DropdownIndicator = useCallback(props => <DropdownIndicatorComponent {...props} size={size} />, [size]);
+    const Option = useCallback(
+      props => <OptionComponent {...props} Renderer={finalOptionRenderer} />,
+      [finalOptionRenderer]
+    );
 
-  const Option = useCallback(
-    props => <OptionComponent {...props} Renderer={finalOptionRenderer} />,
-    [finalOptionRenderer]
-  );
+    const Input = useCallback(props => <components.Input {...props} aria-label="Dropdown input" />, []);
 
-  const Input = useCallback(props => <components.Input {...props} aria-label="Dropdown input" />, []);
+    const SingleValue = useCallback(
+      props => <SingleValueComponent {...props} Renderer={finalValueRenderer} />,
+      [finalValueRenderer]
+    );
 
-  const SingleValue = useCallback(
-    props => <SingleValueComponent {...props} Renderer={finalValueRenderer} />,
-    [finalValueRenderer]
-  );
+    const ClearIndicator = useCallback(props => <ClearIndicatorComponent {...props} size={size} />, [size]);
 
-  const ClearIndicator = useCallback(props => <ClearIndicatorComponent {...props} size={size} />, [size]);
+    const onOptionRemove = useMemo(() => {
+      if (customOnOptionRemove) {
+        return (optionValue, e) => customOnOptionRemove(selectedOptionsMap[optionValue], e);
+      }
+      return function (optionValue, e) {
+        setSelected(selected.filter(option => option.value !== optionValue));
+        e.stopPropagation();
+      };
+    }, [customOnOptionRemove, selected, selectedOptionsMap]);
 
-  const onOptionRemove = useMemo(() => {
-    if (customOnOptionRemove) {
-      return (optionValue, e) => customOnOptionRemove(selectedOptionsMap[optionValue], e);
-    }
-    return function (optionValue, e) {
-      setSelected(selected.filter(option => option.value !== optionValue));
-      e.stopPropagation();
-    };
-  }, [customOnOptionRemove, selected, selectedOptionsMap]);
+    const customProps = useMemo(
+      () => ({
+        selectedOptions,
+        onSelectedDelete: onOptionRemove,
+        setIsDialogShown,
+        isDialogShown,
+        isMultiline: multiline,
+        insideOverflowContainer,
+        controlRef
+      }),
+      [selectedOptions, onOptionRemove, isDialogShown, multiline, insideOverflowContainer]
+    );
 
-  const customProps = useMemo(
-    () => ({
-      selectedOptions,
-      onSelectedDelete: onOptionRemove,
-      setIsDialogShown,
-      isDialogShown,
-      isMultiline: multiline,
-      insideOverflowContainer,
-      controlRef
-    }),
-    [selectedOptions, onOptionRemove, isDialogShown, multiline, insideOverflowContainer]
-  );
-
-  const onChange = (option, event) => {
-    if (customOnChange) {
-      customOnChange(option, event);
-    }
-
-    switch (event.action) {
-      case "select-option": {
-        const selectedOption = multi ? event.option : option;
-
-        if (onOptionSelect) {
-          onOptionSelect(selectedOption);
-        }
-
-        if (!isControlled) {
-          setSelected([...selected, selectedOption]);
-        }
-        break;
+    const onChange = (option, event) => {
+      if (customOnChange) {
+        customOnChange(option, event);
       }
 
-      case "clear":
-        if (onClear) {
-          onClear();
+      switch (event.action) {
+        case "select-option": {
+          const selectedOption = multi ? event.option : option;
+
+          if (onOptionSelect) {
+            onOptionSelect(selectedOption);
+          }
+
+          if (!isControlled) {
+            setSelected([...selected, selectedOption]);
+          }
+          break;
         }
 
-        if (!isControlled) {
-          if (withMandatoryDefaultOptions) setSelected(overrideDefaultValue);
-          else setSelected([]);
-        }
-        break;
-    }
-  };
+        case "clear":
+          if (onClear) {
+            onClear();
+          }
 
-  const DropDownComponent = asyncOptions ? AsyncSelect : Select;
+          if (!isControlled) {
+            if (withMandatoryDefaultOptions) setSelected(overrideDefaultValue);
+            else setSelected([]);
+          }
+          break;
+      }
+    };
 
-  const asyncAdditions = {
-    ...(asyncOptions && {
-      loadOptions: asyncOptions,
-      cacheOptions,
-      ...(defaultOptions && { defaultOptions })
-    })
-  };
+    const DropDownComponent = asyncOptions ? AsyncSelect : Select;
 
-  const additions = {
-    ...(!asyncOptions && { options }),
-    ...(multi && {
-      isMulti: true
-    })
-  };
+    const asyncAdditions = {
+      ...(asyncOptions && {
+        loadOptions: asyncOptions,
+        cacheOptions,
+        ...(defaultOptions && { defaultOptions })
+      })
+    };
 
-  const closeMenuOnScroll = useCallback(() => insideOverflowContainer, [insideOverflowContainer]);
+    const additions = {
+      ...(!asyncOptions && { options }),
+      ...(multi && {
+        isMulti: true
+      })
+    };
 
-  return (
-    <DropDownComponent
-      className={cx("dropdown-wrapper", className)}
-      selectProps={customProps}
-      components={{
-        DropdownIndicator,
-        Menu,
-        ClearIndicator,
-        Input,
-        Option,
-        Control,
-        ...(finalValueRenderer && { SingleValue }),
-        ...(multi && {
-          MultiValue: NOOP, // We need it for react-select to behave nice with "multi"
-          ValueContainer
-        }),
-        ...(isVirtualized && { MenuList: WindowedMenuList })
-      }}
-      // When inside scroll we set the menu position by js and we can't follow the drop down location while use scrolling
-      closeMenuOnScroll={closeMenuOnScroll}
-      size={size}
-      noOptionsMessage={noOptionsMessage}
-      placeholder={placeholder}
-      isDisabled={disabled}
-      isClearable={clearable}
-      isSearchable={searchable}
-      defaultValue={defaultValue}
-      value={value}
-      onMenuOpen={onMenuOpen}
-      onMenuClose={onMenuClose}
-      onFocus={onFocus}
-      onBlur={onBlur}
-      onChange={onChange}
-      onInputChange={onInputChange}
-      openMenuOnFocus={openMenuOnFocus}
-      openMenuOnClick={openMenuOnClick}
-      isRtl={rtl}
-      styles={styles}
-      theme={customTheme}
-      maxMenuHeight={maxMenuHeight}
-      menuPortalTarget={menuPortalTarget}
-      menuPlacement={menuPlacement}
-      menuIsOpen={menuIsOpen}
-      tabIndex={tabIndex}
-      id={id}
-      autoFocus={autoFocus}
-      closeMenuOnSelect={closeMenuOnSelect}
-      ref={ref}
-      withMandatoryDefaultOptions={withMandatoryDefaultOptions}
-      isOptionSelected={isOptionSelected}
-      {...asyncAdditions}
-      {...additions}
-    />
-  );
-};
+    const closeMenuOnScroll = useCallback(
+      event => {
+        const scrolledElement = event.target;
+        const dropdownContainer = document.getElementById(overrideId);
+        if (dropdownContainer?.contains(scrolledElement)) return false;
+        return insideOverflowContainer;
+      },
+      [insideOverflowContainer, overrideId]
+    );
+
+    return (
+      <DropDownComponent
+        className={cx("dropdown-wrapper", className)}
+        selectProps={customProps}
+        components={{
+          DropdownIndicator,
+          Menu,
+          ClearIndicator,
+          Input,
+          Option,
+          Control,
+          ...(finalValueRenderer && { SingleValue }),
+          ...(multi && {
+            MultiValue: NOOP, // We need it for react-select to behave nice with "multi"
+            ValueContainer
+          }),
+          ...(isVirtualized && { MenuList: WindowedMenuList })
+        }}
+        // When inside scroll we set the menu position by js and we can't follow the drop down location while use scrolling
+        closeMenuOnScroll={closeMenuOnScroll}
+        size={size}
+        noOptionsMessage={noOptionsMessage}
+        placeholder={placeholder}
+        isDisabled={disabled}
+        isClearable={clearable}
+        isSearchable={searchable}
+        defaultValue={defaultValue}
+        value={value}
+        onMenuOpen={onMenuOpen}
+        onMenuClose={onMenuClose}
+        onFocus={onFocus}
+        onBlur={onBlur}
+        onChange={onChange}
+        onInputChange={onInputChange}
+        openMenuOnFocus={openMenuOnFocus}
+        openMenuOnClick={openMenuOnClick}
+        isRtl={rtl}
+        styles={styles}
+        theme={customTheme}
+        maxMenuHeight={maxMenuHeight}
+        menuPortalTarget={menuPortalTarget}
+        menuPlacement={menuPlacement}
+        menuIsOpen={menuIsOpen}
+        tabIndex={tabIndex}
+        id={overrideId}
+        autoFocus={autoFocus}
+        closeMenuOnSelect={closeMenuOnSelect}
+        ref={mergedRef}
+        withMandatoryDefaultOptions={withMandatoryDefaultOptions}
+        isOptionSelected={isOptionSelected}
+        {...asyncAdditions}
+        {...additions}
+      />
+    );
+  }
+);
 
 Dropdown.size = SIZES;
 Dropdown.chipColors = DROPDOWN_CHIP_COLORS;

--- a/src/components/Dropdown/DropdownConstants.js
+++ b/src/components/Dropdown/DropdownConstants.js
@@ -1,3 +1,5 @@
 export const defaultCustomStyles = baseStyles => baseStyles;
 
 export const ADD_AUTO_HEIGHT_COMPONENTS = ["container", "control", "valueContainer"];
+
+export const DROPDOWN_ID = "dropdown-menu-id";

--- a/src/components/Dropdown/__tests__/__snapshots__/dropdown-snapshot-tests.jest.js.snap
+++ b/src/components/Dropdown/__tests__/__snapshots__/dropdown-snapshot-tests.jest.js.snap
@@ -4,7 +4,7 @@ exports[`Dropdown renders correctly snapshot driver should open menu on click if
 <DocumentFragment>
   <div
     class="dropdown-wrapper dropdown-story css-bbwnb8-container"
-    id="0"
+    id="dropdown-menu-id"
   >
     <span
       aria-live="polite"
@@ -148,7 +148,7 @@ exports[`Dropdown renders correctly snapshot driver should open menu on focus if
 <DocumentFragment>
   <div
     class="dropdown-wrapper dropdown-story css-bbwnb8-container"
-    id="0"
+    id="dropdown-menu-id"
   >
     <span
       aria-live="polite"
@@ -242,7 +242,7 @@ exports[`Dropdown renders correctly snapshot driver should render correctly for 
 <DocumentFragment>
   <div
     class="dropdown-wrapper dropdown-story css-1pu8kyc-container"
-    id="0"
+    id="dropdown-menu-id"
   >
     <div
       class="monday-dropdown_scrollable-wrapper"
@@ -321,7 +321,7 @@ exports[`Dropdown renders correctly snapshot driver should render correctly for 
 <DocumentFragment>
   <div
     class="dropdown-wrapper dropdown-story css-1pu8kyc-container"
-    id="0"
+    id="dropdown-menu-id"
   >
     <div
       class="monday-dropdown_scrollable-wrapper"
@@ -400,7 +400,7 @@ exports[`Dropdown renders correctly snapshot driver should render correctly for 
 <DocumentFragment>
   <div
     class="dropdown-wrapper dropdown-story css-1pu8kyc-container"
-    id="0"
+    id="dropdown-menu-id"
   >
     <div
       class="monday-dropdown_scrollable-wrapper"
@@ -479,7 +479,7 @@ exports[`Dropdown renders correctly snapshot driver should render correctly for 
 <DocumentFragment>
   <div
     class="dropdown-wrapper dropdown-story css-bbwnb8-container"
-    id="0"
+    id="dropdown-menu-id"
   >
     <div
       class="monday-dropdown_scrollable-wrapper"
@@ -558,7 +558,7 @@ exports[`Dropdown renders correctly snapshot driver should render correctly for 
 <DocumentFragment>
   <div
     class="dropdown-wrapper dropdown-story css-cmnsoe-container"
-    id="0"
+    id="dropdown-menu-id"
   >
     <div
       class="monday-dropdown_scrollable-wrapper"
@@ -637,7 +637,7 @@ exports[`Dropdown renders correctly snapshot driver should render correctly with
 <DocumentFragment>
   <div
     class="dropdown-wrapper dropdown-story css-bbwnb8-container"
-    id="0"
+    id="dropdown-menu-id"
   >
     <div
       class="monday-dropdown_scrollable-wrapper"
@@ -716,7 +716,7 @@ exports[`Dropdown renders correctly snapshot driver should use async if set 1`] 
 <DocumentFragment>
   <div
     class="dropdown-wrapper dropdown-story css-bbwnb8-container"
-    id="0"
+    id="dropdown-menu-id"
   >
     <span
       aria-live="polite"
@@ -824,7 +824,7 @@ exports[`Dropdown renders correctly snapshot driver should use virtualization if
 <DocumentFragment>
   <div
     class="dropdown-wrapper dropdown-story css-bbwnb8-container"
-    id="0"
+    id="dropdown-menu-id"
   >
     <span
       aria-live="polite"
@@ -1073,7 +1073,7 @@ exports[`Dropdown renders correctly snapshot driver should use virtualization if
 exports[`Dropdown renders correctly when disabled 1`] = `
 <div
   className="dropdown-wrapper css-1gsgnpy-container"
-  id={0}
+  id="dropdown-menu-id"
   onKeyDown={[Function]}
 >
   <div
@@ -1190,7 +1190,7 @@ exports[`Dropdown renders correctly when disabled 1`] = `
 exports[`Dropdown renders correctly when rtl 1`] = `
 <div
   className="dropdown-wrapper css-b0xr5u-container"
-  id={0}
+  id="dropdown-menu-id"
   onKeyDown={[Function]}
 >
   <div
@@ -1308,7 +1308,7 @@ exports[`Dropdown renders correctly when rtl 1`] = `
 exports[`Dropdown renders correctly with autoFocus 1`] = `
 <div
   className="dropdown-wrapper css-bbwnb8-container"
-  id={0}
+  id="dropdown-menu-id"
   onKeyDown={[Function]}
 >
   <div
@@ -1426,7 +1426,7 @@ exports[`Dropdown renders correctly with autoFocus 1`] = `
 exports[`Dropdown renders correctly with chip colors 1`] = `
 <div
   className="dropdown-wrapper css-3iiiai-container"
-  id={0}
+  id="dropdown-menu-id"
   onKeyDown={[Function]}
 >
   <div
@@ -1742,7 +1742,7 @@ exports[`Dropdown renders correctly with chip colors 1`] = `
 exports[`Dropdown renders correctly with className 1`] = `
 <div
   className="dropdown-wrapper test css-bbwnb8-container"
-  id={0}
+  id="dropdown-menu-id"
   onKeyDown={[Function]}
 >
   <div
@@ -1860,7 +1860,7 @@ exports[`Dropdown renders correctly with className 1`] = `
 exports[`Dropdown renders correctly with defaultValue 1`] = `
 <div
   className="dropdown-wrapper css-bbwnb8-container"
-  id={0}
+  id="dropdown-menu-id"
   onKeyDown={[Function]}
 >
   <div
@@ -2003,7 +2003,7 @@ exports[`Dropdown renders correctly with defaultValue 1`] = `
 exports[`Dropdown renders correctly with empty props 1`] = `
 <div
   className="dropdown-wrapper css-bbwnb8-container"
-  id={0}
+  id="dropdown-menu-id"
   onKeyDown={[Function]}
 >
   <div
@@ -2121,7 +2121,7 @@ exports[`Dropdown renders correctly with empty props 1`] = `
 exports[`Dropdown renders correctly with id 1`] = `
 <div
   className="dropdown-wrapper css-bbwnb8-container"
-  id={0}
+  id="dropdown-menu-id"
   onKeyDown={[Function]}
 >
   <div
@@ -2239,7 +2239,7 @@ exports[`Dropdown renders correctly with id 1`] = `
 exports[`Dropdown renders correctly with leftAvatar 1`] = `
 <div
   className="dropdown-wrapper css-3iiiai-container"
-  id={0}
+  id="dropdown-menu-id"
   onKeyDown={[Function]}
 >
   <div
@@ -2464,7 +2464,7 @@ exports[`Dropdown renders correctly with leftAvatar 1`] = `
 exports[`Dropdown renders correctly with leftIcon 1`] = `
 <div
   className="dropdown-wrapper css-3iiiai-container"
-  id={0}
+  id="dropdown-menu-id"
   onKeyDown={[Function]}
 >
   <div
@@ -2684,7 +2684,7 @@ exports[`Dropdown renders correctly with leftIcon 1`] = `
 exports[`Dropdown renders correctly with multi 1`] = `
 <div
   className="dropdown-wrapper css-bbwnb8-container"
-  id={0}
+  id="dropdown-menu-id"
   onKeyDown={[Function]}
 >
   <div
@@ -2816,7 +2816,7 @@ exports[`Dropdown renders correctly with multi 1`] = `
 exports[`Dropdown renders correctly with multiline 1`] = `
 <div
   className="dropdown-wrapper css-bbwnb8-container"
-  id={0}
+  id="dropdown-menu-id"
   onKeyDown={[Function]}
 >
   <div
@@ -2934,7 +2934,7 @@ exports[`Dropdown renders correctly with multiline 1`] = `
 exports[`Dropdown renders correctly with options 1`] = `
 <div
   className="dropdown-wrapper css-bbwnb8-container"
-  id={0}
+  id="dropdown-menu-id"
   onKeyDown={[Function]}
 >
   <div
@@ -3052,7 +3052,7 @@ exports[`Dropdown renders correctly with options 1`] = `
 exports[`Dropdown renders correctly with placeholder 1`] = `
 <div
   className="dropdown-wrapper css-bbwnb8-container"
-  id={0}
+  id="dropdown-menu-id"
   onKeyDown={[Function]}
 >
   <div
@@ -3170,7 +3170,7 @@ exports[`Dropdown renders correctly with placeholder 1`] = `
 exports[`Dropdown renders correctly with tabIndex 1`] = `
 <div
   className="dropdown-wrapper css-bbwnb8-container"
-  id={0}
+  id="dropdown-menu-id"
   onKeyDown={[Function]}
 >
   <div
@@ -3288,7 +3288,7 @@ exports[`Dropdown renders correctly with tabIndex 1`] = `
 exports[`Dropdown renders correctly with value 1`] = `
 <div
   className="dropdown-wrapper css-bbwnb8-container"
-  id={0}
+  id="dropdown-menu-id"
   onKeyDown={[Function]}
 >
   <div
@@ -3431,7 +3431,7 @@ exports[`Dropdown renders correctly with value 1`] = `
 exports[`Dropdown renders correctly without clear button 1`] = `
 <div
   className="dropdown-wrapper css-bbwnb8-container"
-  id={0}
+  id="dropdown-menu-id"
   onKeyDown={[Function]}
 >
   <div

--- a/src/components/Dropdown/__tests__/__snapshots__/dropdown-snapshot-tests.jest.js.snap
+++ b/src/components/Dropdown/__tests__/__snapshots__/dropdown-snapshot-tests.jest.js.snap
@@ -4,6 +4,7 @@ exports[`Dropdown renders correctly snapshot driver should open menu on click if
 <DocumentFragment>
   <div
     class="dropdown-wrapper dropdown-story css-bbwnb8-container"
+    id="0"
   >
     <span
       aria-live="polite"
@@ -147,6 +148,7 @@ exports[`Dropdown renders correctly snapshot driver should open menu on focus if
 <DocumentFragment>
   <div
     class="dropdown-wrapper dropdown-story css-bbwnb8-container"
+    id="0"
   >
     <span
       aria-live="polite"
@@ -240,6 +242,7 @@ exports[`Dropdown renders correctly snapshot driver should render correctly for 
 <DocumentFragment>
   <div
     class="dropdown-wrapper dropdown-story css-1pu8kyc-container"
+    id="0"
   >
     <div
       class="monday-dropdown_scrollable-wrapper"
@@ -318,6 +321,7 @@ exports[`Dropdown renders correctly snapshot driver should render correctly for 
 <DocumentFragment>
   <div
     class="dropdown-wrapper dropdown-story css-1pu8kyc-container"
+    id="0"
   >
     <div
       class="monday-dropdown_scrollable-wrapper"
@@ -396,6 +400,7 @@ exports[`Dropdown renders correctly snapshot driver should render correctly for 
 <DocumentFragment>
   <div
     class="dropdown-wrapper dropdown-story css-1pu8kyc-container"
+    id="0"
   >
     <div
       class="monday-dropdown_scrollable-wrapper"
@@ -474,6 +479,7 @@ exports[`Dropdown renders correctly snapshot driver should render correctly for 
 <DocumentFragment>
   <div
     class="dropdown-wrapper dropdown-story css-bbwnb8-container"
+    id="0"
   >
     <div
       class="monday-dropdown_scrollable-wrapper"
@@ -552,6 +558,7 @@ exports[`Dropdown renders correctly snapshot driver should render correctly for 
 <DocumentFragment>
   <div
     class="dropdown-wrapper dropdown-story css-cmnsoe-container"
+    id="0"
   >
     <div
       class="monday-dropdown_scrollable-wrapper"
@@ -630,6 +637,7 @@ exports[`Dropdown renders correctly snapshot driver should render correctly with
 <DocumentFragment>
   <div
     class="dropdown-wrapper dropdown-story css-bbwnb8-container"
+    id="0"
   >
     <div
       class="monday-dropdown_scrollable-wrapper"
@@ -708,6 +716,7 @@ exports[`Dropdown renders correctly snapshot driver should use async if set 1`] 
 <DocumentFragment>
   <div
     class="dropdown-wrapper dropdown-story css-bbwnb8-container"
+    id="0"
   >
     <span
       aria-live="polite"
@@ -815,6 +824,7 @@ exports[`Dropdown renders correctly snapshot driver should use virtualization if
 <DocumentFragment>
   <div
     class="dropdown-wrapper dropdown-story css-bbwnb8-container"
+    id="0"
   >
     <span
       aria-live="polite"
@@ -1063,6 +1073,7 @@ exports[`Dropdown renders correctly snapshot driver should use virtualization if
 exports[`Dropdown renders correctly when disabled 1`] = `
 <div
   className="dropdown-wrapper css-1gsgnpy-container"
+  id={0}
   onKeyDown={[Function]}
 >
   <div
@@ -1179,6 +1190,7 @@ exports[`Dropdown renders correctly when disabled 1`] = `
 exports[`Dropdown renders correctly when rtl 1`] = `
 <div
   className="dropdown-wrapper css-b0xr5u-container"
+  id={0}
   onKeyDown={[Function]}
 >
   <div
@@ -1296,6 +1308,7 @@ exports[`Dropdown renders correctly when rtl 1`] = `
 exports[`Dropdown renders correctly with autoFocus 1`] = `
 <div
   className="dropdown-wrapper css-bbwnb8-container"
+  id={0}
   onKeyDown={[Function]}
 >
   <div
@@ -1413,6 +1426,7 @@ exports[`Dropdown renders correctly with autoFocus 1`] = `
 exports[`Dropdown renders correctly with chip colors 1`] = `
 <div
   className="dropdown-wrapper css-3iiiai-container"
+  id={0}
   onKeyDown={[Function]}
 >
   <div
@@ -1728,6 +1742,7 @@ exports[`Dropdown renders correctly with chip colors 1`] = `
 exports[`Dropdown renders correctly with className 1`] = `
 <div
   className="dropdown-wrapper test css-bbwnb8-container"
+  id={0}
   onKeyDown={[Function]}
 >
   <div
@@ -1845,6 +1860,7 @@ exports[`Dropdown renders correctly with className 1`] = `
 exports[`Dropdown renders correctly with defaultValue 1`] = `
 <div
   className="dropdown-wrapper css-bbwnb8-container"
+  id={0}
   onKeyDown={[Function]}
 >
   <div
@@ -1987,6 +2003,7 @@ exports[`Dropdown renders correctly with defaultValue 1`] = `
 exports[`Dropdown renders correctly with empty props 1`] = `
 <div
   className="dropdown-wrapper css-bbwnb8-container"
+  id={0}
   onKeyDown={[Function]}
 >
   <div
@@ -2104,6 +2121,7 @@ exports[`Dropdown renders correctly with empty props 1`] = `
 exports[`Dropdown renders correctly with id 1`] = `
 <div
   className="dropdown-wrapper css-bbwnb8-container"
+  id={0}
   onKeyDown={[Function]}
 >
   <div
@@ -2221,6 +2239,7 @@ exports[`Dropdown renders correctly with id 1`] = `
 exports[`Dropdown renders correctly with leftAvatar 1`] = `
 <div
   className="dropdown-wrapper css-3iiiai-container"
+  id={0}
   onKeyDown={[Function]}
 >
   <div
@@ -2445,6 +2464,7 @@ exports[`Dropdown renders correctly with leftAvatar 1`] = `
 exports[`Dropdown renders correctly with leftIcon 1`] = `
 <div
   className="dropdown-wrapper css-3iiiai-container"
+  id={0}
   onKeyDown={[Function]}
 >
   <div
@@ -2664,6 +2684,7 @@ exports[`Dropdown renders correctly with leftIcon 1`] = `
 exports[`Dropdown renders correctly with multi 1`] = `
 <div
   className="dropdown-wrapper css-bbwnb8-container"
+  id={0}
   onKeyDown={[Function]}
 >
   <div
@@ -2795,6 +2816,7 @@ exports[`Dropdown renders correctly with multi 1`] = `
 exports[`Dropdown renders correctly with multiline 1`] = `
 <div
   className="dropdown-wrapper css-bbwnb8-container"
+  id={0}
   onKeyDown={[Function]}
 >
   <div
@@ -2912,6 +2934,7 @@ exports[`Dropdown renders correctly with multiline 1`] = `
 exports[`Dropdown renders correctly with options 1`] = `
 <div
   className="dropdown-wrapper css-bbwnb8-container"
+  id={0}
   onKeyDown={[Function]}
 >
   <div
@@ -3029,6 +3052,7 @@ exports[`Dropdown renders correctly with options 1`] = `
 exports[`Dropdown renders correctly with placeholder 1`] = `
 <div
   className="dropdown-wrapper css-bbwnb8-container"
+  id={0}
   onKeyDown={[Function]}
 >
   <div
@@ -3146,6 +3170,7 @@ exports[`Dropdown renders correctly with placeholder 1`] = `
 exports[`Dropdown renders correctly with tabIndex 1`] = `
 <div
   className="dropdown-wrapper css-bbwnb8-container"
+  id={0}
   onKeyDown={[Function]}
 >
   <div
@@ -3263,6 +3288,7 @@ exports[`Dropdown renders correctly with tabIndex 1`] = `
 exports[`Dropdown renders correctly with value 1`] = `
 <div
   className="dropdown-wrapper css-bbwnb8-container"
+  id={0}
   onKeyDown={[Function]}
 >
   <div
@@ -3405,6 +3431,7 @@ exports[`Dropdown renders correctly with value 1`] = `
 exports[`Dropdown renders correctly without clear button 1`] = `
 <div
   className="dropdown-wrapper css-bbwnb8-container"
+  id={0}
   onKeyDown={[Function]}
 >
   <div


### PR DESCRIPTION
Overflow mode is a mode of a dropdown component when the menu is displayed in fixed position for display above modals with absolute position while the dropdown menu need to display outside of the modal. In this state we can't scroll because  then the menu of the dropdown position will look broken (because the fix position).
This fix allow to separate between a scroll of the menu (which is ok and we want to allow it) and a scroll of the document (which should trigger closing the dropdown menu) 