### PR TITLE
Bug Fix: Fixes #1661 Fixed the TS error while using size prop for <ProgressBar />

### DIFF
--- a/src/components/ProgressBars/LinearProgressBar/LinearProgressBar.tsx
+++ b/src/components/ProgressBars/LinearProgressBar/LinearProgressBar.tsx
@@ -4,7 +4,7 @@ import { SIZES } from "../../../constants";
 import { getStyle } from "../../../helpers/typesciptCssModulesHelper";
 import PercentageLabel from "../PercentageLabel/PercentageLabel";
 import { ProgressBarStyle, ProgressBarType } from "./LinearProgressBarConstants";
-import { calculatePercentage, getProgressBarClassNames } from "./LinearProgressBarHelpers";
+import { calculatePercentage, getProgressBarClassNames, Size } from "./LinearProgressBarHelpers";
 import Bar from "./Bar/Bar";
 import { VibeComponent, VibeComponentProps, withStaticProps } from "../../../types";
 import { ComponentDefaultTestId } from "../../../tests/constants";
@@ -43,7 +43,7 @@ interface LinearProgressBarProps extends VibeComponentProps {
   /**
    * Determine the progress bar height (Supported options exposed through `LinearProgressBar.sizes`)
    */
-  size?: typeof SIZES;
+  size?: Size;
   /**
    * Show progress bar progression in percentages
    */

--- a/src/components/ProgressBars/LinearProgressBar/LinearProgressBarHelpers.ts
+++ b/src/components/ProgressBars/LinearProgressBar/LinearProgressBarHelpers.ts
@@ -1,6 +1,9 @@
 import { toNumber } from "lodash-es";
+import { SIZES } from "./../../../constants/sizes";
 import cx from "classnames";
 import styles from "./LinearProgressBar.module.scss";
+
+export type Size = typeof SIZES[keyof typeof SIZES];
 
 export const calculatePercentage = (value: number, min: number, max: number) => {
   const valuePercentage = (toNumber(value - min) / toNumber(max - min)) * 100;


### PR DESCRIPTION

Fixes #1661

- Added a type export to the LinearProgressBarHelper.ts file to export the typeof Keys of SIZE
- Updated the type inside the LinearProgressBar Component itself by using the newly exported type size.

#### Basic

- [ ] Used plop (`npm run plop`) to create a new component.
- [ ] PR has description.
- [ ] New component is functional and uses Hooks.
- [ ] Component is written in TypeScript.

#### Style

- [ ] Styles are added to `NewComponent.modules.scss` file inside the `NewComponent` folder.
- [ ] Component uses CSS Modules.
- [ ] Design is compatible with [Monday Design System](https://design.monday.com/).
- [ ] Styles are defined using [monday-ui-style](https://github.com/mondaycom/monday-ui-style) tokens
- [ ] Displays correctly in all the themes

#### Storybook

- [ ] Stories were added to `/src/components/NewComponent/__stories__/NewComponent.stories.mdx` file.
- [ ] Stories include all flows of using the component.
- [ ] Stories implemented using [vibe-storybook-components](https://github.com/mondaycom/vibe-storybook-components) components and tokens.

#### Tests

- [ ] Tests are compliant with [TESTING_README.md](TESTING_README.md) instructions.

#### Accessibility

- [ ] Component is accessible.
- [ ] Component is compatible with [Vibe Accessibility Guidelines](https://style.monday.com/?path=/docs/foundations-accessibility--page)
