### PR TITLE
fix: <RadioButton/> - fix name not displayed in the docs

### DIFF
--- a/src/components/RadioButton/RadioButton.tsx
+++ b/src/components/RadioButton/RadioButton.tsx
@@ -43,7 +43,7 @@ interface RadioButtonProps extends VibeComponentProps {
   noLabelAnimation?: boolean;
 }
 
-const RadioButton: VibeComponent<RadioButtonProps, HTMLElement> = forwardRef(
+const RadioButton: VibeComponent<RadioButtonProps, HTMLElement> & object = forwardRef(
   (
     {
       className,


### PR DESCRIPTION
There's probably an underlying issue when using the `forwardRef` - but here's the quick fix