### PR TITLE
chore: expose entry in types for non-ts components

### DIFF
--- a/scripts/build-utils.js
+++ b/scripts/build-utils.js
@@ -1,7 +1,11 @@
 #!/usr/bin/env node
 const fs = require("fs");
 const path = require("path");
-const { publishedTSComponents, publishedStorybookComponents } = require("../webpack/published-components");
+const {
+  publishedTSComponents,
+  publishedJSComponents,
+  publishedStorybookComponents
+} = require("../webpack/published-components");
 
 function createFoldersIfNotExist() {
   // if dist is not exist let's create it
@@ -28,16 +32,22 @@ function buildComponentExport(name, path) {
   return `export { default as ${name} } from "${path}";`;
 }
 
+function buildExportToComponentWithoutType(name) {
+  return `export const ${name}: any;`;
+}
+
 function convertExportsToFile(exportsArray, fileName) {
-  const content = exportsArray.join("\n");
+  const content = `${exportsArray.join("\n")}\n`;
   fs.writeFileSync(path.join(__dirname, `../dist/${fileName}`), content, "utf8");
 }
 
 function buildComponentsTypesIndexFile() {
-  const exports = Object.entries(publishedTSComponents).map(([name, path]) =>
+  const exportsWithTypescript = Object.entries(publishedTSComponents).map(([name, path]) =>
     buildComponentExport(name, `./types/${path}`)
   );
-  convertExportsToFile(exports, "types.d.ts");
+
+  const exportsWithJavasript = Object.keys(publishedJSComponents).map(name => buildExportToComponentWithoutType(name));
+  convertExportsToFile(exportsWithTypescript.concat(exportsWithJavasript), "types.d.ts");
 }
 
 function buildStorybookComponentsIndexFile() {

--- a/webpack/published-ts-components.js
+++ b/webpack/published-ts-components.js
@@ -102,7 +102,7 @@ const publishedTSComponents = {
   useVibeMediaQuery: "hooks/useVibeMediaQuery",
   useActiveDescendantListFocus: "hooks/useActiveDescendantListFocus",
   useListenFocusTriggers: "hooks/useListenFocusTriggers",
-  useSwitch: "hooks/index",
+  useSwitch: "hooks/useSwitch",
   // Don't remove next line
   // plop_marker:published-hooks
   useClickableProps: "hooks/useClickableProps/useClickableProps",


### PR DESCRIPTION
Solves https://github.com/mondaycom/monday-ui-react-core/issues/1243

Include in the `dist/types.d.ts` file exports for components not yet migrated to ts (specifically `Dropdown`).
I also fixed the export path of `useSwitch` and add an empty line at the bottom of the file

This will now expose the following:
```ts
export { default as Button } from "./types/components/Button/Button";
.
.
.
export { default as useSwitch } from "./types/hooks/useSwitch";
.
.
.
declare const ResponsiveList: any;
declare const MultiStepIndicator: any;
declare const Dropdown: any;
declare const GridKeyboardNavigationContext: any;
declare const allIcons: any;
```