### PR TITLE
fix(Button): fix grow/shrink behavior with loading state

### DIFF
--- a/src/components/Button/Button.module.scss
+++ b/src/components/Button/Button.module.scss
@@ -5,7 +5,6 @@
 $disabled-on-primary-color-opacity: 0.5;
 
 .button {
-  --loader-padding: 8px;
   outline: none;
   border: none;
   height: auto;
@@ -25,7 +24,18 @@ $disabled-on-primary-color-opacity: 0.5;
   user-select: none;
   /* Will be updated dynamically after render by js */
   --element-width: 32;
-  --element-height: 32;
+  min-width: var(--element-width);
+  width: fit-content;
+
+  .loader {
+    height: 100%;
+
+    .loaderSvg {
+      position: static;
+      height: 100%;
+      margin: 0;
+    }
+  }
 }
 
 .marginRight {
@@ -44,38 +54,6 @@ $disabled-on-primary-color-opacity: 0.5;
 .leftFlat {
   border-top-left-radius: 0;
   border-bottom-left-radius: 0;
-}
-
-.button {
-  min-width: var(--element-width);
-}
-
-.button.loading {
-  min-width: 0;
-}
-
-.button.loading.hasStyleSize {
-  width: var(--element-height);
-  max-width: var(--element-height);
-  height: var(--element-height);
-  max-height: var(--element-height);
-}
-
-.button.loading {
-  position: relative;
-}
-
-.button .loader {
-  width: calc(var(--element-height) - var(--loader-padding) * 2);
-  height: calc(var(--element-height) - var(--loader-padding) * 2);
-  position: absolute;
-  top: var(--loader-padding);
-  left: auto;
-}
-
-.button .loader .loaderSvg {
-  width: calc(var(--element-height) - var(--loader-padding) * 2);
-  height: calc(var(--element-height) - var(--loader-padding) * 2);
 }
 
 .button:active:not(.preventClickAnimation) {
@@ -112,10 +90,6 @@ $disabled-on-primary-color-opacity: 0.5;
   padding: var(--spacing-xs) var(--spacing-small);
   height: 32px;
   line-height: 24px;
-}
-
-.sizeSmall .loader {
-  top: 7px;
 }
 
 .sizeMedium {

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -1,9 +1,8 @@
 /* eslint-disable react/button-has-type */
-import React, { AriaAttributes, forwardRef, useCallback, useEffect, useMemo, useRef, useState } from "react";
+import React, { AriaAttributes, forwardRef, useCallback, useEffect, useMemo, useRef } from "react";
 import { camelCase } from "lodash-es";
 import cx from "classnames";
 import { SIZES } from "../../constants";
-import useResizeObserver from "../../hooks/useResizeObserver";
 import useMergeRefs from "../../hooks/useMergeRefs";
 import { NOOP } from "../../utils/function-utils";
 import Icon from "../../components/Icon/Icon";
@@ -11,16 +10,11 @@ import Loader from "../../components/Loader/Loader";
 import { BUTTON_ICON_SIZE, ButtonColor, ButtonInputType, ButtonType, getActualSize, Size } from "./ButtonConstants";
 import { getParentBackgroundColorNotTransparent, TRANSPARENT_COLOR } from "./helper/dom-helpers";
 import { getTestId } from "../../tests/test-ids-utils";
-import { isIE11 } from "../../utils/user-agent-utils";
 import { SubIcon, VibeComponent, VibeComponentProps, withStaticProps } from "../../types";
 import { ComponentDefaultTestId } from "../../tests/constants";
 import { backwardCompatibilityForProperties } from "../../helpers/backwardCompatibilityForProperties";
 import { getStyle } from "../../helpers/typesciptCssModulesHelper";
 import styles from "./Button.module.scss";
-
-// min button width
-const MIN_BUTTON_HEIGHT_PX = isIE11() ? 32 : 6;
-const UPDATE_CSS_VARIABLES_DEBOUNCE = 200;
 
 export interface ButtonProps extends VibeComponentProps {
   children?: React.ReactNode;
@@ -148,25 +142,12 @@ const Button: VibeComponent<ButtonProps, unknown> & {
   ) => {
     const overrideDataTestId = backwardCompatibilityForProperties([dataTestId, backwardCompatabilityDataTestId]);
     const buttonRef = useRef<HTMLButtonElement>(null);
-    const [hasSizeStyle, setHasSizeStyle] = useState(false);
 
-    const updateCssVariables = useMemo(() => {
-      return ({ borderBoxSize }: { borderBoxSize: { blockSize: number; inlineSize: number } }) => {
-        const { blockSize, inlineSize } = borderBoxSize;
-        const width = Math.max(inlineSize, MIN_BUTTON_HEIGHT_PX);
-        const height = Math.max(blockSize, MIN_BUTTON_HEIGHT_PX);
-        if (!buttonRef.current) return;
-        buttonRef.current.style.setProperty("--element-width", `${width}px`);
-        buttonRef.current.style.setProperty("--element-height", `${height}px`);
-        setHasSizeStyle(true);
-      };
-    }, [buttonRef]);
+    useEffect(() => {
+      const width = buttonRef.current.clientWidth;
+      buttonRef.current.style.setProperty("--element-width", `${width}px`);
+    }, []);
 
-    useResizeObserver({
-      ref: buttonRef,
-      callback: updateCssVariables,
-      debounceTime: UPDATE_CSS_VARIABLES_DEBOUNCE
-    });
     useEffect(() => {
       if (color !== ButtonColor.ON_PRIMARY_COLOR && color !== ButtonColor.FIXED_LIGHT) return;
       if (kind !== ButtonType.PRIMARY) return;
@@ -223,8 +204,6 @@ const Button: VibeComponent<ButtonProps, unknown> & {
         getStyle(styles, camelCase("kind-" + kind)),
         getStyle(styles, camelCase("color-" + calculatedColor)),
         {
-          [styles.hasStyleSize]: hasSizeStyle,
-          [styles.loading]: loading,
           [getStyle(styles, camelCase("color-" + calculatedColor + "-active"))]: active,
           [activeButtonClassName]: active,
           [styles.marginRight]: marginRight,
@@ -243,8 +222,6 @@ const Button: VibeComponent<ButtonProps, unknown> & {
       className,
       size,
       kind,
-      hasSizeStyle,
-      loading,
       active,
       activeButtonClassName,
       marginRight,

--- a/src/components/Button/__stories__/button.stories.mdx
+++ b/src/components/Button/__stories__/button.stories.mdx
@@ -122,10 +122,10 @@ Set disable button for something that isn’t usable. Use a tooltip on hover in 
   </Story>
 </Canvas>
 
-### Error and success
+### Positive and Negative
 
 <Canvas>
-  <Story name="Error and success">
+  <Story name="Positive and Negative">
     <Button color={Button.colors.POSITIVE}>Positive</Button>
     <Button color={Button.colors.NEGATIVE}>Negative</Button>
   </Story>


### PR DESCRIPTION
As requested by design, the loader remains the same size when switched to loading state instead of shrinking. Same for text changes in the button, if it changes with longer text, the button will grow in size, if it changes with shorter text it will remain the same size.
But, container width won't affect the button size whatsoever anymore. The Resize Observer was removed and now we simply keep the button original size in a CSS variable. This is also by design as it shouldn't be affected by the container. 

Note: this will not fix the original issue of the button being responsive to the container as it's a wrong usage for the button. We will suggest using the MenuItem for that case.

<img width="442" alt="Screenshot 2023-10-19 at 14 54 38" src="https://github.com/mondaycom/monday-ui-react-core/assets/18269880/c6698f9f-745d-43c0-9d4a-a9a1cea60711">

https://monday.monday.com/boards/3532714909/pulses/5350721960

This replaces #1681 
