### PR TITLE
chore: <Avatar/>, <AvatarGroup/> - update stories to show absolute urls to files and fix Avatar story to use AvatarGroup

### DIFF
--- a/src/components/Avatar/__stories__/avatar.stories.mdx
+++ b/src/components/Avatar/__stories__/avatar.stories.mdx
@@ -1,4 +1,5 @@
 import Avatar from "../Avatar";
+import AvatarGroup from "../../AvatarGroup/AvatarGroup";
 import { createComponentTemplate, createStoryMetaSettings } from "../../../storybook";
 import { ArgsTable, Canvas, Meta, Story } from "@storybook/addon-docs";
 import {
@@ -256,20 +257,6 @@ Use for non-person avatars, such as a workspace or team.
 
 ## Use cases and examples
 
-### Multiple avatars
-
-When there is more than one avatar, use an -8 margin between avatars.
-
-<Canvas>
-  <Story name="Multiple avatars">
-    <MultipleStoryElementsWrapper className="monday-storybook-avatar_multiple">
-      <Avatar className="multiple-avatar" size={Avatar.sizes.LARGE} type={Avatar.types.IMG} src={person1} ariaLabel="Hadas Fahri" />
-      <Avatar className="multiple-avatar" size={Avatar.sizes.LARGE} type={Avatar.types.IMG} src={person2} ariaLabel="Sergey Roytman" />
-      <Avatar className="multiple-avatar" size={Avatar.sizes.LARGE} type={Avatar.types.IMG} src={person3} ariaLabel="Yonatan Lev Ari" />
-    </MultipleStoryElementsWrapper>
-  </Story>
-</Canvas>
-
 ### Avatar with right badge
 
 Use to indicate the user’s permissions such as: Guest, owner.
@@ -374,6 +361,21 @@ Use to fire actions on avatar click event.
     }}
   </Story>
 </Canvas>
+
+### Multiple avatars
+
+To group multiple Avatars together, use the <Link href="/?path=/docs/media-avatar-avatargroup--overview">`<AvatarGroup/>`</Link> component
+
+<Canvas>
+  <Story name="Multiple avatars">
+    <AvatarGroup max={2} size={Avatar.sizes.LARGE}>
+      <Avatar type={Avatar.types.IMG} src={person1} ariaLabel="Hadas Fahri" />
+      <Avatar type={Avatar.types.IMG} src={person2} ariaLabel="Sergey Roytman" />
+      <Avatar type={Avatar.types.IMG} src={person3} ariaLabel="Yonatan Lev Ari" />
+    </AvatarGroup>
+  </Story>
+</Canvas>
+
 
 ## Related components
 

--- a/src/components/Avatar/__stories__/avatar.stories.mdx
+++ b/src/components/Avatar/__stories__/avatar.stories.mdx
@@ -61,7 +61,7 @@ Avatar is a graphical representation of a person through a profile picture, imag
     name="Overview"
     args={{
       size: Avatar.sizes.LARGE,
-      src: person1,
+      src: window.location.origin + '/' + person1,
       type: Avatar.types.IMG,
       ariaLabel: "Hadas Fahri"
     }}

--- a/src/components/AvatarGroup/__stories__/AvatarGroup.stories.mdx
+++ b/src/components/AvatarGroup/__stories__/AvatarGroup.stories.mdx
@@ -18,6 +18,26 @@ export const metaSettings = createStoryMetaSettings({
   enumPropNamesArray: ["type", "size"] // List enum props here
 });
 
+export const avatarGroupTemplate = ({persons, ...args}) => {
+return (
+  <AvatarGroup size={Avatar.sizes.LARGE} max={3} {...args}>
+    <Avatar type={Avatar.types.IMG} src={persons.person1} ariaLabel="Hadas Fahri" />
+    <Avatar type={Avatar.types.IMG} src={persons.person2} ariaLabel="Sergey Roytman" />
+    <Avatar type={Avatar.types.IMG} src={persons.person3} ariaLabel="Yonatan Lev Ari" />
+    <Avatar type={Avatar.types.IMG} src={persons.person1} ariaLabel="Hadas Fahri" />
+    <Avatar type={Avatar.types.IMG} src={persons.person2} ariaLabel="Sergey Roytman" />
+    <Avatar type={Avatar.types.IMG} src={persons.person3} ariaLabel="Yonatan Lev Ari" />
+    <Avatar type={Avatar.types.IMG} src={persons.person1} ariaLabel="Hadas Fahri" />
+    <Avatar type={Avatar.types.IMG} src={persons.person2} ariaLabel="Sergey Roytman" />
+    <Avatar type={Avatar.types.IMG} src={persons.person3} ariaLabel="Yonatan Lev Ari" />
+    <Avatar type={Avatar.types.IMG} src={persons.person1} ariaLabel="Hadas Fahri" />
+    <Avatar type={Avatar.types.IMG} src={persons.person2} ariaLabel="Sergey Roytman" />
+    <Avatar type={Avatar.types.IMG} src={persons.person3} ariaLabel="Yonatan Lev Ari" />
+    <Avatar type={Avatar.types.TEXT} text="MR" ariaLabel="Mark Roytstein" />
+  </AvatarGroup>
+);}
+;
+
 <Meta
   title="Media/Avatar/AvatarGroup"
   component={AvatarGroup}
@@ -41,22 +61,17 @@ export const metaSettings = createStoryMetaSettings({
 Use this component if you need to stack avatars as a group.
 
 <Canvas>
-  <Story name="Overview">
-    <AvatarGroup size={Avatar.sizes.LARGE} max={3}>
-      <Avatar type={Avatar.types.IMG} src={person1} ariaLabel="Hadas Fahri" />
-      <Avatar type={Avatar.types.IMG} src={person2} ariaLabel="Sergey Roytman" />
-      <Avatar type={Avatar.types.IMG} src={person3} ariaLabel="Yonatan Lev Ari" />
-      <Avatar type={Avatar.types.IMG} src={person1} ariaLabel="Hadas Fahri" />
-      <Avatar type={Avatar.types.IMG} src={person2} ariaLabel="Sergey Roytman" />
-      <Avatar type={Avatar.types.IMG} src={person3} ariaLabel="Yonatan Lev Ari" />
-      <Avatar type={Avatar.types.IMG} src={person1} ariaLabel="Hadas Fahri" />
-      <Avatar type={Avatar.types.IMG} src={person2} ariaLabel="Sergey Roytman" />
-      <Avatar type={Avatar.types.IMG} src={person3} ariaLabel="Yonatan Lev Ari" />
-      <Avatar type={Avatar.types.IMG} src={person1} ariaLabel="Hadas Fahri" />
-      <Avatar type={Avatar.types.IMG} src={person2} ariaLabel="Sergey Roytman" />
-      <Avatar type={Avatar.types.IMG} src={person3} ariaLabel="Yonatan Lev Ari" />
-      <Avatar type={Avatar.types.TEXT} text="MR" ariaLabel="Mark Roytstein" />
-    </AvatarGroup>
+  <Story
+    name="Overview"
+    args={{
+      persons: {
+        person1: window.location.origin + "/" + person1,
+        person2: window.location.origin + "/" + person2,
+        person3: window.location.origin + "/" + person3
+      }
+    }}
+  >
+    {avatarGroupTemplate.bind()}
   </Story>
 </Canvas>
 


### PR DESCRIPTION
The motivation is to allow a predictable copy-paste of the code snippet.

There are still some issues:
1. serialized code using the story `args` means also the `size` / `type` prop is serialized and doesn't appear as an enum
2. other examples are still using the relative path.

Will be happy for your comments and suggestions

<img width="1092" alt="image" src="https://user-images.githubusercontent.com/6093192/236698312-3d8443b3-968c-4bed-87af-ab4ba8680261.png">

<img width="1081" alt="image" src="https://user-images.githubusercontent.com/6093192/236698553-505374ac-d12b-4af0-9845-8791ea57ec54.png">

