### PR TITLE
docs: replace legacy links with the new ones

### DIFF
--- a/src/hooks/useClickOutside/__stories__/useClickOutside.stories.mdx
+++ b/src/hooks/useClickOutside/__stories__/useClickOutside.stories.mdx
@@ -47,7 +47,7 @@ This hook is used when you want to capture click events outside your component.
       description={
         <>
           A React
-          <Link href="https://reactjs.org/docs/hooks-reference.html#useref">
+          <Link href="https://react.dev/reference/react/useRef">
             ref
           </Link>
           object.

--- a/src/hooks/useClickableProps/__stories__/useClickableProps.stories.mdx
+++ b/src/hooks/useClickableProps/__stories__/useClickableProps.stories.mdx
@@ -173,7 +173,7 @@ Return props for making an element or component clickable by mouse and keyboard 
     description={
       <>
         A React
-        <Link size={Link.sizes.SMALL} href="https://reactjs.org/docs/hooks-reference.html#useref">
+        <Link size={Link.sizes.SMALL} href="https://react.dev/reference/react/useRef">
           ref
         </Link>
         object for the clickable element.

--- a/src/hooks/useEventListener/__stories__/useEventListener.stories.mdx
+++ b/src/hooks/useEventListener/__stories__/useEventListener.stories.mdx
@@ -46,7 +46,7 @@ Attaches a listener to any DOM event on a specific element, firing a provided ca
       description={
         <>
           A React{" "}
-          <a href="https://reactjs.org/docs/hooks-reference.html#useref" target="_blank" rel="noopener noreferrer">
+          <a href="https://react.dev/reference/react/useRef" target="_blank" rel="noopener noreferrer">
             ref
           </a>{" "}
           object.

--- a/src/hooks/useGridKeyboardNavigation/__stories__/useGridKeyboardNavigation.stories.mdx
+++ b/src/hooks/useGridKeyboardNavigation/__stories__/useGridKeyboardNavigation.stories.mdx
@@ -95,7 +95,7 @@ export const ON_CLICK = action("item selected");
       description={
         <>
           A React{" "}
-          <a href="https://reactjs.org/docs/hooks-reference.html#useref" target="_blank" rel="noopener noreferrer">
+          <a href="https://react.dev/reference/react/useRef" target="_blank" rel="noopener noreferrer">
             ref
           </a>{" "}
           object. The reference for the component that listens to keyboard. <br />

--- a/src/hooks/useHover/__stories__/useHover.stories.mdx
+++ b/src/hooks/useHover/__stories__/useHover.stories.mdx
@@ -52,7 +52,7 @@ Detect whether the mouse is hovering an element by returning its <code>isHovered
     description={
       <>
         A React
-        <Link size={Link.sizes.MEDIUM} href="https://reactjs.org/docs/hooks-reference.html#useref">
+        <Link size={Link.sizes.MEDIUM} href="https://react.dev/reference/react/useRef">
           ref
         </Link>
         object to assign to the element which hover state needs to be tracked.

--- a/src/hooks/useIsOverflowing/__stories__/useIsOverflowing.stories.mdx
+++ b/src/hooks/useIsOverflowing/__stories__/useIsOverflowing.stories.mdx
@@ -68,7 +68,7 @@ Use this hook, when there is a chance that content won't fit into the container,
     description={
       <>
         A React
-        <Link size={Link.sizes.MEDIUM} href="https://reactjs.org/docs/hooks-reference.html#useref">
+        <Link size={Link.sizes.MEDIUM} href="https://react.dev/reference/react/useRef">
           ref
         </Link>
         object for the container of likely to overflow content.

--- a/src/hooks/useKeyEvent/__stories__/useKeyEvent.stories.mdx
+++ b/src/hooks/useKeyEvent/__stories__/useKeyEvent.stories.mdx
@@ -64,7 +64,7 @@ Attaches a listener to keyboard DOM events on a specific element, firing a provi
       description={
         <>
           A React{" "}
-          <a href="https://reactjs.org/docs/hooks-reference.html#useref" target="_blank" rel="noopener noreferrer">
+          <a href="https://react.dev/reference/react/useRef" target="_blank" rel="noopener noreferrer">
             ref
           </a>{" "}
           object.

--- a/src/hooks/useListenFocusTriggers/__stories__/useListenFocusTriggers.stories.mdx
+++ b/src/hooks/useListenFocusTriggers/__stories__/useListenFocusTriggers.stories.mdx
@@ -55,7 +55,7 @@ Fire provided callbacks, when focus by mouse or by keyboard happens.
       description={
         <>
           A React
-          <Link size={Link.sizes.MEDIUM} href="https://reactjs.org/docs/hooks-reference.html#useref">
+          <Link size={Link.sizes.MEDIUM} href="https://react.dev/reference/react/useRef">
             ref
           </Link>
           object.

--- a/src/hooks/useSetFocus/__stories__/useSetFocus.stories.mdx
+++ b/src/hooks/useSetFocus/__stories__/useSetFocus.stories.mdx
@@ -51,7 +51,7 @@ Hook for controlling focus on specific component e.g. Input.
       description={
         <>
           A React{" "}
-          <a href="https://reactjs.org/docs/hooks-reference.html#useref" target="_blank" rel="noopener noreferrer">
+          <a href="https://react.dev/reference/react/useRef" target="_blank" rel="noopener noreferrer">
             ref
           </a>{" "}
           object.


### PR DESCRIPTION
Replace react docs legacy links with the new ones (https://github.com/mondaycom/monday-ui-react-core/issues/1589)