### PR TITLE
<DropdownMenu> - disable animation when using menuPortalTarget - temp fix

### DIFF
--- a/src/components/Dropdown/components/menu/menu.jsx
+++ b/src/components/Dropdown/components/menu/menu.jsx
@@ -7,13 +7,16 @@ const Menu = ({ children, Renderer, selectProps, dropdownMenuWrapperClassName, .
   const rendererProps = { children, selectProps, ...props };
   const withFixedPosition =
     selectProps?.selectProps?.insideOverflowContainer || selectProps?.selectProps?.insideOverflowWithTransformContainer;
+  // Temporary fix for menu animation is above the select when using menuPortalTarget
+  const withoutAnimation = !!selectProps?.menuPortalTarget;
   return (
     <components.Menu
       {...props}
       className={cx(
         styles.dropdownMenuWrapper,
         {
-          [styles.dropdownMenuWrapperFixedPosition]: withFixedPosition
+          [styles.dropdownMenuWrapperFixedPosition]: withFixedPosition,
+          [styles.withoutAnimation]: withoutAnimation
         },
         dropdownMenuWrapperClassName
       )}

--- a/src/components/Dropdown/components/menu/menu.module.scss
+++ b/src/components/Dropdown/components/menu/menu.module.scss
@@ -2,6 +2,10 @@
 
 .dropdownMenuWrapper {
   animation: fadeIn var(--motion-productive-medium) var(--motion-timing-enter);
+
+  &.withoutAnimation {
+    animation: none;
+  }
 }
 
 .dropdownMenuWrapperFixedPosition {


### PR DESCRIPTION
https://monday.monday.com/boards/3532714909/pulses/5135298038

When using `menuPortalTarget` the Dropdown menu while animating is locating above the select, which is causing issues (tapping Dialog issue). Tried to play with z-index to fix it, but didn't succeed. Feel like I've wasted too much time on it already, so this is a temp fix, which just disables animation when using  `menuPortalTarget`. If we don't like this temp solution, help would be appreciated here - can provide all the data which is needed to reproduce the issue

Video - on the left Dropdown with `menuPortalTarget`, on the right without. Opacity disabled and duration increased for the demo
https://github.com/mondaycom/monday-ui-react-core/assets/104433616/0185cdb6-ed24-41d8-bce8-97d314e75216

