### PR TITLE
Fix tooltip-arrow color to adapt to the theme

### DIFF
--- a/src/components/Dialog/Dialog.scss
+++ b/src/components/Dialog/Dialog.scss
@@ -15,7 +15,7 @@ $arrow-size: 12px;
   position: absolute;
   border-radius: 2px;
 
-  background-color: $white-theme-bg-color;
+  background-color: var(--secondary-background-color);
 
   &[data-placement*="bottom"] {
     top: 1px;


### PR DESCRIPTION
https://monday.monday.com/boards/2861766393/pulses/3506070789
Fix this bug
![image](https://user-images.githubusercontent.com/104433616/201111599-00b0b482-77c2-4f58-a4c6-7a04675fbb86.png)
