### PR TITLE
fix: <StepsGalleryHeader> - galleryHeaderDot increase specificity

### DIFF
--- a/src/components/Steps/StepsGalleryHeader.module.scss
+++ b/src/components/Steps/StepsGalleryHeader.module.scss
@@ -2,11 +2,11 @@
   margin: 0 var(--spacing-small);
   display: flex;
   align-items: center;
-}
 
-.galleryHeaderDot {
-  margin-right: var(--spacing-small);
-  &:last-child {
-    margin-right: 0;
+  .galleryHeaderDot {
+    margin-right: var(--spacing-small);
+    &:last-child {
+      margin-right: 0;
+    }
   }
 }


### PR DESCRIPTION
https://monday.monday.com/boards/3532714909/pulses/4547079320

Fixes absence margin between the `GalleryHeaderDot`(s)
![image](https://github.com/mondaycom/monday-ui-react-core/assets/104433616/07590850-9898-4353-ae5c-1a3e55f4c9f0)
