### PR TITLE
fix: < Accordion >: change declared type to VibeComponent

### DIFF
--- a/src/components/Accordion/Accordion/Accordion.tsx
+++ b/src/components/Accordion/Accordion/Accordion.tsx
@@ -3,6 +3,7 @@ import React, { forwardRef, ReactElement, useCallback, useMemo, useRef, useState
 import VibeComponentProps from "src/types/VibeComponentProps";
 import useMergeRefs from "../../../hooks/useMergeRefs";
 import "./Accordion.scss";
+import { VibeComponent } from "../../../types";
 
 const COMPONENT_ID = "monday-accordion";
 
@@ -35,7 +36,7 @@ interface AccordionProps extends VibeComponentProps {
   defaultIndex?: Array<number>;
 }
 
-const Accordion: React.FC<AccordionProps> = forwardRef(
+const Accordion: VibeComponent<AccordionProps, unknown> = forwardRef(
   (
     {
       children: originalChildren = null,

--- a/src/components/Accordion/Accordion/Accordion.tsx
+++ b/src/components/Accordion/Accordion/Accordion.tsx
@@ -36,7 +36,7 @@ interface AccordionProps extends VibeComponentProps {
   defaultIndex?: Array<number>;
 }
 
-const Accordion: VibeComponent<AccordionProps, unknown> = forwardRef(
+const Accordion: VibeComponent<AccordionProps, unknown> & object = forwardRef(
   (
     {
       children: originalChildren = null,


### PR DESCRIPTION
porting this fix
https://github.com/mondaycom/monday-ui-react-core/pull/1364