### PR TITLE
chore: enable source maps in tsconfig

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,7 @@
     "allowJs": true,
     "target": "es6",
     "module": "CommonJS",
-    "sourceMap": false,
+    "sourceMap": true,
     "moduleResolution": "node",
     "resolveJsonModule": true,
     "declarationDir": "dist/types",


### PR DESCRIPTION
note: in current config, this should allow having full source map in a prod build and eval in dev mode (storybook)