### PR TITLE
fix: <Dropdown> pass children to the menuRenderer

### DIFF
--- a/src/components/Dropdown/components/menu/menu.jsx
+++ b/src/components/Dropdown/components/menu/menu.jsx
@@ -4,6 +4,7 @@ import { components } from "react-select";
 import styles from "./menu.module.scss";
 
 const Menu = ({ children, Renderer, selectProps, dropdownMenuWrapperClassName, ...props }) => {
+  const rendererProps = { children, ...props };
   const withFixedPosition =
     selectProps?.selectProps?.insideOverflowContainer || selectProps?.selectProps?.insideOverflowWithTransformContainer;
   return (
@@ -17,7 +18,7 @@ const Menu = ({ children, Renderer, selectProps, dropdownMenuWrapperClassName, .
         dropdownMenuWrapperClassName
       )}
     >
-      {Renderer && Renderer(props)}
+      {Renderer && Renderer(rendererProps)}
       {!Renderer && children}
     </components.Menu>
   );


### PR DESCRIPTION
https://monday.monday.com/boards/3532714909/pulses/5029231156

menuRenderer wasn't receiving children, so it wasn't able to render options properly, e.g. when menuRenderer looks like this

```
import React, { Fragment } from "react";
import { components } from "react-select";
import "./dropdown.stories.scss";

export const MenuRenderer = props => {
  return (
    <Fragment>
      <components.Menu {...props} />
    </Fragment>
  );
};
```