### PR TITLE
Same behaviour for active button ,active split button and active icon button

### DIFF
--- a/src/components/Button/Button.scss
+++ b/src/components/Button/Button.scss
@@ -194,7 +194,7 @@
         &--color {
           &-primary {
             &-active {
-              background: var(--primary-selected-color);
+              background-color: var(--primary-selected-color);
               border-color: var(--primary-color);
             }
             &:hover,
@@ -253,7 +253,7 @@
         &--color {
           &-primary {
             &-active {
-              background: var(--primary-selected-color);
+              background-color: var(--primary-selected-color);
             }
             &:hover,
             &:focus {

--- a/src/components/Button/Button.scss
+++ b/src/components/Button/Button.scss
@@ -193,7 +193,10 @@
         }
         &--color {
           &-primary {
-            &-active,
+            &-active {
+              background: var(--primary-selected-color);
+              border-color: var(--primary-color);
+            }
             &:hover,
             &:focus {
               @include theme-prop(background-color, primary-background-hover-color);
@@ -249,7 +252,9 @@
       &.monday-style-button {
         &--color {
           &-primary {
-            &-active,
+            &-active {
+              background: var(--primary-selected-color);
+            }
             &:hover,
             &:focus {
               @include theme-prop(background-color, primary-background-hover-color);

--- a/src/components/Button/Button.scss
+++ b/src/components/Button/Button.scss
@@ -193,12 +193,12 @@
         }
         &--color {
           &-primary {
-            &-active {
+            &-active, &-active:hover {
               background-color: var(--primary-selected-color);
               border-color: var(--primary-color);
             }
-            &:hover,
-            &:focus {
+            &:hover:not(.monday-style-button--color-primary-active),
+            &:focus:not(.monday-style-button--color-primary-active) {
               @include theme-prop(background-color, primary-background-hover-color);
             }
           }
@@ -252,11 +252,11 @@
       &.monday-style-button {
         &--color {
           &-primary {
-            &-active {
+            &-active, &-active:hover {
               background-color: var(--primary-selected-color);
             }
-            &:hover,
-            &:focus {
+            &:hover:not(.monday-style-button--color-primary-active),
+            &:focus:not(.monday-style-button--color-primary-active){
               @include theme-prop(background-color, primary-background-hover-color);
             }
           }
@@ -302,7 +302,7 @@
         @include theme-prop(color, disabled-text-color);
         cursor: not-allowed;
         pointer-events: none;
-        &:hover {
+        &:hover, {
           background-color: transparent;
         }
       }

--- a/src/components/Button/Button.scss
+++ b/src/components/Button/Button.scss
@@ -302,7 +302,7 @@
         @include theme-prop(color, disabled-text-color);
         cursor: not-allowed;
         pointer-events: none;
-        &:hover, {
+        &:hover {
           background-color: transparent;
         }
       }

--- a/src/components/IconButton/IconButton.tsx
+++ b/src/components/IconButton/IconButton.tsx
@@ -125,19 +125,12 @@ const IconButton: VibeComponent<IconButtonProps> & {
         alignItems: "center",
         padding: 0
       } as React.CSSProperties;
-      if (active && kind !== IconButton.kinds.PRIMARY) {
-        style.background = "var(--primary-selected-color)";
-      }
-
-      if (active && kind === IconButton.kinds.SECONDARY) {
-        style.borderColor = "var(--primary-color)";
-      }
 
       if (size) {
         style = { ...style, ...getWidthHeight(size) };
       }
       return style;
-    }, [active, kind, size]);
+    }, [size]);
 
     const calculatedTooltipContent = useMemo(() => {
       if (hideTooltip) return null;

--- a/src/components/IconButton/__tests__/__snapshots__/iconButton-snapshot-tests.jest.tsx.snap
+++ b/src/components/IconButton/__tests__/__snapshots__/iconButton-snapshot-tests.jest.tsx.snap
@@ -55,7 +55,6 @@ exports[`IconButton renders correctly with active 1`] = `
   style={
     Object {
       "alignItems": "center",
-      "background": "var(--primary-selected-color)",
       "height": "40px",
       "justifyContent": "center",
       "padding": 0,

--- a/src/components/SplitButton/SplitButton.scss
+++ b/src/components/SplitButton/SplitButton.scss
@@ -51,7 +51,7 @@
                 &.monday-style-split-button--split-content-open {
                   .monday-style-split-button__secondary-button,
                   .monday-style-split-button__secondary-button:hover {
-                    @include theme-prop(color, primary-color);
+                    color: var(--primary-color);
                   }
                 }
               }

--- a/src/components/SplitButton/SplitButton.scss
+++ b/src/components/SplitButton/SplitButton.scss
@@ -39,40 +39,19 @@
           &-primary {
             &.monday-style-split-button--main-active {
               .monday-style-split-button__main-button {
-                background-color: var(--primary-selected-hover-color);
+                background-color: var(--primary-selected-color);
               }
 
               .monday-style-split-button__secondary-button {
                 background-color: var(--primary-selected-color);
               }
 
-              &.monday-style-split-button--split-content-open {
-                .monday-style-split-button__main-button {
-                  .monday-style-split-button__main-button {
-                    background-color: var(--primary-selected-color);
-                  }
-
-                  .monday-style-split-button__secondary-button {
-                    background-color: var(--primary-selected-hover-color) !important;
-                  }
-                }
-              }
-
               &.monday-style-split-button--split-content-open,
               &.monday-style-split-button--hovered {
-                &:not(.monday-style-split-button--main-active) {
-                  .monday-style-split-button__secondary-button {
-                    border-color: transparent;
-                    @include theme-prop(background-color, primary-background-hover-color);
-
-                  }
-                }
-
                 &.monday-style-split-button--split-content-open {
                   .monday-style-split-button__secondary-button,
                   .monday-style-split-button__secondary-button:hover {
                     @include theme-prop(color, primary-color);
-                    @include theme-prop(background-color, primary-selected-color);
                   }
                 }
               }
@@ -130,6 +109,11 @@
       &:not(.monday-style-split-button--disabled).monday-style-split-button {
         &--color {
           &-primary {
+            &.monday-style-split-button--main-active {
+              .monday-style-split-button__secondary-button {
+                background-color: var(--primary-hover-color);
+              }
+            }
             .monday-style-split-button__secondary-button {
               border-left: 1px solid;
 
@@ -173,20 +157,11 @@
           &-primary {
             &.monday-style-split-button--main-active {
               .monday-style-split-button__main-button {
-                background-color: var(--primary-selected-hover-color);
+                background-color: var(--primary-selected-color);
               }
               .monday-style-split-button__secondary-button {
                 background-color: var(--primary-selected-color);
                 border-color: var(--primary-color);
-              }
-
-              &.monday-style-split-button--split-content-open {
-                .monday-style-split-button__main-button {
-                  background-color: var(--primary-selected-color);
-                }
-                .monday-style-split-button__secondary-button {
-                  background-color: var(--primary-selected-hover-color) !important;
-                }
               }
             }
 

--- a/src/components/SplitButton/SplitButton.scss
+++ b/src/components/SplitButton/SplitButton.scss
@@ -112,6 +112,7 @@
             &.monday-style-split-button--main-active {
               .monday-style-split-button__secondary-button {
                 background-color: var(--primary-hover-color);
+                border-color: var(--text-color-on-primary)
               }
             }
             .monday-style-split-button__secondary-button {

--- a/src/components/SplitButton/SplitButton.scss
+++ b/src/components/SplitButton/SplitButton.scss
@@ -37,44 +37,47 @@
       &.monday-style-split-button {
         &--color {
           &-primary {
-            &.monday-style-split-button--split-content-open,
-            &.monday-style-split-button--hovered,
-            &:hover,
-            &:focus {
-              .monday-style-split-button__secondary-button {
-                border-color: transparent;
-
-                @include theme-prop(background-color, primary-background-hover-color);
-              }
-
+            &.monday-style-split-button--main-active {
               .monday-style-split-button__main-button {
-                @include theme-prop(background-color, primary-background-hover-color);
+                background-color: var(--primary-selected-hover-color);
               }
-            }
 
-            &.monday-style-split-button--split-content-open {
-              .monday-style-split-button__secondary-button,
-              .monday-style-split-button__secondary-button:hover {
-                @include theme-prop(color, primary-color);
-                @include theme-prop(background-color, primary-selected-color);
+              .monday-style-split-button__secondary-button {
+                background-color: var(--primary-selected-color);
               }
-            }
 
-            .monday-style-split-button__secondary-button {
-              &:hover,
-              &:focus {
-                @include theme-prop(background-color, ui-border-color);
+              &.monday-style-split-button--split-content-open {
+                .monday-style-split-button__main-button {
+                  .monday-style-split-button__main-button {
+                    background-color: var(--primary-selected-color);
+                  }
+
+                  .monday-style-split-button__secondary-button {
+                    background-color: var(--primary-selected-hover-color) !important;
+                  }
+                }
               }
-            }
 
-            .monday-style-split-button__main-button {
-              &:hover,
-              &:focus {
-                @include theme-prop(background-color, ui-border-color);
+              &.monday-style-split-button--split-content-open,
+              &.monday-style-split-button--hovered {
+                &:not(.monday-style-split-button--main-active) {
+                  .monday-style-split-button__secondary-button {
+                    border-color: transparent;
+                    @include theme-prop(background-color, primary-background-hover-color);
+
+                  }
+                }
+
+                &.monday-style-split-button--split-content-open {
+                  .monday-style-split-button__secondary-button,
+                  .monday-style-split-button__secondary-button:hover {
+                    @include theme-prop(color, primary-color);
+                    @include theme-prop(background-color, primary-selected-color);
+                  }
+                }
               }
             }
           }
-
           &-positive {
             &.monday-style-split-button--split-content-open,
             &:hover,
@@ -168,6 +171,25 @@
       &.monday-style-split-button {
         &--color {
           &-primary {
+            &.monday-style-split-button--main-active {
+              .monday-style-split-button__main-button {
+                background-color: var(--primary-selected-hover-color);
+              }
+              .monday-style-split-button__secondary-button {
+                background-color: var(--primary-selected-color);
+                border-color: var(--primary-color);
+              }
+
+              &.monday-style-split-button--split-content-open {
+                .monday-style-split-button__main-button {
+                  background-color: var(--primary-selected-color);
+                }
+                .monday-style-split-button__secondary-button {
+                  background-color: var(--primary-selected-hover-color) !important;
+                }
+              }
+            }
+
             &.monday-style-split-button--split-content-open {
               .monday-style-split-button__secondary-button,
               .monday-style-split-button__secondary-button:hover {

--- a/src/components/SplitButton/SplitButton.tsx
+++ b/src/components/SplitButton/SplitButton.tsx
@@ -153,7 +153,7 @@ const SplitButton: FC<SplitButtonProps> & {
           "monday-style-split-button--main-active": active,
           "monday-style-split-button--active": isActive,
           "monday-style-split-button--split-content-open": isDialogOpen,
-          "monday-style-split-button--hovered": isHovered && !active,
+          "monday-style-split-button--hovered": isHovered,
           "monday-style-split-button--disabled": disabled
         },
         className

--- a/src/components/SplitButton/SplitButton.tsx
+++ b/src/components/SplitButton/SplitButton.tsx
@@ -76,6 +76,7 @@ const SplitButton: FC<SplitButtonProps> & {
   children,
   marginLeft,
   marginRight,
+  active,
   ...buttonProps
 }) => {
   // State //
@@ -149,9 +150,10 @@ const SplitButton: FC<SplitButtonProps> & {
         `monday-style-split-button--kind-${kind}`,
         `monday-style-split-button--color-${color}`,
         {
+          "monday-style-split-button--main-active": active,
           "monday-style-split-button--active": isActive,
           "monday-style-split-button--split-content-open": isDialogOpen,
-          "monday-style-split-button--hovered": isHovered,
+          "monday-style-split-button--hovered": isHovered && !active,
           "monday-style-split-button--disabled": disabled
         },
         className
@@ -198,6 +200,7 @@ const SplitButton: FC<SplitButtonProps> & {
         rightFlat
         color={color}
         kind={kind}
+        active={active}
         onClick={onClick}
         className="monday-style-split-button__main-button"
         marginLeft={marginLeft}


### PR DESCRIPTION
https://monday.monday.com/boards/3533418254/pulses/3534468566

According to meirav request updating active state to be the same for icon button and button (menu button is already support this)
tertiary:
<img width="130" alt="צילום מסך 2022-12-18 ב-13 44 38" src="https://user-images.githubusercontent.com/72390374/208296502-3a03a425-a49f-4e3b-be4b-5d90d965240a.png">

secondary:
<img width="117" alt="צילום מסך 2022-12-18 ב-13 44 18" src="https://user-images.githubusercontent.com/72390374/208296486-053357d7-b120-4a7d-acc5-8fe8e1af5576.png">
