### PR TITLE
chore(data-testid): util function does not chain id if it is falsy

### DIFF
--- a/src/tests/test-ids-utils.ts
+++ b/src/tests/test-ids-utils.ts
@@ -1,5 +1,6 @@
 import { ComponentDefaultTestId as TestIds } from "./constants";
 export const ComponentDefaultTestId = TestIds;
 export const getTestId = (elementType: TestIds, id?: string | number) => {
-  return id ? `${elementType}_${id}` : elementType;
+  const formattedId = id ?? "";
+  return `${elementType}${formattedId && `_${formattedId}`}`;
 };


### PR DESCRIPTION
https://monday.monday.com/boards/3532714909/pulses/4899875511

it should only not-chain if it's `null` or `undefined`, but currently, it does not chain also if it is `0` or `false`
