### PR TITLE
docs: Shortening texts - add space before the link

### DIFF
--- a/src/components/Link/__stories__/Link.stories.mdx
+++ b/src/components/Link/__stories__/Link.stories.mdx
@@ -167,8 +167,8 @@ Use read more to shorten long paragraphs of text
   <Story name="Shortening texts">
     <div>
       Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a
-      galley of type and scrambled it to make a type specimen book.
-      <Link text=" Read more..." href="https://www.monday.com" inheritFontSize inlineText />
+      galley of type and scrambled it to make a type specimen book.{" "}
+      <Link text="Read more..." href="https://www.monday.com" inheritFontSize inlineText />
     </div>
   </Story>
 </Canvas>


### PR DESCRIPTION
Resloves: #1606
