### PR TITLE
improve useState to only called once in useIsOverflowing

### DIFF
--- a/src/hooks/useIsOverflowing/useIsOverflowing.ts
+++ b/src/hooks/useIsOverflowing/useIsOverflowing.ts
@@ -21,7 +21,7 @@ export default function useIsOverflowing({
   ref: RefObject<HTMLElement>;
   ignoreHeightOverflow?: boolean;
 }) {
-  const [isOverflowing, setIsOverflowing] = useState<boolean>(checkOverflow(ref?.current, ignoreHeightOverflow));
+  const [isOverflowing, setIsOverflowing] = useState<boolean>(() => checkOverflow(ref?.current, ignoreHeightOverflow));
   const callback = useCallback(() => {
     setIsOverflowing(checkOverflow(ref?.current, ignoreHeightOverflow));
   }, [ignoreHeightOverflow, ref]);


### PR DESCRIPTION
We saw some long task on the browser coming from `Heading` component, seems that the source of the issue is this styling accessing:

```
function checkOverflow(element: HTMLElement, ignoreHeightOverflow: boolean) {
...
  const isOverflowing =
    element.clientWidth < element.scrollWidth || (!ignoreHeightOverflow && element.clientHeight < element.scrollHeight);
...
}
```
We might can improve this, but first thing we can do is to reduce the times it calling this function by changing the `useState` function invocation to only call this once.


#### Basic
- [ ] Used plop (`npm run plop`) to create a new component.
- [ ] PR has description.
- [ ] New component is functional and uses Hooks. 
- [ ] Component defines [`PropTypes`](https://reactjs.org/docs/typechecking-with-proptypes.html).
#### Style
- [ ] Styles are added to `NewComponent.modules.scss` file inside of the `NewComponent` folder.
- [ ] Component uses CSS Modules.
- [ ] Design is compatible with [Monday Design System](https://design.monday.com/).
#### Storybook
- [ ] Stories were added to `/src/NewComponent/__stories__/NewComponent.stories.js` file.
- [ ] Stories include all flows of using the component.
#### Tests
- [ ] Tests are compliant with [TESTING_README.md](TESTING_README.md) instructions.
