### PR TITLE
fix(DatePicker): do not set vertical alignment to be baseline (defaults to middle)

### DIFF
--- a/src/components/DatePicker/DatePicker.module.scss
+++ b/src/components/DatePicker/DatePicker.module.scss
@@ -21,7 +21,6 @@
       padding: 0;
       border: 0;
       font-size: 100%;
-      vertical-align: baseline;
       box-shadow: none;
     }
     td {


### PR DESCRIPTION
https://monday.monday.com/boards/3532714909/pulses/4803862196

Before:
<img width="408" alt="image" src="https://github.com/mondaycom/monday-ui-react-core/assets/30905362/8e1233b4-6197-48b4-a328-f045ee2ce540">

---
After:
<img width="445" alt="image" src="https://github.com/mondaycom/monday-ui-react-core/assets/30905362/9cafbcbb-908f-4bb5-8e36-03a6046b556c">
