### PR TITLE
docs: Add space between <Combobox> tips and links

### DIFF
--- a/src/components/Combobox/__stories__/combobox.stories.mdx
+++ b/src/components/Combobox/__stories__/combobox.stories.mdx
@@ -98,14 +98,14 @@ Combo box allowing users to filter longer lists to only the selections matching 
   <Link href="/?path=/docs/inputs-radio-button--overview" size={Link.sizes.SMALL} withoutSpacing>
     Radio buttons
   </Link>
-  (if only one item can be selected) or <Link
+  {" "}(if only one item can be selected) or <Link
     href="/?path=/docs/inputs-checkbox--overview"
     size={Link.sizes.SMALL}
     withoutSpacing
   >
     Checkboxes
   </Link>
-  (if multiple items can be selected).
+  {" "}(if multiple items can be selected).
 </Tip>
 
 ## Variants


### PR DESCRIPTION
Add spaces between links and text in the Tip section of Combobox
https://style.monday.com/?path=/docs/inputs-combo-box--overview
![image](https://github.com/mondaycom/monday-ui-react-core/assets/137381184/c544acef-6e9f-4b5f-b2ef-41bf8e848dc1)


Closes issue #1578 