### PR TITLE
feat : Migrate < GridKeyboardNavigationContext / >, useGridKeyboardNavigation to Typescirpt

### DIFF
--- a/src/components/GridKeyboardNavigationContext/GridKeyboardNavigationContext.tsx
+++ b/src/components/GridKeyboardNavigationContext/GridKeyboardNavigationContext.tsx
@@ -2,22 +2,42 @@ import React, { useContext, useCallback, useMemo } from "react";
 import useEventListener from "../../hooks/useEventListener";
 import { useLastNavigationDirection } from "../Menu/Menu/hooks/useLastNavigationDirection";
 import {
+  DirectionMap,
+  Direction,
   getDirectionMaps,
   getNextElementToFocusInDirection,
   getOppositeDirection,
   getOutmostElementInDirection
 } from "./helper";
+import VibeComponentProps from "../../types/VibeComponentProps";
+import { NavDirections } from "../../hooks/useFullKeyboardListeners";
 
-export const GridKeyboardNavigationContext = React.createContext();
+export interface GridKeyboardNavigationContextProps extends VibeComponentProps {
+  disabled?: boolean;
+}
+export const GridKeyboardNavigationContext = React.createContext<any>(null);
 
 /**
  * @param {({topElement: React.MutableRefObject, bottomElement: React.MutableRefObject}|
  * {leftElement: React.MutableRefObject, rightElement: React.MutableRefObject})[]} positions - the positions of the navigable items
  * @param {*} wrapperRef - a reference for a wrapper element which contains all the referenced elements
  */
-export const useGridKeyboardNavigationContext = (positions, wrapperRef, { disabled } = { disabled: false }) => {
-  const directionMaps = useMemo(() => getDirectionMaps(positions), [positions]);
-  const upperContext = useContext(GridKeyboardNavigationContext);
+export const useGridKeyboardNavigationContext = (
+  positions: (
+    | {
+        topElement: React.MutableRefObject<any>;
+        bottomElement: React.MutableRefObject<any>;
+      }
+    | {
+        leftElement: React.MutableRefObject<any>;
+        rightElement: React.MutableRefObject<any>;
+      }
+  )[],
+  wrapperRef: React.MutableRefObject<any>,
+  { disabled }: GridKeyboardNavigationContextProps = { disabled: false }
+) => {
+  const directionMaps: DirectionMap = useMemo(() => getDirectionMaps(positions), [positions]);
+  const upperContext: any = useContext(GridKeyboardNavigationContext);
   const { lastNavigationDirectionRef } = useLastNavigationDirection();
 
   const onWrapperFocus = useCallback(() => {
@@ -29,12 +49,16 @@ export const useGridKeyboardNavigationContext = (positions, wrapperRef, { disabl
     const refToFocus = getOutmostElementInDirection(directionMaps, oppositeDirection);
     refToFocus?.current?.focus();
   }, [directionMaps, disabled, lastNavigationDirectionRef]);
-  useEventListener({ eventName: "focus", callback: onWrapperFocus, ref: wrapperRef });
+  useEventListener({
+    eventName: "focus",
+    callback: onWrapperFocus,
+    ref: wrapperRef
+  });
 
   const onOutboundNavigation = useCallback(
-    (elementRef, direction) => {
+    (elementRef: React.MutableRefObject<any>, direction: string) => {
       if (disabled) return;
-      const maybeNextElement = getNextElementToFocusInDirection(directionMaps[direction], elementRef);
+      const maybeNextElement = getNextElementToFocusInDirection(directionMaps[direction as NavDirections], elementRef);
       if (maybeNextElement) {
         elementRef.current?.blur();
         maybeNextElement.current?.focus();

--- a/src/components/GridKeyboardNavigationContext/__tests__/GridKeyboardNavigationContext.jest.tsx
+++ b/src/components/GridKeyboardNavigationContext/__tests__/GridKeyboardNavigationContext.jest.tsx
@@ -4,12 +4,12 @@ import { NavDirections } from "../../../hooks/useFullKeyboardListeners";
 import { GridKeyboardNavigationContext, useGridKeyboardNavigationContext } from "../GridKeyboardNavigationContext";
 
 describe("GridKeyboardNavigationContext", () => {
-  let wrapperRef;
-  let ref1;
-  let ref2;
-  let ref3;
-  let ref4;
-  let ref5;
+  let wrapperRef: React.MutableRefObject<HTMLElement | null>;
+  let ref1: React.MutableRefObject<HTMLElement | null>;
+  let ref2: React.MutableRefObject<HTMLElement | null>;
+  let ref3: React.MutableRefObject<HTMLElement | null>;
+  let ref4: React.MutableRefObject<HTMLElement | null>;
+  let ref5: React.MutableRefObject<HTMLElement | null>;
 
   beforeEach(() => {
     ref1 = createElementRef("ref1");
@@ -71,7 +71,7 @@ describe("GridKeyboardNavigationContext", () => {
     it("should not focus any other element when the is no last direction of keyboard navigation, after the wrapper element is focused", () => {
       const positions = [
         { leftElement: ref2, rightElement: ref4 },
-        { topElement: ref1, rightElement: ref3 }
+        { topElement: ref1, bottomElement: ref3 }
       ];
 
       renderHookForTest(positions);
@@ -110,14 +110,38 @@ describe("GridKeyboardNavigationContext", () => {
       expect(ref4.current.focus).toHaveBeenCalled();
     });
 
-    function renderHookForTest(positions, disabled = false) {
+    function renderHookForTest(
+      positions: (
+        | {
+            topElement: React.MutableRefObject<any>;
+            bottomElement: React.MutableRefObject<any>;
+          }
+        | {
+            leftElement: React.MutableRefObject<any>;
+            rightElement: React.MutableRefObject<any>;
+          }
+      )[],
+      disabled = false
+    ) {
       wrapperRef = createElementRef("wrapper");
       return renderHook(() => useGridKeyboardNavigationContext(positions, wrapperRef, { disabled }));
     }
 
-    function renderHookWithContext(positions, contextValue) {
-      wrapperRef = createElementRef();
-      const wrapper = ({ children }) => (
+    function renderHookWithContext(
+      positions: (
+        | {
+            topElement: React.MutableRefObject<any>;
+            bottomElement: React.MutableRefObject<any>;
+          }
+        | {
+            leftElement: React.MutableRefObject<any>;
+            rightElement: React.MutableRefObject<any>;
+          }
+      )[],
+      contextValue: any
+    ) {
+      wrapperRef = createElementRef(null);
+      const wrapper = ({ children }: { children: React.ReactNode }) => (
         <GridKeyboardNavigationContext.Provider value={contextValue}>{children}</GridKeyboardNavigationContext.Provider>
       );
       return renderHook(() => useGridKeyboardNavigationContext(positions, wrapperRef), { wrapper });
@@ -130,7 +154,7 @@ describe("GridKeyboardNavigationContext", () => {
     }
   });
 
-  function createElementRef(id) {
+  function createElementRef(id: string) {
     const element = document.createElement("div");
     element.id = id;
     document.body.appendChild(element);

--- a/src/components/GridKeyboardNavigationContext/__tests__/helper.jest.ts
+++ b/src/components/GridKeyboardNavigationContext/__tests__/helper.jest.ts
@@ -12,15 +12,15 @@ describe("GridKeyboardNavigationContext.helper", () => {
   const ELEMENT3 = { current: "e3" };
   const ELEMENT4 = { current: "e4" };
   const ELEMENT5 = { current: "e5" };
-  const UNMOUNTED_ELEMENT_1 = { current: null };
-  const UNMOUNTED_ELEMENT_2 = { current: null };
+  const UNMOUNTED_ELEMENT_1: { current: any } = { current: null };
+  const UNMOUNTED_ELEMENT_2: { current: any } = { current: null };
   const DISABLED_ELEMENT = { current: { disabled: true } };
   const DISABLED_DATASET_ELEMENT = { current: { dataset: { disabled: "true" } } };
   const DATASET_NOT_DISABLED_ELEMENT = { current: { dataset: { disabled: "false" } } };
 
   describe("getDirectionMaps", () => {
     it("should return empty direction maps when no positions are supplied", () => {
-      const input = [];
+      const input: any[] = [];
       const expected = {
         [NavDirections.RIGHT]: new Map(),
         [NavDirections.LEFT]: new Map(),

--- a/src/components/GridKeyboardNavigationContext/helper.ts
+++ b/src/components/GridKeyboardNavigationContext/helper.ts
@@ -1,6 +1,11 @@
 import { NavDirections } from "../../hooks/useFullKeyboardListeners";
 
-function throwIfCausingCircularDependency(directionMaps, newPosition) {
+export type DirectionMap = {
+  [key in NavDirections]: Map<any, any>;
+};
+export type Direction = NavDirections;
+
+function throwIfCausingCircularDependency(directionMaps: DirectionMap, newPosition: any): void {
   const { topElement, bottomElement, leftElement, rightElement } = newPosition;
   if (topElement && bottomElement) {
     if (directionMaps[NavDirections.UP].get(topElement) === bottomElement) {
@@ -19,15 +24,15 @@ function throwIfCausingCircularDependency(directionMaps, newPosition) {
     }
   }
 
-  function throwMessage(directionFrom, directionTo) {
+  function throwMessage(directionFrom: string, directionTo: string): void {
     throw new Error(
       `Circular positioning detected: the ${directionFrom} element is already positioned to the ${directionTo} of the ${directionTo} element. This probably means the layout isn't ordered correctly.`
     );
   }
 }
 
-export const getDirectionMaps = positions => {
-  const directionMaps = {
+export const getDirectionMaps = (positions: any[]): DirectionMap => {
+  const directionMaps: DirectionMap = {
     [NavDirections.RIGHT]: new Map(),
     [NavDirections.LEFT]: new Map(),
     [NavDirections.UP]: new Map(),
@@ -49,7 +54,7 @@ export const getDirectionMaps = positions => {
   return directionMaps;
 };
 
-export const getOppositeDirection = direction => {
+export const getOppositeDirection = (direction: string) => {
   switch (direction) {
     case NavDirections.LEFT:
       return NavDirections.RIGHT;
@@ -64,12 +69,15 @@ export const getOppositeDirection = direction => {
   }
 };
 
-export const getOutmostElementInDirection = (directionMaps, direction) => {
-  const directionMap = directionMaps[direction];
+export const getOutmostElementInDirection = (
+  directionMaps: DirectionMap,
+  direction: Direction
+): React.MutableRefObject<any> => {
+  const directionMap: Map<any, any> = directionMaps[direction as NavDirections];
   const firstEntry = [...directionMap][0]; // start with any element
   if (!firstEntry) {
     // no relations were registered for this direction - fallback to a different direction
-    if ([NavDirections.LEFT, NavDirections.RIGHT].includes(direction)) {
+    if ([NavDirections.LEFT, NavDirections.RIGHT].includes(direction as NavDirections)) {
       // there are no registered horizontal relations registered, try vertical relations. Get the top-most element.
       return getOutmostElementInDirection(directionMaps, NavDirections.UP);
     }
@@ -80,7 +88,10 @@ export const getOutmostElementInDirection = (directionMaps, direction) => {
   return getLastFocusableElementFromElementInDirection(directionMap, firstRef);
 };
 
-export const getNextElementToFocusInDirection = (directionMap, elementRef) => {
+export const getNextElementToFocusInDirection = (
+  directionMap: Map<any, any>,
+  elementRef: React.MutableRefObject<any>
+): React.MutableRefObject<any> => {
   const next = directionMap.get(elementRef);
   if (!next) {
     // this is the last element on the direction map - there' nothing next
@@ -93,7 +104,10 @@ export const getNextElementToFocusInDirection = (directionMap, elementRef) => {
   return next;
 };
 
-function getLastFocusableElementFromElementInDirection(directionMap, initialRef) {
+function getLastFocusableElementFromElementInDirection(
+  directionMap: Map<any, any>,
+  initialRef: React.MutableRefObject<any>
+): React.MutableRefObject<any> {
   let done = false;
   let currentRef = initialRef;
 


### PR DESCRIPTION
Closes https://github.com/mondaycom/monday-ui-react-core/issues/1568

…nContext - migrate to Typescript

<!--

Please go over the checklist and make sure all conditions are met.

--->

#### Basic

- [ ] Used plop (`npm run plop`) to create a new component.
- [x] PR has description.
- [ ] New component is functional and uses Hooks.
- [ ] Component is written in TypeScript.

#### Style

- [ ] Styles are added to `NewComponent.modules.scss` file inside the `NewComponent` folder.
- [ ] Component uses CSS Modules.
- [ ] Design is compatible with [Monday Design System](https://design.monday.com/).
- [ ] Styles are defined using [monday-ui-style](https://github.com/mondaycom/monday-ui-style) tokens
- [ ] Displays correctly in all the themes

#### Storybook

- [ ] Stories were added to `/src/components/NewComponent/__stories__/NewComponent.stories.mdx` file.
- [ ] Stories include all flows of using the component.
- [ ] Stories implemented using [vibe-storybook-components](https://github.com/mondaycom/vibe-storybook-components) components and tokens.

#### Tests

- [x] Tests are compliant with [TESTING_README.md](TESTING_README.md) instructions.

#### Accessibility

- [ ] Component is accessible.
- [ ] Component is compatible with [Vibe Accessibility Guidelines](https://style.monday.com/?path=/docs/foundations-accessibility--page)
