### PR TITLE
useMergeRefs - fix return type

### DIFF
--- a/src/components/Menu/MenuGridItem/useMenuGridItemNavContext.tsx
+++ b/src/components/Menu/MenuGridItem/useMenuGridItemNavContext.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from "react";
+import React, { RefObject, useMemo } from "react";
 import { NavDirections } from "../../../hooks/useFullKeyboardListeners";
 import { useGridKeyboardNavigationContext } from "../../GridKeyboardNavigationContext/GridKeyboardNavigationContext";
 import { CloseMenuOption } from "../Menu/MenuConstants";
@@ -12,7 +12,7 @@ export const useMenuGridItemNavContext = ({
   isUnderSubMenu,
   closeMenu
 }: {
-  wrapperRef?: (node: HTMLElement) => void;
+  wrapperRef?: RefObject<HTMLElement>;
   setActiveItemIndex?: (index: number) => void;
   getNextSelectableIndex?: (activeItemIndex: number) => number;
   getPreviousSelectableIndex?: (activeItemIndex: number) => number;

--- a/src/components/Typography/TypographyHooks.tsx
+++ b/src/components/Typography/TypographyHooks.tsx
@@ -2,13 +2,14 @@ import { MutableRefObject } from "react";
 import { ElementContent } from "../../types";
 import useIsOverflowing from "../../hooks/useIsOverflowing/useIsOverflowing";
 import { TooltipProps } from "../Tooltip/Tooltip";
+import { assignRef } from "../../hooks/useMergeRefs";
 import styles from "./Typography.module.scss";
 
-export function useEllipsisClass(ref: (node: HTMLElement) => void, ellipsis: boolean, maxLines: number) {
+export function useEllipsisClass(ref: MutableRefObject<HTMLElement>, ellipsis: boolean, maxLines: number) {
   let ellipsisClass;
   const overrideRef = (node: HTMLElement) => {
     node?.style.setProperty("--text-clamp-lines", maxLines.toString());
-    ref(node);
+    assignRef(ref, node);
   };
 
   // If component contains ellipsis return the fit ellipsis class

--- a/src/hooks/__tests__/useMergeRefs.jest.tsx
+++ b/src/hooks/__tests__/useMergeRefs.jest.tsx
@@ -1,6 +1,6 @@
 import React, { forwardRef, useRef, useEffect, RefObject, createRef } from "react";
 import { fireEvent, render, cleanup, act, screen, waitFor } from "@testing-library/react";
-import useMergeRefs from "../useMergeRefs";
+import useMergeRefs, { assignRef } from "../useMergeRefs";
 
 describe("useMergeRefs", () => {
   let Component: React.ElementType;
@@ -21,6 +21,7 @@ describe("useMergeRefs", () => {
 
     afterEach(() => {
       cleanup();
+      assignRef(internalRef, null);
     });
 
     it("should be able to set internal ref", () => {
@@ -88,6 +89,7 @@ describe("useMergeRefs", () => {
 
     afterEach(() => {
       cleanup();
+      assignRef(internalRef, null);
     });
 
     it("should not call any listeners if element didn't had click event", () => {


### PR DESCRIPTION
https://monday.monday.com/boards/3532714909/pulses/5335082110

Idea: change useMergeRefs return type to be RefObject, so we could have used it normally afterwards without type issue

It's a breaking change, so I'll do it in a separate hook - just testing for now