### PR TITLE
fix: MultiStepIndicator - fix divider to not squeeze bullets

### DIFF
--- a/src/components/MultiStepIndicator/components/StepIndicator/StepIndicator.module.scss
+++ b/src/components/MultiStepIndicator/components/StepIndicator/StepIndicator.module.scss
@@ -88,7 +88,7 @@
   @include theme-prop(background-color, ui-border-color);
   margin: 16px 0 16px 16px;
   height: 1px;
-  flex-grow: 1;
+  flex: 1 1 0;
 }
 
 .sizeCompactNumberDividerContainer {


### PR DESCRIPTION
<img width="1049" alt="image" src="https://github.com/mondaycom/monday-ui-react-core/assets/6093192/ccd4d175-29aa-4dc2-a3e3-e70f958d93b1">

could not reproduce in the storybook, but probably a case of long content and missing constraints