### PR TITLE
fix: <BreadcrumbsBar> - shouldn't be clickable when type = Indication

### DIFF
--- a/src/components/BreadcrumbsBar/BreadcrumbItem/BreadcrumbContent/BreadcrumbContent.module.scss
+++ b/src/components/BreadcrumbsBar/BreadcrumbItem/BreadcrumbContent/BreadcrumbContent.module.scss
@@ -51,3 +51,7 @@
   @include disabled;
   pointer-events: none;
 }
+
+.breadcrumbContent.notClickable{
+  pointer-events: none;
+}

--- a/src/components/BreadcrumbsBar/BreadcrumbItem/BreadcrumbContent/BreadcrumbContent.tsx
+++ b/src/components/BreadcrumbsBar/BreadcrumbItem/BreadcrumbContent/BreadcrumbContent.tsx
@@ -81,7 +81,8 @@ export const BreadcrumbContent: React.ForwardRefExoticComponent<BreadcrumbConten
           className={cx(styles.breadcrumbContent, className, {
             [styles.disabled]: disabled,
             [styles.clickable]: isClickable,
-            [styles.current]: isCurrent
+            [styles.current]: isCurrent,
+            [styles.notClickable]: !isClickable
           })}
           aria-disabled="true"
           tabIndex={tabIndex}

--- a/src/components/BreadcrumbsBar/BreadcrumbItem/__tests__/__snapshots__/breadcrumbItem-snapshot-tests.jest.js.snap
+++ b/src/components/BreadcrumbsBar/BreadcrumbItem/__tests__/__snapshots__/breadcrumbItem-snapshot-tests.jest.js.snap
@@ -13,7 +13,7 @@ exports[`BreadcrumbsItem renders correctly  when disabled item 1`] = `
     >
       <span
         aria-disabled="true"
-        className="breadcrumbContent disabled"
+        className="breadcrumbContent disabled notClickable"
         tabIndex={-1}
       >
         <span
@@ -40,7 +40,7 @@ exports[`BreadcrumbsItem renders correctly  with className 1`] = `
     >
       <span
         aria-disabled="true"
-        className="breadcrumbContent"
+        className="breadcrumbContent notClickable"
         tabIndex={0}
       >
         <span
@@ -68,7 +68,7 @@ exports[`BreadcrumbsItem renders correctly  with current item 1`] = `
       <span
         aria-current="page"
         aria-disabled="true"
-        className="breadcrumbContent current"
+        className="breadcrumbContent current notClickable"
         tabIndex={0}
       >
         <span
@@ -95,7 +95,7 @@ exports[`BreadcrumbsItem renders correctly  with empty props 1`] = `
     >
       <span
         aria-disabled="true"
-        className="breadcrumbContent"
+        className="breadcrumbContent notClickable"
         tabIndex={0}
       >
         <span
@@ -122,7 +122,7 @@ exports[`BreadcrumbsItem renders correctly  with icon 1`] = `
     >
       <span
         aria-disabled="true"
-        className="breadcrumbContent"
+        className="breadcrumbContent notClickable"
         tabIndex={0}
       >
         <svg
@@ -164,7 +164,7 @@ exports[`BreadcrumbsItem renders correctly  with text 1`] = `
     >
       <span
         aria-disabled="true"
-        className="breadcrumbContent"
+        className="breadcrumbContent notClickable"
         tabIndex={0}
       >
         <span

--- a/src/components/BreadcrumbsBar/__tests__/__snapshots__/breadcrumbsBar-snapshot-tests.jest.js.snap
+++ b/src/components/BreadcrumbsBar/__tests__/__snapshots__/breadcrumbsBar-snapshot-tests.jest.js.snap
@@ -33,7 +33,7 @@ exports[`BreadcrumbsBar renders correctly with children 1`] = `
     >
       <span
         aria-disabled="true"
-        className="breadcrumbContent"
+        className="breadcrumbContent notClickable"
         tabIndex={0}
       >
         <span
@@ -64,7 +64,7 @@ exports[`BreadcrumbsBar renders correctly with children 1`] = `
     >
       <span
         aria-disabled="true"
-        className="breadcrumbContent"
+        className="breadcrumbContent notClickable"
         tabIndex={0}
       >
         <span


### PR DESCRIPTION
Fixes issue #1569

#### Basic

- [x] Used plop (`npm run plop`) to create a new component.
- [x] PR has description.
- [x] New component is functional and uses Hooks.
- [x] Component is written in TypeScript.

#### Style

- [x] Styles are added to `NewComponent.modules.scss` file inside the `NewComponent` folder.
- [x] Component uses CSS Modules.
- [x] Design is compatible with [Monday Design System](https://design.monday.com/).
- [x] Styles are defined using [monday-ui-style](https://github.com/mondaycom/monday-ui-style) tokens
- [x] Displays correctly in all the themes

#### Storybook

- [x] Stories were added to `/src/components/NewComponent/__stories__/NewComponent.stories.mdx` file.
- [x] Stories include all flows of using the component.
- [x] Stories implemented using [vibe-storybook-components](https://github.com/mondaycom/vibe-storybook-components) components and tokens.

#### Tests

- [x] Tests are compliant with [TESTING_README.md](TESTING_README.md) instructions.

#### Accessibility

- [x] Component is accessible.
- [x] Component is compatible with [Vibe Accessibility Guidelines](https://style.monday.com/?path=/docs/foundations-accessibility--page)
