### PR TITLE
fix css build issue :(

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -1,6 +1,7 @@
 import { addParameters } from "@storybook/react";
 import { DocsContainer, DocsPage } from "@storybook/addon-docs";
 import { withPerformance } from "storybook-addon-performance";
+import "monday-ui-style/dist/index.min.css";
 import {
   AnchorListItem,
   ComponentName,

--- a/package-lock.json
+++ b/package-lock.json
@@ -115,6 +115,7 @@
         "mini-css-extract-plugin": "^2.4.5",
         "plop": "2.7.6",
         "postcss": "^8.4.5",
+        "postcss-import": "^15.1.0",
         "postcss-loader": "^6.2.1",
         "postcss-scss": "^4.0.2",
         "preact": "^10.8.0",
@@ -125,6 +126,7 @@
         "react-resizable": "^3.0.4",
         "react-test-renderer": "^16.14.0",
         "rollup": "^2.79.1",
+        "rollup-plugin-import-css": "^3.1.0",
         "rollup-plugin-postcss": "^4.0.2",
         "rollup-plugin-terser": "^7.0.2",
         "rollup-plugin-typescript2": "^0.34.1",
@@ -28695,6 +28697,23 @@
         "node": ">=4"
       }
     },
+    "node_modules/postcss-import": {
+      "version": "15.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-import/-/postcss-import-15.1.0.tgz",
+      "integrity": "sha512-hpr+J05B2FVYUAXHeK1YyI267J/dDDhMU6B6civm8hSY1jYJnBXxzKDKDswzJmtLHryrjhnDjqqp/49t8FALew==",
+      "dev": true,
+      "dependencies": {
+        "postcss-value-parser": "^4.0.0",
+        "read-cache": "^1.0.0",
+        "resolve": "^1.1.7"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.0.0"
+      }
+    },
     "node_modules/postcss-load-config": {
       "version": "3.1.4",
       "resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-3.1.4.tgz",
@@ -30517,6 +30536,24 @@
         "react-with-styles": "^3.0.0 || ^4.0.0"
       }
     },
+    "node_modules/read-cache": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
+      "integrity": "sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA==",
+      "dev": true,
+      "dependencies": {
+        "pify": "^2.3.0"
+      }
+    },
+    "node_modules/read-cache/node_modules/pify": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+      "integrity": "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/read-pkg": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-5.2.0.tgz",
@@ -31451,6 +31488,18 @@
       },
       "optionalDependencies": {
         "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/rollup-plugin-import-css": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-import-css/-/rollup-plugin-import-css-3.1.0.tgz",
+      "integrity": "sha512-+azurUk2QrUNWs1V5EzpuvV9bRQDEjG+aQDadM6ZEc5LbU6VvFiR3+MPIBnqKrg/miBNag/9H1TWhEUv4TH+jQ==",
+      "dev": true,
+      "dependencies": {
+        "@rollup/pluginutils": "^5.0.2"
+      },
+      "peerDependencies": {
+        "rollup": "^2.x.x || ^3.x.x"
       }
     },
     "node_modules/rollup-plugin-postcss": {
@@ -59640,6 +59689,17 @@
         }
       }
     },
+    "postcss-import": {
+      "version": "15.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-import/-/postcss-import-15.1.0.tgz",
+      "integrity": "sha512-hpr+J05B2FVYUAXHeK1YyI267J/dDDhMU6B6civm8hSY1jYJnBXxzKDKDswzJmtLHryrjhnDjqqp/49t8FALew==",
+      "dev": true,
+      "requires": {
+        "postcss-value-parser": "^4.0.0",
+        "read-cache": "^1.0.0",
+        "resolve": "^1.1.7"
+      }
+    },
     "postcss-load-config": {
       "version": "3.1.4",
       "resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-3.1.4.tgz",
@@ -60971,6 +61031,23 @@
         "global-cache": "^1.2.1"
       }
     },
+    "read-cache": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
+      "integrity": "sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA==",
+      "dev": true,
+      "requires": {
+        "pify": "^2.3.0"
+      },
+      "dependencies": {
+        "pify": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+          "integrity": "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==",
+          "dev": true
+        }
+      }
+    },
     "read-pkg": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-5.2.0.tgz",
@@ -61697,6 +61774,15 @@
       "dev": true,
       "requires": {
         "fsevents": "~2.3.2"
+      }
+    },
+    "rollup-plugin-import-css": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-import-css/-/rollup-plugin-import-css-3.1.0.tgz",
+      "integrity": "sha512-+azurUk2QrUNWs1V5EzpuvV9bRQDEjG+aQDadM6ZEc5LbU6VvFiR3+MPIBnqKrg/miBNag/9H1TWhEUv4TH+jQ==",
+      "dev": true,
+      "requires": {
+        "@rollup/pluginutils": "^5.0.2"
       }
     },
     "rollup-plugin-postcss": {

--- a/package.json
+++ b/package.json
@@ -163,6 +163,7 @@
     "mini-css-extract-plugin": "^2.4.5",
     "plop": "2.7.6",
     "postcss": "^8.4.5",
+    "postcss-import": "^15.1.0",
     "postcss-loader": "^6.2.1",
     "postcss-scss": "^4.0.2",
     "preact": "^10.8.0",
@@ -173,6 +174,7 @@
     "react-resizable": "^3.0.4",
     "react-test-renderer": "^16.14.0",
     "rollup": "^2.79.1",
+    "rollup-plugin-import-css": "^3.1.0",
     "rollup-plugin-postcss": "^4.0.2",
     "rollup-plugin-terser": "^7.0.2",
     "rollup-plugin-typescript2": "^0.34.1",
@@ -207,7 +209,9 @@
   },
   "sideEffects": [
     "*.scss",
-    "*.css"
+    "*.css",
+    "*.scss.js",
+    "*.css.js"
   ],
   "storybook-deployer": {
     "commitMessage": "Deploy Storybook [ci-skip]"

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -24,9 +24,9 @@ export default {
   },
   input: {
     index: path.join(SRC_PATH, "index.js")
-    // icons: path.join(SRC_PATH, "components/Icon/Icons/index.ts"),
-    // interactionsTests: path.join(SRC_PATH, "tests/interactions-utils.ts"),
-    // testIds: path.join(SRC_PATH, "tests/test-ids-utils.ts")
+    icons: path.join(SRC_PATH, "components/Icon/Icons/index.ts"),
+    interactionsTests: path.join(SRC_PATH, "tests/interactions-utils.ts"),
+    testIds: path.join(SRC_PATH, "tests/test-ids-utils.ts")
   },
   // external: [/node_modules/],
   external: [/node_modules\/(?!monday-ui-style)(.*)/],

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -23,7 +23,7 @@ export default {
     preserveModules: true
   },
   input: {
-    index: path.join(SRC_PATH, "index.js")
+    index: path.join(SRC_PATH, "index.js"),
     icons: path.join(SRC_PATH, "components/Icon/Icons/index.ts"),
     interactionsTests: path.join(SRC_PATH, "tests/interactions-utils.ts"),
     testIds: path.join(SRC_PATH, "tests/test-ids-utils.ts")

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -5,6 +5,8 @@ import commonjs from "@rollup/plugin-commonjs";
 import typescript from "rollup-plugin-typescript2";
 import { terser } from "rollup-plugin-terser";
 import postcss from "rollup-plugin-postcss";
+import postCssImport from "postcss-import";
+
 import autoprefixer from "autoprefixer";
 
 const EXTENSIONS = [".js", ".jsx", ".ts", ".tsx"];
@@ -21,16 +23,17 @@ export default {
     preserveModules: true
   },
   input: {
-    index: path.join(SRC_PATH, "index.js"),
-    icons: path.join(SRC_PATH, "components/Icon/Icons/index.ts"),
-    interactionsTests: path.join(SRC_PATH, "tests/interactions-utils.ts"),
-    testIds: path.join(SRC_PATH, "tests/test-ids-utils.ts")
+    index: path.join(SRC_PATH, "index.js")
+    // icons: path.join(SRC_PATH, "components/Icon/Icons/index.ts"),
+    // interactionsTests: path.join(SRC_PATH, "tests/interactions-utils.ts"),
+    // testIds: path.join(SRC_PATH, "tests/test-ids-utils.ts")
   },
-  external: [/node_modules/],
+  // external: [/node_modules/],
+  external: [/node_modules\/(?!monday-ui-style)(.*)/],
   plugins: [
     commonjs(),
     nodeResolve({
-      extensions: [...EXTENSIONS, ".json"]
+      extensions: [...EXTENSIONS, ".json", ".css"]
     }),
     typescript({
       tsconfig: path.join(ROOT_PATH, "tsconfig.esm.json")
@@ -55,7 +58,7 @@ export default {
       inject(cssVariableName) {
         return `import styleInject from 'style-inject';\nstyleInject(${cssVariableName});`;
       },
-      plugins: [autoprefixer()],
+      plugins: [autoprefixer(), postCssImport()],
       autoModules: true
     })
   ]

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,5 @@
 import "./general.scss";
+import "./style-imports";
 
 export * from "./components";
 export * from "./hooks";

--- a/src/style-imports.ts
+++ b/src/style-imports.ts
@@ -1,0 +1,1 @@
+import "monday-ui-style/dist/index.min.css";

--- a/src/styles/themes.scss
+++ b/src/styles/themes.scss
@@ -1,5 +1,5 @@
 @import "./theme-mixin";
-@import "~monday-ui-style/dist/index.min.css";
+
 
 $white-theme-bg-color: #fff;
 $white-theme-font-color: #333;

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -60,7 +60,10 @@ module.exports = options => {
   const publishedComponents = storybook ? {} : getPublishedComponents();
 
   const entry = {
-    main: path.join(__dirname, "/src/index.js"),
+    main: [
+      path.join(__dirname, "/node_modules/monday-ui-style/dist/index.min.css"),
+      path.join(__dirname, "/src/index.js")
+    ],
     interactionTests: path.join(__dirname, "/src/tests/interactions-utils"),
     testIds: path.join(__dirname, "/src/tests/test-ids-utils"),
     ...publishedComponents
@@ -88,7 +91,7 @@ module.exports = options => {
         },
         {
           test: /\.(js|jsx)$/,
-          exclude: /node_modules/,
+          exclude: /node_modules\/(?!monday-ui-style)(.*)/,
           use: ["babel-loader"]
         },
         {

--- a/webpack/published-components.js
+++ b/webpack/published-components.js
@@ -12,7 +12,7 @@ function getPublishedComponents() {
   return Object.entries(publishedComponents).reduce(
     (acc, [componentName, componentPath]) => ({
       ...acc,
-      [componentName]: path.join(SRC_PATH, componentPath)
+      [componentName]: [path.join(SRC_PATH, componentPath), path.join(SRC_PATH, "/style-imports.js")]
     }),
     exposeIcons()
   );

--- a/webpack/published-components.js
+++ b/webpack/published-components.js
@@ -12,7 +12,7 @@ function getPublishedComponents() {
   return Object.entries(publishedComponents).reduce(
     (acc, [componentName, componentPath]) => ({
       ...acc,
-      [componentName]: [path.join(SRC_PATH, componentPath), path.join(SRC_PATH, "/style-imports.js")]
+      [componentName]: [path.join(SRC_PATH, componentPath), "/node_modules/monday-ui-style/dist/index.min.css"]
     }),
     exposeIcons()
   );


### PR DESCRIPTION
After the rollup migration we had an issue where we were trying to load monday-ui-style css with the wrong path
this fix fixes it by moving the import to the a ts file and combining it with the webpack build as multiple entries