### PR TITLE
Accordion: fix vibe props are not recognized.

### DIFF
--- a/src/components/Accordion/Accordion/Accordion.tsx
+++ b/src/components/Accordion/Accordion/Accordion.tsx
@@ -1,9 +1,8 @@
 import cx from "classnames";
 import React, { forwardRef, ReactElement, useCallback, useMemo, useRef, useState } from "react";
-import VibeComponentProps from "src/types/VibeComponentProps";
 import useMergeRefs from "../../../hooks/useMergeRefs";
 import styles from "./Accordion.module.scss";
-import { VibeComponent } from "../../../types";
+import { VibeComponent, VibeComponentProps } from "../../../types";
 
 const COMPONENT_ID = "monday-accordion";
 

--- a/src/components/Accordion/AccordionItem/AccordionItem.tsx
+++ b/src/components/Accordion/AccordionItem/AccordionItem.tsx
@@ -1,8 +1,8 @@
 import React, { forwardRef, useCallback, useRef } from "react";
-import VibeComponentProps from "src/types/VibeComponentProps";
 import useMergeRefs from "../../../hooks/useMergeRefs";
 import ExpandCollapse from "../../ExpandCollapse/ExpandCollapse";
 import { ElementContent } from "../../../types/ElementContent";
+import { VibeComponentProps } from "../../../types";
 
 interface AccordionItemProps extends VibeComponentProps {
   /**


### PR DESCRIPTION
Vibe props on Accordion and AccordionItem were not recognized by clients of the package. The reason was because importing of the type was with an absolute path and during the TS build, the type "got lost".

<!--

Please go over the checklist and make sure all conditions are met.

--->

#### Basic
- [ ] Used plop (`npm run plop`) to create a new component.
- [ ] PR has description.
- [ ] New component is functional and uses Hooks. 
- [ ] Component defines [`PropTypes`](https://reactjs.org/docs/typechecking-with-proptypes.html).
#### Style
- [ ] Styles are added to `NewComponent.modules.scss` file inside of the `NewComponent` folder.
- [ ] Component uses CSS Modules.
- [ ] Design is compatible with [Monday Design System](https://design.monday.com/).
#### Storybook
- [ ] Stories were added to `/src/NewComponent/__stories__/NewComponent.stories.js` file.
- [ ] Stories include all flows of using the component.
#### Tests
- [ ] Tests are compliant with [TESTING_README.md](TESTING_README.md) instructions.
