### PR TITLE
Combobox: expose actual type instead a no argument on hover callback.

### DIFF
--- a/src/components/Combobox/Combobox.tsx
+++ b/src/components/Combobox/Combobox.tsx
@@ -66,7 +66,7 @@ export interface ComboboxProps extends VibeComponentProps {
    * on mouse hover callback for option
    */
   // onOptionHover?: PropTypes.func,
-  onOptionHover?: () => void;
+  onOptionHover?: (event: React.MouseEvent, index: number, option: IComboboxOption) => void;
   /**
    * on mouse leave callback for option
    */


### PR DESCRIPTION
Combobox' `onOptionHover` prop was exposed as a no argument props instead of exposing the arguments that are sent with it. 
This PR adds the relevant data to the type definition.

<!--

Please go over the checklist and make sure all conditions are met.

--->

#### Basic
- [ ] Used plop (`npm run plop`) to create a new component.
- [x] PR has description.
- [ ] New component is functional and uses Hooks. 
- [ ] Component defines [`PropTypes`](https://reactjs.org/docs/typechecking-with-proptypes.html).
#### Style
- [ ] Styles are added to `NewComponent.modules.scss` file inside of the `NewComponent` folder.
- [ ] Component uses CSS Modules.
- [ ] Design is compatible with [Monday Design System](https://design.monday.com/).
#### Storybook
- [ ] Stories were added to `/src/NewComponent/__stories__/NewComponent.stories.js` file.
- [ ] Stories include all flows of using the component.
#### Tests
- [ ] Tests are compliant with [TESTING_README.md](TESTING_README.md) instructions.
