### PR TITLE
chore: <Table/> - fix virtualization scroll issue

### DIFF
--- a/src/components/Table/TableRow/TableRow.tsx
+++ b/src/components/Table/TableRow/TableRow.tsx
@@ -12,7 +12,7 @@ export interface ITableRowProps extends VibeComponentProps {
 }
 
 const TableRow: VibeComponent<ITableRowProps, HTMLDivElement> = forwardRef(
-  ({ id, className, "data-testid": dataTestId, children }, ref) => {
+  ({ id, className, "data-testid": dataTestId, children, style }, ref) => {
     return (
       <div
         ref={ref}
@@ -20,6 +20,7 @@ const TableRow: VibeComponent<ITableRowProps, HTMLDivElement> = forwardRef(
         className={cx(styles.tableRow, className)}
         data-testid={dataTestId || getTestId(ComponentDefaultTestId.TABLE_ROW, id)}
         role="row"
+        style={style}
       >
         {children}
       </div>


### PR DESCRIPTION
We had an issue here: https://style.monday.com/?path=/docs/data-display-table--virtualized-scroll
scrolling happened but rows were glitchy and didn't render some
![image](https://github.com/mondaycom/monday-ui-react-core/assets/6093192/987c47b8-6523-4668-805d-b644b11bda4c)
can reproduce in this Storybook preview: https://62037c72e0e4d6004a9a450f-oyicztqxje.chromatic.com/?path=/docs/data-display-table--virtualized-scroll