### PR TITLE
fix(Chips): change border color token, do not limit chip-with-border's height

### DIFF
--- a/src/components/Chips/Chips.module.scss
+++ b/src/components/Chips/Chips.module.scss
@@ -18,9 +18,7 @@
   animation: chips-pop-in-emphasized var(--motion-productive-medium) var(--motion-timing-emphasize);
   @include font-general-text();
   &.border {
-    height: 22px;
-    border: 1px solid var(--text-color-on-primary);
-    line-height: 21px;
+    border: 1px solid var(--primary-background-color);
   }
   &.withUserSelect {
     user-select: text;


### PR DESCRIPTION
https://monday.monday.com/boards/3532714909/pulses/4818138972

as it is using box-sizing of border-box, limiting the height to 22px causes the chip to be with total height of 22px instead of like regular chip which is 24px.

Before:
![image](https://github.com/mondaycom/monday-ui-react-core/assets/30905362/f29dceda-9a2c-4b3d-8f89-d37083f955bf)

After:
![image](https://github.com/mondaycom/monday-ui-react-core/assets/30905362/f2ef202d-5327-4c9b-aace-2de4227c862a)

---

Bug fix:
It caused this bug:
![image](https://github.com/mondaycom/monday-ui-react-core/assets/30905362/36740a4f-ccad-4792-9f67-f6dea9d79951)

✅ Before, without border - correct (24px)
![image](https://github.com/mondaycom/monday-ui-react-core/assets/30905362/3e70b740-16b6-493a-92d8-757eb6791dcd)

❌ Before, with border - wrong (22px)
![image](https://github.com/mondaycom/monday-ui-react-core/assets/30905362/54b74b1b-0aac-45f5-b8ec-3e0b7c9e46e5)

✅ After, with border - correct (24px)
![image](https://github.com/mondaycom/monday-ui-react-core/assets/30905362/0062619e-1a20-41d9-9873-e7bd41dbdb7c)
