### PR TITLE
chore: < Dialog > add an example for basic controlled component

### DIFF
--- a/src/components/Dialog/__stories__/Dialog.stories.mdx
+++ b/src/components/Dialog/__stories__/Dialog.stories.mdx
@@ -462,6 +462,40 @@ We can set the triggers which will be responsible for hide the dialog
 </Canvas>
 
 
+### Controlled Dialog
+
+Manage the open and close state of the dialog. Note that `isOpen` is used and `showTrigger` is set to `[]` to disable the default triggers.
+
+<Canvas>
+  <Story name="Controlled Dialog">
+    {() => {
+      const { isChecked: isOpen, onChange: setIsOpen } = useSwitch({ defaultChecked: false });
+      return (
+        <Dialog
+          showTrigger={[]} //disable default triggers
+          open={isOpen} // manage the opening state in the app level
+          content={
+            <DialogContentContainer>
+              <DialogContentContainer>
+                <Button
+                  kind={Button.kinds.SECONDARY}
+                  onClick={() => setIsOpen(false)}
+                >
+                  This will close as well
+                </Button>
+              </DialogContentContainer>
+            </DialogContentContainer>
+          }
+        >
+          <Button onClick={() => setIsOpen(!isOpen)}>
+            Click me to toggle the Dialog
+          </Button>
+        </Dialog>
+      );
+    }}
+  </Story>
+</Canvas>
+
 ### Dialog prevent container scroll
 
 Prevent containerSelector scroll when dialog open


### PR DESCRIPTION
Add a very basic example of using the Dialog in a controlled mode.

We probably hide here an issue of mixture between controlled and uncontrolled states, but at least we can be overcome it like this