### PR TITLE
Letter-spacing alternative override solution

### DIFF
--- a/src/components/Heading/Heading.module.scss
+++ b/src/components/Heading/Heading.module.scss
@@ -53,7 +53,7 @@
 .elementTypeH3.sizeMedium,
 .elementTypeH4 {
   @include vibe-title("h3", "normal");
-  letter-spacing: 0.1px !important;
+  letter-spacing: var(--h3-normal-override, 0.1px) !important;
 }
 
 .elementTypeH5, .elementTypeP {


### PR DESCRIPTION
Alternative solution - will need also to change overriden variable (`--letter-spacing-h3-normal`) in the Monolith