### PR TITLE
chore: enforce using npm

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+engine-strict=true

--- a/package-lock.json
+++ b/package-lock.json
@@ -159,6 +159,9 @@
         "webpack-cli": "^4.9.1",
         "webpack-node-externals": "^3.0.0"
       },
+      "engines": {
+        "yarn": "please-use-npm"
+      },
       "peerDependencies": {
         "moment": "^2.29.1",
         "react": ">=16.9.0",

--- a/package.json
+++ b/package.json
@@ -262,5 +262,8 @@
       "PR: Breaking Changes 💥": "Breaking Changes",
       "PR: Icon 💎": "New Icons"
     }
+  },
+  "engines": {
+    "yarn": "please-use-npm"
   }
 }


### PR DESCRIPTION
https://monday.monday.com/boards/3532714909/pulses/5265659631

To prevent issues in dependency resolution when using different package managers

When using `yarn install` for example it will throw an error:
![Screenshot 2023-10-03 at 16 07 28](https://github.com/mondaycom/monday-ui-react-core/assets/18269880/5b877b11-afc5-4b4b-a88a-63cca7accd63)
