### PR TITLE
Icon: follow create component best practices.

### DIFF
--- a/src/components/Icon/Icon.tsx
+++ b/src/components/Icon/Icon.tsx
@@ -109,19 +109,16 @@ const Icon: VibeComponent<IconProps, HTMLElement> & { type?: typeof IconType } =
     const isFunctionType = typeof icon === "function";
     // Replace in major version change with more accurate check
     if (iconType === IconType.SVG || isFunctionType || typeof icon === "object") {
-      const IconComponent = icon;
-      return (
-        <IconComponent
-          id={id}
-          {...screenReaderAccessProps}
-          ref={isFunctionType ? undefined : mergedRef}
-          size={iconSize.toString()}
-          onClick={onClick}
-          className={computedClassName}
-          style={style}
-          data-testid={dataTestId}
-        />
-      );
+      return React.createElement(icon, {
+        id,
+        ...screenReaderAccessProps,
+        ref: isFunctionType ? undefined : mergedRef,
+        size: iconSize.toString(),
+        onClick,
+        className: computedClassName,
+        style,
+        "data-testid": dataTestId
+      });
     }
     if (iconType === IconType.SRC) {
       return (

--- a/src/components/Icon/Icon.tsx
+++ b/src/components/Icon/Icon.tsx
@@ -21,7 +21,7 @@ export interface IconSubComponentProps {
   "data-testid"?: string;
 }
 
-function renderIcon(Icon: SubIcon, props: IconSubComponentProps): JSX.Element {
+function renderIcon(Icon: SubIcon, props: IconSubComponentProps) {
   return <Icon {...props} />;
 }
 

--- a/src/components/Icon/Icon.tsx
+++ b/src/components/Icon/Icon.tsx
@@ -21,6 +21,10 @@ export interface IconSubComponentProps {
   "data-testid"?: string;
 }
 
+function renderIcon(Icon: SubIcon, props: IconSubComponentProps): JSX.Element {
+  return <Icon {...props} />;
+}
+
 interface IconProps extends VibeComponentProps {
   // eslint-disable-next-line no-unused-vars
   onClick?: (event: React.MouseEvent) => void;
@@ -109,7 +113,7 @@ const Icon: VibeComponent<IconProps, HTMLElement> & { type?: typeof IconType } =
     const isFunctionType = typeof icon === "function";
     // Replace in major version change with more accurate check
     if (iconType === IconType.SVG || isFunctionType || typeof icon === "object") {
-      return React.createElement(icon, {
+      return renderIcon(icon, {
         id,
         ...screenReaderAccessProps,
         ref: isFunctionType ? undefined : mergedRef,


### PR DESCRIPTION
It is considered unsafe to render a component directly from the class or function if you're getting it from props. The best practice for that is to create the element with React and pass it around.
This fix will should remove many warnings about rendering custom components that are not following the PascalCase naming.
