### PR TITLE
feature: added isLoading and loadingMessage props into Dropdown

### DIFF
--- a/src/components/Dropdown/Dropdown.jsx
+++ b/src/components/Dropdown/Dropdown.jsx
@@ -68,7 +68,9 @@ const Dropdown = ({
   insideOverflowWithTransformContainer,
   ref,
   tooltipContent,
-  onKeyDown
+  onKeyDown,
+  isLoading,
+  loadingMessage
 }) => {
   const controlRef = useRef();
   const overrideDefaultValue = useMemo(() => {
@@ -304,6 +306,8 @@ const Dropdown = ({
       withMandatoryDefaultOptions={withMandatoryDefaultOptions}
       isOptionSelected={isOptionSelected}
       aria-details={tooltipContent}
+      isLoading={isLoading}
+      loadingMessage={loadingMessage}
       {...asyncAdditions}
       {...additions}
     />
@@ -339,7 +343,9 @@ Dropdown.defaultProps = {
   withMandatoryDefaultOptions: false,
   insideOverflowContainer: false,
   insideOverflowWithTransformContainer: false,
-  tooltipContent: ""
+  tooltipContent: "",
+  isLoading: false,
+  loadingMessage: undefined
 };
 
 Dropdown.propTypes = {
@@ -549,7 +555,15 @@ Dropdown.propTypes = {
   /**
    * When content is passed, the dropdown will include a tooltip on the dropdown's value.
    */
-  tooltipContent: PropTypes.string
+  tooltipContent: PropTypes.string,
+  /**
+   * Display the drop down with loading state.
+   */
+  isLoading: PropTypes.bool,
+  /**
+   * Overrides the built-in logic of loading message design
+   */
+  loadingMessage: PropTypes.func
 };
 
 export default Dropdown;

--- a/src/components/Dropdown/__stories__/dropdown.stories.mdx
+++ b/src/components/Dropdown/__stories__/dropdown.stories.mdx
@@ -704,6 +704,45 @@ with overflow hidden content which use CSS transform function.
   </Story>
 </Canvas>
 
+### Dropdown with loading
+
+If importing the drop down options may take time, you can reflect this to the user using Dropdown isLoading flag with optional custom message.
+
+<Canvas>
+  <Story name="Dropdown with loading">
+    {() => {
+      const [isLoading, setIsLoading] = useState(false);
+      const options = useMemo(
+        () => [
+          { value: "1", label: "Option 1" },
+          { value: "2", label: "Option 2" },
+          { value: "3", label: "Option 3" }
+        ],
+        []
+      );
+      const loadingOnInputChange = useCallback(
+        () => {
+          setIsLoading(true);
+          setTimeout(() => {
+            setIsLoading(false);
+          }, 1000);
+        },
+        []
+      );
+      return (
+        <Dropdown
+          placeholder={"Type to start loading"}
+          options={options}
+          isLoading={isLoading}
+          loadingMessage={() => "Loading options..."}
+          className="dropdown-stories-styles_big-spacing"
+          onInputChange={loadingOnInputChange}
+        />
+      );
+    }}
+  </Story>
+</Canvas>
+
 ## Related components
 
 <RelatedComponents componentsNames={[COMBOBOX, SPLIT_BUTTON, MENU]} />


### PR DESCRIPTION
Exposed 2 props relevant for loading state in the dropdown. These props exist in react-select, just wern't propogated to it.

https://user-images.githubusercontent.com/103024234/221595853-c3905d07-48e7-4a0f-b036-a3cb9f1e6cc6.mov


#### Basic
- [ ] Used plop (`npm run plop`) to create a new component.
- [x] PR has description.
- [ ] New component is functional and uses Hooks. 
- [x] Component defines [`PropTypes`](https://reactjs.org/docs/typechecking-with-proptypes.html).
#### Style
- [ ] Styles are added to `NewComponent.modules.scss` file inside of the `NewComponent` folder.
- [ ] Component uses CSS Modules.
- [ ] Design is compatible with [Monday Design System](https://design.monday.com/).
#### Storybook
- [X] Stories were added to `/src/NewComponent/__stories__/NewComponent.stories.js` file.
- [X] Stories include all flows of using the component.
#### Tests
- [ ] Tests are compliant with [TESTING_README.md](TESTING_README.md) instructions.
