### PR TITLE
chore: fix typography docs to map to the exact typography css vars

### DIFF
--- a/src/storybook/components/visual-description/visual-description.jsx
+++ b/src/storybook/components/visual-description/visual-description.jsx
@@ -1,7 +1,7 @@
 import cx from "classnames";
 import "./visual-description.scss";
 
-export const VisualDescription = ({ title, ariaLabel, children, description, className }) => {
+export const VisualDescription = ({ title, ariaLabel, children, description, code, className }) => {
   return (
     <div className={cx("monday-storybook-visual-description", className)} aria-label={ariaLabel}>
       <figure className="monday-storybook-visual-description_visual" aria-hidden>
@@ -10,6 +10,7 @@ export const VisualDescription = ({ title, ariaLabel, children, description, cla
       <section className="monday-storybook-visual-description_text">
         <h5 className="monday-storybook-visual-description_title">{title}</h5>
         {description}
+        {code && <code>{code}</code>}
       </section>
     </div>
   );

--- a/src/storybook/stand-alone-documentaion/typography/text-styles/text-styles.jsx
+++ b/src/storybook/stand-alone-documentaion/typography/text-styles/text-styles.jsx
@@ -61,9 +61,7 @@ export const TextStyles = () => {
         description="Use for general text or labels"
         className={CSS_BASE_CLASS}
       >
-        <span style={{ font: "var(--font-general-label)" }} className={cx(bemHelper({ element: "visual-element" }))}>
-          text
-        </span>
+        <span style={{ font: "var(--font-general-label)" }}>text</span>
       </VisualDescription>
       <VisualDescription
         ariaLabel="paragraph"

--- a/src/storybook/stand-alone-documentaion/typography/text-styles/text-styles.jsx
+++ b/src/storybook/stand-alone-documentaion/typography/text-styles/text-styles.jsx
@@ -1,6 +1,5 @@
 import cx from "classnames";
 import { VisualDescription, Frame } from "../../../components";
-import Heading from "../../../../components/Heading/Heading";
 import { BEMClass } from "../../../../helpers/bem-helper";
 import "./text-styles.scss";
 
@@ -13,137 +12,83 @@ export const TextStyles = () => {
       <VisualDescription
         className={CSS_BASE_CLASS}
         ariaLabel="H1"
-        title="Main heading (Poppins 30px bold)"
+        code="font: var(--font-h1)"
+        title="H1 Main heading"
         description="Use as main header on a page"
       >
-        <Heading
-          type={Heading.types.h1}
-          value="H1"
-          ellipsis={false}
-          className={cx(
-            bemHelper({ element: "visual-element" }),
-            bemHelper({ element: "visual-element", state: "heading" })
-          )}
-        />
+        <h1 style={{ font: "var(--font-h1)" }}>{`H1`}</h1>
       </VisualDescription>
       <VisualDescription
         className="monday-storybook-text-description"
         ariaLabel="H2"
-        title="Secondary heading (Poppins 24px bold)"
+        code="font: var(--font-h2)"
+        title="H2 Secondary heading"
         description="Use as secondary header on a page"
       >
-        <Heading
-          type={Heading.types.h2}
-          value="H2"
-          ellipsis={false}
-          className={cx(
-            bemHelper({ element: "visual-element" }),
-            bemHelper({ element: "visual-element", state: "heading" })
-          )}
-        />
+        <h2 style={{ font: "var(--font-h2)" }}>{`H2`}</h2>
       </VisualDescription>
       <VisualDescription
         className={CSS_BASE_CLASS}
         ariaLabel="H3"
-        title="Tertiary heading (Poppins 24px light)"
+        code="font: var(--font-h3)"
+        title="Tertiary Heading"
         description="Use after heading, profile page headings"
       >
-        <Heading
-          type={Heading.types.h3}
-          value="H3"
-          className={cx(
-            bemHelper({ element: "visual-element" }),
-            bemHelper({ element: "visual-element", state: "heading" })
-          )}
-        />
+        <h3 style={{ font: "var(--font-h3)" }}>{`H3`}</h3>
       </VisualDescription>
       <VisualDescription
         className={CSS_BASE_CLASS}
         ariaLabel="H4"
-        title="Fourth heading (Poppins 18px bold)"
+        code="font: var(--font-h4)"
+        title="Fourth heading"
         description="Use for subtitles, group name, subheading in admin"
       >
-        <Heading
-          type={Heading.types.h4}
-          value="H4"
-          className={cx(
-            bemHelper({ element: "visual-element" }),
-            bemHelper({ element: "visual-element", state: "heading" })
-          )}
-        />
+        <h4 style={{ font: "var(--font-h4)" }}>{`H4`}</h4>
       </VisualDescription>
       <VisualDescription
         ariaLabel="H5"
-        title="Fourth heading (Poppins 16px bold)"
+        code="font: var(--font-h5)"
+        title="Paragraph"
         className={CSS_BASE_CLASS}
         description="Use as subtitles for paragraphs"
       >
-        <Heading
-          type={Heading.types.h5}
-          value="H5"
-          className={cx(
-            bemHelper({ element: "visual-element" }),
-            bemHelper({ element: "visual-element", state: "heading" })
-          )}
-        />
+        <h5 style={{ font: "var(--font-h5)" }}>{`H5`}</h5>
       </VisualDescription>
       <VisualDescription
         ariaLabel="text"
-        title="UI labels / General text (Figtree 14px normal)"
+        code="font: var(--font-general-label)"
+        title="UI labels / General text"
         description="Use for general text or labels"
         className={CSS_BASE_CLASS}
       >
-        <span
-          className={cx(
-            bemHelper({ element: "visual-element" }),
-            bemHelper({ element: "visual-element", state: "regular-text" })
-          )}
-        >
+        <span style={{ font: "var(--font-general-label)" }} className={cx(bemHelper({ element: "visual-element" }))}>
           text
         </span>
       </VisualDescription>
       <VisualDescription
         ariaLabel="paragraph"
         className={CSS_BASE_CLASS}
-        title="Paragraph text (Figtree 16px normal)"
+        code="font: var(--font-paragraph)"
+        title="Paragraph text"
         description="Use for item name, text in update"
       >
-        <span
-          className={cx(
-            bemHelper({ element: "visual-element" }),
-            bemHelper({ element: "visual-element", state: "paragraph" })
-          )}
-        >
-          {"<p>"}
-        </span>
+        <span style={{ font: "var(--font-paragraph)" }}>{"<p>"}</span>
       </VisualDescription>
       <VisualDescription
-        title="Caption/Subtext (Figtree 14px normal)"
+        code="font: var(--font-subtext)"
+        title="Medium Text"
         className={CSS_BASE_CLASS}
         description="Use for subtexts"
       >
-        <span
-          className={cx(
-            bemHelper({ element: "visual-element" }),
-            bemHelper({ element: "visual-element", state: "subtext" })
-          )}
-        >
-          subtext
-        </span>
+        <span style={{ font: "var(--font-subtext)" }}>subtext</span>
       </VisualDescription>
       <VisualDescription
-        title="Link text (Figtree 14px normal)"
+        code="font: var(--font-general-label); color: var(--link-color)"
+        title="Link text"
         className="monday-storybook-text-description"
         description="Use for links"
       >
-        <span
-          className={cx(
-            bemHelper({ element: "visual-element" }),
-            bemHelper({ element: "visual-element", state: "link" })
-          )}
-        >
-          Link
-        </span>
+        <span style={{ font: "var(--font-general-label)", color: "var(--link-color)" }}>Link</span>
       </VisualDescription>
     </Frame>
   );

--- a/src/storybook/stand-alone-documentaion/typography/text-styles/text-styles.jsx
+++ b/src/storybook/stand-alone-documentaion/typography/text-styles/text-styles.jsx
@@ -1,10 +1,7 @@
-import cx from "classnames";
 import { VisualDescription, Frame } from "../../../components";
-import { BEMClass } from "../../../../helpers/bem-helper";
 import "./text-styles.scss";
 
 const CSS_BASE_CLASS = "monday-storybook-text-description";
-const bemHelper = BEMClass(CSS_BASE_CLASS);
 
 export const TextStyles = () => {
   return (

--- a/src/storybook/stand-alone-documentaion/typography/text-styles/text-styles.jsx
+++ b/src/storybook/stand-alone-documentaion/typography/text-styles/text-styles.jsx
@@ -31,7 +31,7 @@ export const TextStyles = () => {
         className={CSS_BASE_CLASS}
         ariaLabel="H3"
         code="font: var(--font-h3)"
-        title="Tertiary Heading"
+        title="H3 Tertiary heading"
         description="Use after heading, profile page headings"
       >
         <h3 style={{ font: "var(--font-h3)" }}>{`H3`}</h3>
@@ -40,7 +40,7 @@ export const TextStyles = () => {
         className={CSS_BASE_CLASS}
         ariaLabel="H4"
         code="font: var(--font-h4)"
-        title="Fourth heading"
+        title="H4 Fourth heading"
         description="Use for subtitles, group name, subheading in admin"
       >
         <h4 style={{ font: "var(--font-h4)" }}>{`H4`}</h4>
@@ -48,7 +48,7 @@ export const TextStyles = () => {
       <VisualDescription
         ariaLabel="H5"
         code="font: var(--font-h5)"
-        title="Paragraph"
+        title="H5 Paragraph"
         className={CSS_BASE_CLASS}
         description="Use as subtitles for paragraphs"
       >
@@ -57,7 +57,7 @@ export const TextStyles = () => {
       <VisualDescription
         ariaLabel="text"
         code="font: var(--font-general-label)"
-        title="UI labels / General text"
+        title="H6 UI text"
         description="Use for general text or labels"
         className={CSS_BASE_CLASS}
       >
@@ -67,7 +67,7 @@ export const TextStyles = () => {
         ariaLabel="paragraph"
         className={CSS_BASE_CLASS}
         code="font: var(--font-paragraph)"
-        title="Paragraph text"
+        title="P Paragraph text"
         description="Use for item name, text in update"
       >
         <span style={{ font: "var(--font-paragraph)" }}>{"<p>"}</span>
@@ -82,7 +82,7 @@ export const TextStyles = () => {
       </VisualDescription>
       <VisualDescription
         code="font: var(--font-general-label); color: var(--link-color)"
-        title="Link text"
+        title="Medium text link"
         className="monday-storybook-text-description"
         description="Use for links"
       >


### PR DESCRIPTION
Following the definition Figma: https://www.figma.com/file/UcjPooakzpU4lZyKCD2Pim/%F0%9F%A6%8B-New-typography-styles-%F0%9F%A6%8B?type=design&node-id=1-33&t=Ub5dYimpeTjCUNWs-4

1. map directly to the CSS vars
2. change titles a bit
3. remove the story CSS overrides to align the typography example to the description. The example might look bad, but this is the actual code we have and it should be resolved

</div>
Before:
<img width="486" alt="image" src="https://user-images.githubusercontent.com/6093192/236702327-d3f1caa3-616c-43c0-aef3-f44ff0bdf3c1.png">

After:
<img width="529" alt="image" src="https://user-images.githubusercontent.com/6093192/236702340-37fe77c4-6129-4fae-adac-62f0cd17a8cd.png">
