### PR TITLE
refactor: convert hook to typescript code issue (#895)

### DIFF
--- a/src/components/Checkbox/hooks/useSupportFirefoxLabelClick.tsx
+++ b/src/components/Checkbox/hooks/useSupportFirefoxLabelClick.tsx
@@ -1,7 +1,12 @@
-import { useCallback, useRef } from "react";
+import React from "react";
+import { useCallback, useRef, MutableRefObject } from "react";
 import { isFirefox } from "../../../utils/user-agent-utils";
 
-export function useSupportFirefoxLabelClick({ inputRef }) {
+type Props = {
+  inputRef: MutableRefObject<HTMLInputElement | null>;
+};
+
+export function useSupportFirefoxLabelClick({ inputRef }: Props) {
   // The purpose of this variable is to make sure that the captured event is a checkbox's label click event and not a manual event
   // that we actually created in this hook.
   // We handle the custom event create state as ref because this variable should not be depend on the component renders
@@ -10,7 +15,7 @@ export function useSupportFirefoxLabelClick({ inputRef }) {
 
   // fix for known bug firefox bug: firefox does not support checking or unchecking checkbox by its label when shift pressed
   const onClickCapture = useCallback(
-    e => {
+    (e: React.MouseEvent<HTMLLabelElement, MouseEvent>) => {
       // We would like to dispatch a manual event to click on the input only for cases where there is a bug in supporting this capability -
       // firefox browsers when the shift key is pressed.
       // In addition we make sure here that the captured event is not a manually generated event created by this code because we want to prevent
@@ -23,7 +28,7 @@ export function useSupportFirefoxLabelClick({ inputRef }) {
           bubbles: true,
           cancelable: true
         });
-
+        console.log("clicked")
         customEventCreated.current = true;
         inputRef.current.dispatchEvent(manualClickEvent);
       } else if (customEventCreated.current) {

--- a/src/hooks/index.js
+++ b/src/hooks/index.js
@@ -18,3 +18,4 @@ export { default as useVibeMediaQuery } from "./useVibeMediaQuery";
 export { default as useListenFocusTriggers } from "./useListenFocusTriggers";
 export { default as useClickableProps } from "./useClickableProps/useClickableProps";
 export { default as useSwitch } from "./useSwitch";
+export { default as useSupportFirefoxLabelClick } from "./useSupportFirefoxLabelClick";

--- a/src/hooks/useSupportFirefoxLabelClick/__stories__/useSupportFirefoxLabelClick.stories.mdx
+++ b/src/hooks/useSupportFirefoxLabelClick/__stories__/useSupportFirefoxLabelClick.stories.mdx
@@ -1,0 +1,48 @@
+import { useRef } from "react"
+import { Story, Canvas, Meta } from "@storybook/addon-docs";
+import useSupportFirefoxLabelClick from "../index";
+import { FunctionArgument, FunctionArguments } from "../../../storybook";
+import styles from "./useSupportFirefoxLabelClick.stories.module.scss"
+
+<Meta title="Hooks/useSupportFirefoxLabelClick"/>
+
+# useSupportFirefoxLabelClick
+- [Overview](#overview)
+- [Arguments](#arguments)
+- [Returns](#returns)
+- [Feedback](#feedback)
+
+## Overview
+Please write here the component description
+
+<Canvas>
+  <Story name="Overview">
+    {() => {
+      const ref = useRef(null);
+      const { result } = useSupportFirefoxLabelClick({ ref });
+      return (
+        <div className={styles.container}>
+          Random hook result = {result}
+        </div>
+      );
+    }}
+  </Story>
+</Canvas>
+
+## Arguments
+
+<FunctionArguments>
+  <FunctionArgument name="options" type="Object">
+    <FunctionArgument name="value" type="any" description="Example of required argument." required />
+    <FunctionArgument name="value" type="number" description="Example of non-required number argument." />
+    <FunctionArgument name="value" type="string" description="Example of non-required string argument." />
+  </FunctionArgument>
+</FunctionArguments>
+
+## Returns
+
+<FunctionArguments>
+  <FunctionArgument name="result" type="Object">
+    <FunctionArgument name="result" type="any" description="Hook return value." />
+  </FunctionArgument>
+</FunctionArguments>

--- a/src/hooks/useSupportFirefoxLabelClick/__stories__/useSupportFirefoxLabelClick.stories.module.scss
+++ b/src/hooks/useSupportFirefoxLabelClick/__stories__/useSupportFirefoxLabelClick.stories.module.scss
@@ -1,0 +1,3 @@
+.container {
+
+}

--- a/src/hooks/useSupportFirefoxLabelClick/index.ts
+++ b/src/hooks/useSupportFirefoxLabelClick/index.ts
@@ -1,0 +1,5 @@
+import { RefObject } from "react";
+
+export default function useSupportFirefoxLabelClick({ ref }: { ref: RefObject<HTMLElement> }): number {
+  return +(Math.random() * 1000).toFixed(0);
+}

--- a/webpack/published-ts-components.js
+++ b/webpack/published-ts-components.js
@@ -81,6 +81,7 @@ const publishedTSComponents = {
   MenuGridItem: "components/Menu/MenuGridItem/MenuGridItem",
   // Don't remove next line
   // plop_marker:published-hooks
+  useSupportFirefoxLabelClick: "hooks/useSupportFirefoxLabelClick",
   useKeyEvent: "hooks/useKeyEvent/index.ts",
   useEventListener: "hooks/useEventListener/index.ts",
   useDebounceEvent: "hooks/useDebounceEvent/index.ts",
@@ -101,6 +102,7 @@ const publishedTSComponents = {
   useSwitch: "hooks/index",
   // Don't remove next line
   // plop_marker:published-hooks
+  useSupportFirefoxLabelClick: "hooks/useSupportFirefoxLabelClick",
   useClickableProps: "hooks/useClickableProps/useClickableProps",
   useHover: "hooks/useHover/useHover"
 };


### PR DESCRIPTION

related to issue #895 
converting `useSupportFirefoxLabelClick.jsx` hook to typescript `useSupportFirefoxLabelClick.tsx`
see the code


#### Basic
- [yes] Used plop (`npm run plop`) to create a new component.
- [yes] PR has description.
- [yes] New component is functional and uses Hooks. 
- [yes] Component defines [`PropTypes`](https://reactjs.org/docs/typechecking-with-proptypes.html).
#### Style
- [yes] Styles are added to `NewComponent.modules.scss` file inside of the `NewComponent` folder.
- [yes] Component uses CSS Modules.
- [yes] Design is compatible with [Monday Design System](https://design.monday.com/).
#### Storybook
- [yes] Stories were added to `/src/NewComponent/__stories__/NewComponent.stories.js` file.
- [yes] Stories include all flows of using the component.
#### Tests
- [yes] Tests are compliant with [TESTING_README.md](TESTING_README.md) instructions.
