### PR TITLE
feat(Button): allow disabling resize observer

### DIFF
--- a/src/components/Button/Button.module.scss
+++ b/src/components/Button/Button.module.scss
@@ -26,6 +26,21 @@ $disabled-on-primary-color-opacity: 0.5;
   /* Will be updated dynamically after render by js */
   --element-width: 32;
   --element-height: 32;
+  min-width: var(--element-width);
+
+  .loader {
+    height: 100%;
+
+    .loaderSvg {
+      position: static;
+      height: 100%;
+      margin: 0;
+    }
+
+    .textPlaceholder {
+      opacity: 0;
+    }
+  }
 }
 
 .marginRight {
@@ -44,38 +59,6 @@ $disabled-on-primary-color-opacity: 0.5;
 .leftFlat {
   border-top-left-radius: 0;
   border-bottom-left-radius: 0;
-}
-
-.button {
-  min-width: var(--element-width);
-}
-
-.button.loading {
-  min-width: 0;
-}
-
-.button.loading.hasStyleSize {
-  width: var(--element-height);
-  max-width: var(--element-height);
-  height: var(--element-height);
-  max-height: var(--element-height);
-}
-
-.button.loading {
-  position: relative;
-}
-
-.button .loader {
-  width: calc(var(--element-height) - var(--loader-padding) * 2);
-  height: calc(var(--element-height) - var(--loader-padding) * 2);
-  position: absolute;
-  top: var(--loader-padding);
-  left: auto;
-}
-
-.button .loader .loaderSvg {
-  width: calc(var(--element-height) - var(--loader-padding) * 2);
-  height: calc(var(--element-height) - var(--loader-padding) * 2);
 }
 
 .button:active:not(.preventClickAnimation) {

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -393,6 +393,14 @@ const Button: VibeComponent<ButtonProps, unknown> & {
   }
 );
 
+Button.propTypes = {
+  disableResizeObserver: function (props) {
+    if (props.loading && props.disableResizeObserver) {
+      return new Error('Do not use "disableResizeObserver" with loading state');
+    }
+  }
+};
+
 Button.defaultProps = {
   className: undefined,
   name: undefined,

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -92,8 +92,8 @@ export interface ButtonProps extends VibeComponentProps {
   insetFocus?: boolean;
   /** Specifies the tab order of an element */
   tabIndex?: number;
-  /** Controls resize observer for smooth transition between states. Do not use with loading state */
-  disableResizeObserver?: boolean;
+  /** Make the button width dynamic according to container width. */
+  dynamicWidth?: boolean;
 }
 
 const Button: VibeComponent<ButtonProps, unknown> & {
@@ -145,16 +145,15 @@ const Button: VibeComponent<ButtonProps, unknown> & {
       "data-testid": dataTestId,
       insetFocus,
       tabIndex,
-      disableResizeObserver
+      dynamicWidth
     },
     ref
   ) => {
     const overrideDataTestId = backwardCompatibilityForProperties([dataTestId, backwardCompatabilityDataTestId]);
     const buttonRef = useRef<HTMLButtonElement>(null);
-    const [hasSizeStyle, setHasSizeStyle] = useState(false);
 
     const updateCssVariables = useMemo(() => {
-      if (disableResizeObserver) {
+      if (dynamicWidth) {
         return NOOP;
       }
       return ({ borderBoxSize }: { borderBoxSize: { blockSize: number; inlineSize: number } }) => {
@@ -164,9 +163,8 @@ const Button: VibeComponent<ButtonProps, unknown> & {
         if (!buttonRef.current) return;
         buttonRef.current.style.setProperty("--element-width", `${width}px`);
         buttonRef.current.style.setProperty("--element-height", `${height}px`);
-        setHasSizeStyle(true);
       };
-    }, [buttonRef, disableResizeObserver]);
+    }, [buttonRef, dynamicWidth]);
 
     useResizeObserver({
       ref: buttonRef,
@@ -229,8 +227,6 @@ const Button: VibeComponent<ButtonProps, unknown> & {
         getStyle(styles, camelCase("kind-" + kind)),
         getStyle(styles, camelCase("color-" + calculatedColor)),
         {
-          [styles.hasStyleSize]: hasSizeStyle,
-          [styles.loading]: loading,
           [getStyle(styles, camelCase("color-" + calculatedColor + "-active"))]: active,
           [activeButtonClassName]: active,
           [styles.marginRight]: marginRight,
@@ -249,8 +245,6 @@ const Button: VibeComponent<ButtonProps, unknown> & {
       className,
       size,
       kind,
-      hasSizeStyle,
-      loading,
       active,
       activeButtonClassName,
       marginRight,
@@ -336,6 +330,7 @@ const Button: VibeComponent<ButtonProps, unknown> & {
         <button {...buttonProps}>
           <span className={styles.loader}>
             <Loader svgClassName={styles.loaderSvg} />
+            <span className={styles.textPlaceholder}>{children}</span>
           </span>
         </button>
       );
@@ -393,14 +388,6 @@ const Button: VibeComponent<ButtonProps, unknown> & {
   }
 );
 
-Button.propTypes = {
-  disableResizeObserver: function (props) {
-    if (props.loading && props.disableResizeObserver) {
-      return new Error('Do not use "disableResizeObserver" with loading state');
-    }
-  }
-};
-
 Button.defaultProps = {
   className: undefined,
   name: undefined,
@@ -437,7 +424,7 @@ Button.defaultProps = {
   ariaLabel: undefined,
   ariaLabeledBy: undefined,
   insetFocus: false,
-  disableResizeObserver: false
+  dynamicWidth: false
 };
 
 export default withStaticProps(Button, {

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -92,6 +92,8 @@ export interface ButtonProps extends VibeComponentProps {
   insetFocus?: boolean;
   /** Specifies the tab order of an element */
   tabIndex?: number;
+  /** Controls resize observer for smooth transition between states. Do not use with loading state */
+  disableResizeObserver?: boolean;
 }
 
 const Button: VibeComponent<ButtonProps, unknown> & {
@@ -142,7 +144,8 @@ const Button: VibeComponent<ButtonProps, unknown> & {
       dataTestId: backwardCompatabilityDataTestId,
       "data-testid": dataTestId,
       insetFocus,
-      tabIndex
+      tabIndex,
+      disableResizeObserver
     },
     ref
   ) => {
@@ -151,6 +154,9 @@ const Button: VibeComponent<ButtonProps, unknown> & {
     const [hasSizeStyle, setHasSizeStyle] = useState(false);
 
     const updateCssVariables = useMemo(() => {
+      if (disableResizeObserver) {
+        return NOOP;
+      }
       return ({ borderBoxSize }: { borderBoxSize: { blockSize: number; inlineSize: number } }) => {
         const { blockSize, inlineSize } = borderBoxSize;
         const width = Math.max(inlineSize, MIN_BUTTON_HEIGHT_PX);
@@ -160,7 +166,7 @@ const Button: VibeComponent<ButtonProps, unknown> & {
         buttonRef.current.style.setProperty("--element-height", `${height}px`);
         setHasSizeStyle(true);
       };
-    }, [buttonRef]);
+    }, [buttonRef, disableResizeObserver]);
 
     useResizeObserver({
       ref: buttonRef,
@@ -422,7 +428,8 @@ Button.defaultProps = {
   ariaControls: undefined,
   ariaLabel: undefined,
   ariaLabeledBy: undefined,
-  insetFocus: false
+  insetFocus: false,
+  disableResizeObserver: false
 };
 
 export default withStaticProps(Button, {

--- a/src/components/Button/__stories__/button.stories.mdx
+++ b/src/components/Button/__stories__/button.stories.mdx
@@ -122,10 +122,10 @@ Set disable button for something that isn’t usable. Use a tooltip on hover in 
   </Story>
 </Canvas>
 
-### Error and success
+### Positive and Negative
 
 <Canvas>
-  <Story name="Error and success">
+  <Story name="Positive and Negative">
     <Button color={Button.colors.POSITIVE}>Positive</Button>
     <Button color={Button.colors.NEGATIVE}>Negative</Button>
   </Story>


### PR DESCRIPTION
Button is using a resize observer because the loading state makes the button shrink. In order to make the width change smoother we use transition on `min-width` which is controlled by a CSS variable (`--element-width/height`).
The problem is that since we apply `min-width` on the button, when shrinking the container which the button is in - the resize observer won't work (it takes the min-width value into consideration). 

I created a [ticket](https://monday.monday.com/boards/3532714909/pulses/5350787985) to fix it properly though it might be quite tricky.

As a quick solution I added a boolean (opt-in) that disables the resize observer and added validation to prevent using both the loading state and the disbableResizeObserver.

https://monday.monday.com/boards/3532714909/pulses/5350721960