### PR TITLE
ComboboxItems: add categories to calculations.

### DIFF
--- a/src/components/Combobox/components/ComboboxItems/ComboboxItems.jsx
+++ b/src/components/Combobox/components/ComboboxItems/ComboboxItems.jsx
@@ -38,11 +38,11 @@ export const ComboboxItems = forwardRef(
     const style = useMemo(() => {
       if (maxOptionsWithoutScroll) {
         // Adding 0.5 to show next option to indicate scroll is available
-        const maxCount = Math.min(options.length, maxOptionsWithoutScroll + 0.5);
+        const maxCount = Math.min(options.length + Object.keys(categories ?? {}).length, maxOptionsWithoutScroll + 0.5);
         return { height: optionLineHeight * maxCount };
       }
       return undefined;
-    }, [maxOptionsWithoutScroll, optionLineHeight, options]);
+    }, [maxOptionsWithoutScroll, optionLineHeight, options, categories]);
 
     const createItemElementRenderer = useCallback(
       (item, index, style) =>


### PR DESCRIPTION
When a combobox has categories they are not calculated in the max options without scroll calculations. In some rare cases (one category with one option for example) the component is not usable at all.
This commit adds the categories number to the calculation.

<!--

Please go over the checklist and make sure all conditions are met.

--->

#### Basic
- [ ] Used plop (`npm run plop`) to create a new component.
- [ ] PR has description.
- [ ] New component is functional and uses Hooks. 
- [ ] Component defines [`PropTypes`](https://reactjs.org/docs/typechecking-with-proptypes.html).
#### Style
- [ ] Styles are added to `NewComponent.modules.scss` file inside of the `NewComponent` folder.
- [ ] Component uses CSS Modules.
- [ ] Design is compatible with [Monday Design System](https://design.monday.com/).
#### Storybook
- [ ] Stories were added to `/src/NewComponent/__stories__/NewComponent.stories.js` file.
- [ ] Stories include all flows of using the component.
#### Tests
- [ ] Tests are compliant with [TESTING_README.md](TESTING_README.md) instructions.
