### PR TITLE
fix: incorrect display of Checkbox page in docs

### DIFF
--- a/src/components/Checkbox/__stories__/checkbox.stories.mdx
+++ b/src/components/Checkbox/__stories__/checkbox.stories.mdx
@@ -1,6 +1,6 @@
 import { ArgsTable, Canvas, Meta, Story } from "@storybook/addon-docs";
 import Checkbox from "../Checkbox";
-import LinkComponent from "../../Link/Link";
+import { Link } from "../../../storybook";
 import { createComponentTemplate, createStoryMetaSettings, RelatedComponents } from "../../../storybook";
 import {
   DROPDOWN,
@@ -205,8 +205,8 @@ Allows the user to choose a single option. For example: accept terms of use.
       checked
       label={
         <>
-          I agree to the <LinkComponent text="Terms of Service" className="monday-storybook-checkbox_link" /> and{" "}
-          <LinkComponent text="Privacy Policy." className="monday-storybook-checkbox_link" />
+          I agree to the <Link size={Link.sizes.SMALL} withoutSpacing>Terms of Service</Link> and{" "}
+          <Link size={Link.sizes.SMALL} withoutSpacing>Privacy Policy.</Link>
         </>
       }
     />

--- a/src/components/IconButton/__stories__/IconButton.stories.mdx
+++ b/src/components/IconButton/__stories__/IconButton.stories.mdx
@@ -21,7 +21,6 @@ import {
 import { ArgsTable, Story, Canvas, Meta } from "@storybook/addon-docs";
 import { BUTTON_GROUP, MENU_BUTTON, BUTTON } from "../../../storybook/components/related-components/component-description-map";
 import { Link, createComponentTemplate, createStoryMetaSettings } from "../../../storybook";
-import LinkComponent  from "../../Link/Link";
 import Icon from "../../Icon/Icon";
 import Heading from "../../Heading/Heading";
 import classes from "./iconButton.stories.module.scss";
@@ -190,7 +189,7 @@ Set disable button for something that isn’t usable. Use a tooltip on hover in 
                 <Avatar size={Avatar.sizes.LARGE} src={person1} type={Avatar.types.IMG} />
                 <Flex direction={Flex.directions.COLUMN} className={classes.recycleBinContent} align={Flex.justify.START} ariaLabelledby="monday-recycle-bin-title">
                     <Flex gap={Flex.gaps.XS}>
-                        <LinkComponent text="Hadas Farhi"/><span>deleted the item </span><span className={classes.recycleBinItemName}>Hello World</span><span>from the board</span>
+                        <Link withoutSpacing>Hadas Farhi</Link><span>deleted the item </span><span className={classes.recycleBinItemName}>Hello World</span><span>from the board</span>
                     </Flex>
                     <span className={classes.recycleBinBoardName}>Tasks</span>
                     <Flex gap={Flex.gaps.XS} className={classes.recycleBinSubNote}>


### PR DESCRIPTION
Seems like display bug had been occured due to inappropriate component import usage, so i fixed it :)
<details>
  <summary>Screenshot comparsion</summary>

  Before:
  <img width="1436" alt="checkbox-before" src="https://github.com/mondaycom/monday-ui-react-core/assets/29986501/35d09233-ccc8-4d37-83d6-e9c938474674">
  After:
  <img width="1434" alt="checkbox-after" src="https://github.com/mondaycom/monday-ui-react-core/assets/29986501/ba8b746d-be7c-45a5-bf3a-dd98be933f95">

</details>


Also slightly faced up usage example on IconButton page too.
<details>
  <summary>Screenshot comparsion</summary>

   Before:
  <img width="1430" alt="iconbutton-before" src="https://github.com/mondaycom/monday-ui-react-core/assets/29986501/fa5ea5ca-5e04-4bd7-828c-e2764935a837">
  After:
  <img width="1424" alt="iconbutton-after" src="https://github.com/mondaycom/monday-ui-react-core/assets/29986501/9e63c85f-f7e5-4971-adb3-f6c988c9c89d">

</details>



