### PR TITLE
MenuItem id

### DIFF
--- a/src/components/Menu/Menu/Menu.tsx
+++ b/src/components/Menu/Menu/Menu.tsx
@@ -76,7 +76,7 @@ const Menu: VibeComponent<MenuProps> & {
     const mergedRef = useMergeRefs({ refs: [ref, forwardedRef] });
 
     const overrideClassName = backwardCompatibilityForProperties([className, classname]);
-    const [activeItemIndex, setActiveItemIndexState] = useState(focusItemIndex);
+    const [activeItemIndex, setActiveItemIndex] = useState(focusItemIndex);
     const [isInitialSelectedState, setIsInitialSelectedState] = useState(false);
 
     const children = useMemo(() => {
@@ -92,9 +92,9 @@ const Menu: VibeComponent<MenuProps> & {
       });
     }, [originalChildren]);
 
-    const setActiveItemIndex = useCallback(
+    const updateActiveItemIndex = useCallback(
       (index: number) => {
-        setActiveItemIndexState(index);
+        setActiveItemIndex(index);
 
         const activeChild = children[index];
         const ariaActiveDescendant = React.isValidElement(activeChild)
@@ -111,19 +111,19 @@ const Menu: VibeComponent<MenuProps> & {
 
     const onSetActiveItemIndexCallback = useCallback(
       (index: number) => {
-        setActiveItemIndex(index);
+        updateActiveItemIndex(index);
         setIsInitialSelectedState(false);
       },
-      [setActiveItemIndex]
+      [updateActiveItemIndex]
     );
 
     useEffect(() => {
       if (focusItemIndexOnMount === -1) {
         return;
       }
-      setActiveItemIndex(focusItemIndexOnMount);
+      updateActiveItemIndex(focusItemIndexOnMount);
       setIsInitialSelectedState(true);
-    }, [focusItemIndexOnMount, setActiveItemIndex, setIsInitialSelectedState]);
+    }, [focusItemIndexOnMount, updateActiveItemIndex, setIsInitialSelectedState]);
 
     const { setSubMenuIsOpenByIndex, hasOpenSubMenu, openSubMenuIndex, setOpenSubMenuIndex, resetOpenSubMenuIndex } =
       useSubMenuIndex();
@@ -199,7 +199,7 @@ const Menu: VibeComponent<MenuProps> & {
                   ...child?.props,
                   activeItemIndex,
                   index,
-                  setActiveItemIndex,
+                  setActiveItemIndex: updateActiveItemIndex,
                   menuRef: ref,
                   resetOpenSubMenuIndex,
                   isParentMenuVisible: isVisible,

--- a/src/components/Menu/Menu/Menu.tsx
+++ b/src/components/Menu/Menu/Menu.tsx
@@ -90,6 +90,12 @@ const Menu: VibeComponent<MenuProps> & {
       });
     }, [originalChildren]);
 
+    useEffect(() => {
+      if (!id) {
+        console.warn("Menu should have a valid id prop");
+      }
+    }, [id]);
+
     const updateActiveItemIndex = useCallback(
       (index: number) => {
         setActiveItemIndex(index);

--- a/src/components/Menu/Menu/Menu.tsx
+++ b/src/components/Menu/Menu/Menu.tsx
@@ -23,7 +23,6 @@ import { useFocusWithin } from "../../../hooks/useFocusWithin";
 import usePrevious from "../../../hooks/usePrevious";
 import { VibeComponent, VibeComponentProps } from "../../../types";
 import { CloseMenuOption } from "./MenuConstants";
-import { generateUuid } from "../../../utils/function-utils";
 import "./Menu.scss";
 
 interface MenuProps extends VibeComponentProps {
@@ -71,8 +70,6 @@ const Menu: VibeComponent<MenuProps> & {
     },
     forwardedRef
   ) => {
-    const overrideId = useMemo(() => id || `menu-${generateUuid()}`, [id]);
-
     const ref = useRef<HTMLElement>(null);
     const mergedRef = useMergeRefs({ refs: [ref, forwardedRef] });
 
@@ -99,7 +96,7 @@ const Menu: VibeComponent<MenuProps> & {
 
         const activeChild = children[index];
         const ariaActiveDescendant = React.isValidElement(activeChild)
-          ? activeChild?.props?.id || `${overrideId}-${index}`
+          ? activeChild?.props?.id || `${id}-${index}`
           : undefined;
         if (ariaActiveDescendant) {
           ref?.current?.setAttribute("aria-activedescendant", ariaActiveDescendant);
@@ -107,7 +104,7 @@ const Menu: VibeComponent<MenuProps> & {
           ref?.current?.removeAttribute("aria-activedescendant");
         }
       },
-      [children, overrideId]
+      [children, id]
     );
 
     const onSetActiveItemIndexCallback = useCallback(
@@ -184,7 +181,7 @@ const Menu: VibeComponent<MenuProps> & {
       <ul
         onFocus={focusWithinProps?.onFocus}
         onBlur={focusWithinProps?.onBlur}
-        id={overrideId}
+        id={id}
         className={cx("monday-style-menu", overrideClassName, `monday-style-menu--${size}`)}
         ref={mergedRef}
         tabIndex={tabIndex}
@@ -207,7 +204,7 @@ const Menu: VibeComponent<MenuProps> & {
                   setSubMenuIsOpenByIndex,
                   hasOpenSubMenu: index === openSubMenuIndex,
                   closeMenu: onCloseMenu,
-                  menuId: overrideId,
+                  menuId: id,
                   useDocumentEventListeners,
                   isInitialSelectedState,
                   shouldScrollMenu,

--- a/src/components/Menu/Menu/Menu.tsx
+++ b/src/components/Menu/Menu/Menu.tsx
@@ -23,6 +23,7 @@ import { useFocusWithin } from "../../../hooks/useFocusWithin";
 import usePrevious from "../../../hooks/usePrevious";
 import { VibeComponent, VibeComponentProps } from "../../../types";
 import { CloseMenuOption } from "./MenuConstants";
+import { generateUuid } from "../../../utils/function-utils";
 import "./Menu.scss";
 
 interface MenuProps extends VibeComponentProps {
@@ -70,7 +71,7 @@ const Menu: VibeComponent<MenuProps> & {
     },
     forwardedRef
   ) => {
-    const overrideId = useMemo(() => id || `menu-${crypto.randomUUID()}`, [id]);
+    const overrideId = useMemo(() => id || `menu-${generateUuid()}`, [id]);
 
     const ref = useRef<HTMLElement>(null);
     const mergedRef = useMergeRefs({ refs: [ref, forwardedRef] });

--- a/src/components/Menu/Menu/Menu.tsx
+++ b/src/components/Menu/Menu/Menu.tsx
@@ -22,8 +22,8 @@ import { useAdjacentSelectableMenuIndex } from "./hooks/useAdjacentSelectableMen
 import { useFocusWithin } from "../../../hooks/useFocusWithin";
 import usePrevious from "../../../hooks/usePrevious";
 import { VibeComponent, VibeComponentProps } from "../../../types";
-import "./Menu.scss";
 import { CloseMenuOption } from "./MenuConstants";
+import "./Menu.scss";
 
 interface MenuProps extends VibeComponentProps {
   /** Backward compatibility for props naming **/
@@ -50,7 +50,7 @@ const Menu: VibeComponent<MenuProps> & {
 } = forwardRef(
   (
     {
-      id = "menu",
+      id,
       className,
       // Backward compatibility for props naming
       classname,
@@ -70,6 +70,8 @@ const Menu: VibeComponent<MenuProps> & {
     },
     forwardedRef
   ) => {
+    const overrideId = useMemo(() => id || `menu-${crypto.randomUUID()}`, [id]);
+
     const ref = useRef<HTMLElement>(null);
     const mergedRef = useMergeRefs({ refs: [ref, forwardedRef] });
 
@@ -96,7 +98,7 @@ const Menu: VibeComponent<MenuProps> & {
 
         const activeChild = children[index];
         const ariaActiveDescendant = React.isValidElement(activeChild)
-          ? activeChild?.props?.id || `${id}-${index}`
+          ? activeChild?.props?.id || `${overrideId}-${index}`
           : undefined;
         if (ariaActiveDescendant) {
           ref?.current?.setAttribute("aria-activedescendant", ariaActiveDescendant);
@@ -104,7 +106,7 @@ const Menu: VibeComponent<MenuProps> & {
           ref?.current?.removeAttribute("aria-activedescendant");
         }
       },
-      [children, id]
+      [children, overrideId]
     );
 
     const onSetActiveItemIndexCallback = useCallback(
@@ -181,7 +183,7 @@ const Menu: VibeComponent<MenuProps> & {
       <ul
         onFocus={focusWithinProps?.onFocus}
         onBlur={focusWithinProps?.onBlur}
-        id={id}
+        id={overrideId}
         className={cx("monday-style-menu", overrideClassName, `monday-style-menu--${size}`)}
         ref={mergedRef}
         tabIndex={tabIndex}
@@ -204,7 +206,7 @@ const Menu: VibeComponent<MenuProps> & {
                   setSubMenuIsOpenByIndex,
                   hasOpenSubMenu: index === openSubMenuIndex,
                   closeMenu: onCloseMenu,
-                  menuId: id,
+                  menuId: overrideId,
                   useDocumentEventListeners,
                   isInitialSelectedState,
                   shouldScrollMenu,

--- a/src/components/Menu/Menu/__tests__/__snapshots__/menu.jest.js.snap
+++ b/src/components/Menu/Menu/__tests__/__snapshots__/menu.jest.js.snap
@@ -4,7 +4,7 @@ exports[`Snapshots renders correctly with children 1`] = `
 <ul
   aria-label="Menu"
   className="monday-style-menu dummy-class-name monday-style-menu--medium"
-  id="menu"
+  id="menu-lgt9666osanxf"
   onBlur={[Function]}
   onFocus={[Function]}
   onMouseOver={[Function]}
@@ -23,7 +23,7 @@ exports[`Snapshots renders correctly with children 1`] = `
   <li
     aria-current={false}
     className="monday-style-menu-item"
-    id="menu-1"
+    id="menu-lgt9666osanxf-1"
     onClick={[Function]}
     role="menuitem"
     tabIndex={-1}
@@ -49,7 +49,7 @@ exports[`Snapshots renders correctly with children 1`] = `
   <li
     aria-current={false}
     className="monday-style-menu-item"
-    id="menu-2"
+    id="menu-lgt9666osanxf-2"
     onClick={[Function]}
     role="menuitem"
     tabIndex={-1}
@@ -79,7 +79,7 @@ exports[`Snapshots renders correctly with custom class name 1`] = `
 <ul
   aria-label="Menu"
   className="monday-style-menu dummy-class-name monday-style-menu--medium"
-  id="menu"
+  id="menu-lgt9666bvghy5"
   onBlur={[Function]}
   onFocus={[Function]}
   onMouseOver={[Function]}
@@ -92,7 +92,7 @@ exports[`Snapshots renders correctly with empty props 1`] = `
 <ul
   aria-label="Menu"
   className="monday-style-menu monday-style-menu--medium"
-  id="menu"
+  id="menu-lgt9665l106pl"
   onBlur={[Function]}
   onFocus={[Function]}
   onMouseOver={[Function]}

--- a/src/components/Menu/Menu/__tests__/__snapshots__/menu.jest.js.snap
+++ b/src/components/Menu/Menu/__tests__/__snapshots__/menu.jest.js.snap
@@ -4,7 +4,6 @@ exports[`Snapshots renders correctly with children 1`] = `
 <ul
   aria-label="Menu"
   className="monday-style-menu dummy-class-name monday-style-menu--medium"
-  id="menu-lgt9666osanxf"
   onBlur={[Function]}
   onFocus={[Function]}
   onMouseOver={[Function]}
@@ -23,7 +22,7 @@ exports[`Snapshots renders correctly with children 1`] = `
   <li
     aria-current={false}
     className="monday-style-menu-item"
-    id="menu-lgt9666osanxf-1"
+    id="undefined-1"
     onClick={[Function]}
     role="menuitem"
     tabIndex={-1}
@@ -49,7 +48,7 @@ exports[`Snapshots renders correctly with children 1`] = `
   <li
     aria-current={false}
     className="monday-style-menu-item"
-    id="menu-lgt9666osanxf-2"
+    id="undefined-2"
     onClick={[Function]}
     role="menuitem"
     tabIndex={-1}
@@ -79,7 +78,6 @@ exports[`Snapshots renders correctly with custom class name 1`] = `
 <ul
   aria-label="Menu"
   className="monday-style-menu dummy-class-name monday-style-menu--medium"
-  id="menu-lgt9666bvghy5"
   onBlur={[Function]}
   onFocus={[Function]}
   onMouseOver={[Function]}
@@ -92,7 +90,6 @@ exports[`Snapshots renders correctly with empty props 1`] = `
 <ul
   aria-label="Menu"
   className="monday-style-menu monday-style-menu--medium"
-  id="menu-lgt9665l106pl"
   onBlur={[Function]}
   onFocus={[Function]}
   onMouseOver={[Function]}

--- a/src/components/Menu/Menu/__tests__/__snapshots__/menu.jest.js.snap
+++ b/src/components/Menu/Menu/__tests__/__snapshots__/menu.jest.js.snap
@@ -2,9 +2,9 @@
 
 exports[`Snapshots renders correctly with children 1`] = `
 <ul
-  aria-activedescendant="undefined--1"
   aria-label="Menu"
   className="monday-style-menu dummy-class-name monday-style-menu--medium"
+  id="menu"
   onBlur={[Function]}
   onFocus={[Function]}
   onMouseOver={[Function]}
@@ -23,7 +23,7 @@ exports[`Snapshots renders correctly with children 1`] = `
   <li
     aria-current={false}
     className="monday-style-menu-item"
-    id="undefined-1"
+    id="menu-1"
     onClick={[Function]}
     role="menuitem"
     tabIndex={-1}
@@ -49,7 +49,7 @@ exports[`Snapshots renders correctly with children 1`] = `
   <li
     aria-current={false}
     className="monday-style-menu-item"
-    id="undefined-2"
+    id="menu-2"
     onClick={[Function]}
     role="menuitem"
     tabIndex={-1}
@@ -77,9 +77,9 @@ exports[`Snapshots renders correctly with children 1`] = `
 
 exports[`Snapshots renders correctly with custom class name 1`] = `
 <ul
-  aria-activedescendant="undefined--1"
   aria-label="Menu"
   className="monday-style-menu dummy-class-name monday-style-menu--medium"
+  id="menu"
   onBlur={[Function]}
   onFocus={[Function]}
   onMouseOver={[Function]}
@@ -90,9 +90,9 @@ exports[`Snapshots renders correctly with custom class name 1`] = `
 
 exports[`Snapshots renders correctly with empty props 1`] = `
 <ul
-  aria-activedescendant="undefined--1"
   aria-label="Menu"
   className="monday-style-menu monday-style-menu--medium"
+  id="menu"
   onBlur={[Function]}
   onFocus={[Function]}
   onMouseOver={[Function]}

--- a/src/components/Menu/Menu/__tests__/menu.jest.js
+++ b/src/components/Menu/Menu/__tests__/menu.jest.js
@@ -36,17 +36,19 @@ describe("Snapshots", () => {
 jest.useFakeTimers();
 const menuTitleCaption = "Title";
 const menuItem1Name = "My item 1";
+const menuItem1Id = "menu-item-1";
 const menuItem1OnClickMock = jest.fn();
 const menuItem2OnClickMock = jest.fn();
 const menuItem2Name = "My item 2";
+const menuItem2Id = "menu-item-2";
 
 const renderComponent = ({ ...props } = {}) => {
   return render(
     <Menu {...props} ariaLabel="menu">
       <MenuTitle caption={menuTitleCaption} />
-      <MenuItem title={menuItem1Name} onClick={menuItem1OnClickMock} />
+      <MenuItem title={menuItem1Name} onClick={menuItem1OnClickMock} id={menuItem1Id} />
       <Divider />
-      <MenuItem title={menuItem2Name} onClick={menuItem2OnClickMock} />
+      <MenuItem title={menuItem2Name} onClick={menuItem2OnClickMock} id={menuItem2Id} />
     </Menu>
   );
 };
@@ -100,5 +102,21 @@ describe.skip("<Menu />", () => {
     jest.advanceTimersByTime(1000);
     expect(menuItem1OnClickMock.mock.calls.length).toBe(1);
     expect(menuItem2OnClickMock.mock.calls.length).toBe(0);
+  });
+
+  it("menu has correct active-descendant when item is active", () => {
+    const menuComponent = renderComponent();
+    expect(menuComponent).not.toHaveAttribute("aria-activedescendant");
+
+    const menuItem = menuComponent.getByText(menuItem1Name);
+
+    act(() => {
+      fireEvent.mouseOver(menuItem);
+      jest.advanceTimersByTime(1000);
+      fireEvent.click(menuItem);
+    });
+
+    jest.advanceTimersByTime(1000);
+    expect(menuComponent).toHaveAttribute("aria-activedescendant", menuItem1Id);
   });
 });

--- a/src/components/Menu/MenuItem/MenuItem.tsx
+++ b/src/components/Menu/MenuItem/MenuItem.tsx
@@ -92,6 +92,7 @@ const MenuItem: VibeComponent<MenuItemProps> & {
       setActiveItemIndex,
       index,
       key,
+      id,
       menuId,
       children,
       isParentMenuVisible = false,
@@ -280,7 +281,7 @@ const MenuItem: VibeComponent<MenuItemProps> & {
     return (
       // eslint-disable-next-line jsx-a11y/click-events-have-key-events
       <li
-        id={`${menuId}-${index}`}
+        id={id || `${menuId}-${index}`}
         key={key}
         {...a11yProps}
         className={cx("monday-style-menu-item", overrideClassName, {

--- a/src/utils/function-utils.ts
+++ b/src/utils/function-utils.ts
@@ -49,10 +49,3 @@ export function convertToArray<T>(input: T | Array<T>): Array<T> {
 }
 
 export function NOOP() {}
-
-/**
- * Ids generator function (12 symbols). If IDs are generated more than 1 millisecond apart, they are 100% unique.
- */
-export function generateUuid() {
-  return Date.now().toString(36) + Math.random().toString(36).substring(8);
-}

--- a/src/utils/function-utils.ts
+++ b/src/utils/function-utils.ts
@@ -49,3 +49,10 @@ export function convertToArray<T>(input: T | Array<T>): Array<T> {
 }
 
 export function NOOP() {}
+
+/**
+ * Ids generator function (12 symbols). If IDs are generated more than 1 millisecond apart, they are 100% unique.
+ */
+export function generateUuid() {
+  return Date.now().toString(36) + Math.random().toString(36).substring(8);
+}


### PR DESCRIPTION
https://monday.monday.com/boards/3532714909/pulses/4328988728

By request: https://monday.slack.com/archives/C02S6F817JQ/p1681833672598009?thread_ts=1681828071.936349&cid=C02S6F817JQ

Feels like an overkill most definitely... not sure if we even need this...

Other solution would be just to omit Id from Menuitem props - and let people use its index combined with menuId