### PR TITLE
fix: <Dropdown> multi - single line, fix mixed controlled-uncontrolled <Dialog> state management - move to uncontrolled

### DIFF
--- a/src/components/Dropdown/Dropdown.jsx
+++ b/src/components/Dropdown/Dropdown.jsx
@@ -99,7 +99,6 @@ const Dropdown = forwardRef(
     }, [defaultValue]);
 
     const [selected, setSelected] = useState(overrideDefaultValue || []);
-    const [isDialogShown, setIsDialogShown] = useState(false);
     const finalOptionRenderer = optionRenderer || OptionRenderer;
     const finalValueRenderer = valueRenderer || ValueRenderer;
     const isControlled = !!customValue;
@@ -217,8 +216,6 @@ const Dropdown = forwardRef(
       () => ({
         selectedOptions,
         onSelectedDelete: onOptionRemove,
-        setIsDialogShown,
-        isDialogShown,
         isMultiline: multiline,
         insideOverflowContainer,
         insideOverflowWithTransformContainer,
@@ -229,7 +226,6 @@ const Dropdown = forwardRef(
       [
         selectedOptions,
         onOptionRemove,
-        isDialogShown,
         multiline,
         insideOverflowContainer,
         insideOverflowWithTransformContainer,

--- a/src/components/Dropdown/components/MultiValueContainer/MultiValueContainer.jsx
+++ b/src/components/Dropdown/components/MultiValueContainer/MultiValueContainer.jsx
@@ -19,8 +19,7 @@ export default function Container({ children, selectProps, ...otherProps }) {
     withMandatoryDefaultOptions,
     readOnly
   } = selectProps;
-  const { selectedOptions, onSelectedDelete, setIsDialogShown, isDialogShown, isMultiline, popupsContainerSelector } =
-    customProps;
+  const { selectedOptions, onSelectedDelete, isMultiline, popupsContainerSelector } = customProps;
   const clickHandler = children[1];
   const [ref, setRef] = useState();
   const [isCounterShown, setIsCounterShown] = useState(false);
@@ -126,9 +125,6 @@ export default function Container({ children, selectProps, ...otherProps }) {
               tooltip
               showTrigger={Dialog.hideShowTriggers.CLICK}
               hideTrigger={Dialog.hideShowTriggers.CLICK_OUTSIDE}
-              open={isDialogShown}
-              onClick={() => setIsDialogShown(true)}
-              onClickOutside={() => setIsDialogShown(false)}
             >
               <Counter
                 kind={Counter.kinds.LINE}


### PR DESCRIPTION
https://monday.monday.com/boards/3532714909/pulses/5400142555

Mixed mode of controlled-uncontrolled Dialog open state caused it to unexpectedly open from time to time and not closing on Counter click

Reproducible on other examples also, but more convenient to see on same demo story example

Base branch - https://github.com/mondaycom/monday-ui-react-core/pull/1708