### PR TITLE
chore: expose types for vite and next-based projects

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,10 +8,15 @@
     "./package.json": "./package.json",
     ".": {
       "import": "./dist/esm/src/index.js",
-      "default": "./dist/main.js"
+      "default": "./dist/main.js",
+      "types": "./dist/types.d.ts"
     },
     "./dist/": "./dist/",
-    "./icons": "./dist/esm/src/components/Icon/Icons/icons.js",
+    "./icons": {
+      "import": "./dist/esm/src/components/Icon/Icons/icons.js",
+      "default": "./dist/esm/src/components/Icon/Icons/icons.js",
+      "types": "./dist/esm/components/Icon/Icons/index.d.ts"
+    },
     "./interactionsTests": "./dist/esm/src/tests/interactionsTests.js",
     "./testIds": "./dist/esm/src/tests/testIds.js",
     "./storybookComponents": "./dist/storybook/index.js",


### PR DESCRIPTION
attempt to solve this: https://github.com/mondaycom/monday-ui-react-core/issues/1423