### PR TITLE
docs: extract AlertBanner template to stories file

### DIFF
--- a/src/components/AlertBanner/__stories__/alertBanner.stories.js
+++ b/src/components/AlertBanner/__stories__/alertBanner.stories.js
@@ -1,0 +1,12 @@
+import AlertBanner from "../AlertBanner";
+import AlertBannerText from "../AlertBannerText/AlertBannerText";
+import AlertBannerLink from "../AlertBannerLink/AlertBannerLink";
+
+export const alertBannerTemplate = args => {
+  return (
+    <AlertBanner {...args}>
+      <AlertBannerText text={args.bannerText} />
+      <AlertBannerLink text={args.linkText} href="https://monday.com" />
+    </AlertBanner>
+  );
+};

--- a/src/components/AlertBanner/__stories__/alertBanner.stories.mdx
+++ b/src/components/AlertBanner/__stories__/alertBanner.stories.mdx
@@ -12,6 +12,7 @@ import {
   TOOLTIP
 } from "../../../storybook/components/related-components/component-description-map";
 import "./alertBanner.stories.scss";
+import { alertBannerTemplate } from "./alertBanner.stories";
 
 export const metaSettings = createStoryMetaSettingsDecorator({
   component: AlertBanner,
@@ -24,17 +25,6 @@ export const metaSettings = createStoryMetaSettingsDecorator({
   argTypes={metaSettings.argTypes}
   decorators={metaSettings.decorators}
 />
-
-<!--- Component template -->
-
-export const alertBannerTemplate = args => {
-  return (
-    <AlertBanner {...args}>
-      <AlertBannerText text={args.bannerText} />
-      <AlertBannerLink text={args.linkText} href="https://monday.com" />
-    </AlertBanner>
-  );
-};
 
 <!--- Component documentation -->
 


### PR DESCRIPTION
The issue was that the condition in `AlertBanner.tsx:109` where the condition identified the children as MDX element and not AlertBanner Text, the ellipsis actually works well, there's even a story for that.
https://monday.monday.com/boards/3532714909/pulses/5382950355
<img width="701" alt="Screenshot 2023-10-29 at 16 47 11" src="https://github.com/mondaycom/monday-ui-react-core/assets/18269880/b711bb66-5552-4749-b83b-35cbfa74bdb1">
