### PR TITLE
Accordion: change declared type to VibeComponent.

### DIFF
--- a/src/components/Accordion/Accordion/Accordion.tsx
+++ b/src/components/Accordion/Accordion/Accordion.tsx
@@ -3,6 +3,7 @@ import React, { forwardRef, ReactElement, useCallback, useMemo, useRef, useState
 import VibeComponentProps from "src/types/VibeComponentProps";
 import useMergeRefs from "../../../hooks/useMergeRefs";
 import styles from "./Accordion.module.scss";
+import { VibeComponent } from "../../../types";
 
 const COMPONENT_ID = "monday-accordion";
 
@@ -35,7 +36,7 @@ interface AccordionProps extends VibeComponentProps {
   defaultIndex?: Array<number>;
 }
 
-const Accordion: React.FC<AccordionProps> = forwardRef(
+const Accordion: VibeComponent<AccordionProps, unknown> = forwardRef(
   (
     {
       children: originalChildren = null,


### PR DESCRIPTION
Accordion component was exposed as a simple `React.FC` which shadowed the VibeComponentProps.
This PR changes the declared type in order to expose all available props to the users.

<!--

Please go over the checklist and make sure all conditions are met.

--->

#### Basic
- [ ] Used plop (`npm run plop`) to create a new component.
- [x] PR has description.
- [ ] New component is functional and uses Hooks. 
- [ ] Component defines [`PropTypes`](https://reactjs.org/docs/typechecking-with-proptypes.html).
#### Style
- [ ] Styles are added to `NewComponent.modules.scss` file inside of the `NewComponent` folder.
- [ ] Component uses CSS Modules.
- [ ] Design is compatible with [Monday Design System](https://design.monday.com/).
#### Storybook
- [ ] Stories were added to `/src/NewComponent/__stories__/NewComponent.stories.js` file.
- [ ] Stories include all flows of using the component.
#### Tests
- [ ] Tests are compliant with [TESTING_README.md](TESTING_README.md) instructions.
