### PR TITLE
feat: fix for Vite

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,13 +13,23 @@
     },
     "./dist/": "./dist/",
     "./icons": {
+      "types": "./dist/esm/components/Icon/Icons/index.d.ts",
       "import": "./dist/esm/src/components/Icon/Icons/icons.js",
       "default": "./dist/allIcons.js"
     },
-    "./interactionsTests": "./dist/esm/src/tests/interactionsTests.js",
-    "./testIds": "./dist/esm/src/tests/testIds.js",
+    "./interactionsTests": {
+      "types": "./dist/esm/tests/interactions-utils.d.ts",
+      "import": "./dist/esm/src/tests/interactionsTests.js"
+    },
+    "./testIds": {
+      "types": "./dist/esm/tests/test-ids-utils.d.ts",
+      "import": "./dist/esm/src/tests/testIds.js"
+    },
     "./storybookComponents": "./dist/storybook/index.js",
-    "./next": "./dist/esm/src/next/next.js",
+    "./next": {
+      "types": "./dist/esm/next/next.d.ts",
+      "import": "./dist/esm/src/next/next.js"
+    },
     "./tokens": "./dist/tokens/tokens.css",
     "./mockedClassNames": {
       "import": "./dist/mocked_classnames_esm/src/index.js"

--- a/package.json
+++ b/package.json
@@ -19,16 +19,19 @@
     },
     "./interactionsTests": {
       "types": "./dist/esm/tests/interactions-utils.d.ts",
-      "import": "./dist/esm/src/tests/interactionsTests.js"
+      "import": "./dist/esm/src/tests/interactionsTests.js",
+      "default": "./dist/esm/src/tests/interactionsTests.js"
     },
     "./testIds": {
       "types": "./dist/esm/tests/test-ids-utils.d.ts",
-      "import": "./dist/esm/src/tests/testIds.js"
+      "import": "./dist/esm/src/tests/testIds.js",
+      "default": "./dist/esm/src/tests/testIds.js"
     },
     "./storybookComponents": "./dist/storybook/index.js",
     "./next": {
       "types": "./dist/esm/next/next.d.ts",
-      "import": "./dist/esm/src/next/next.js"
+      "import": "./dist/esm/src/next/next.js",
+      "default": "./dist/esm/src/next/next.js"
     },
     "./tokens": "./dist/tokens/tokens.css",
     "./mockedClassNames": {

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "types": "./dist/types.d.ts",
       "import": "./dist/esm/src/index.js",
       "default": "./dist/main.js"
     },


### PR DESCRIPTION
https://monday.monday.com/boards/3532714909/pulses/5266928257

Tested it on
- monday-ui-components https://github.com/DaPulse/monday-npm-packages/pull/4173
- vite & TS test project
- react & ts test project
- Monolith - all good but fails on borg (i think cause of the prerelease version)- https://github.com/DaPulse/dapulse/pull/64168
- One of the MFs - mf-avaliablility-calendar 

Resolves https://github.com/mondaycom/monday-ui-react-core/issues/1598