### PR TITLE
fix: Modified the styling of the <TextField> icon 

### DIFF
--- a/src/components/Combobox/__tests__/__snapshots__/combobox-snapshot-tests.jest.js.snap
+++ b/src/components/Combobox/__tests__/__snapshots__/combobox-snapshot-tests.jest.js.snap
@@ -50,7 +50,7 @@ exports[`Combobox renders correctly when disabled 1`] = `
             value=""
           />
           <div
-            className="clickable iconContainer iconContainerHasIcon iconContainerActive disableTextSelection"
+            className="clickable iconContainer iconContainerHasIcon iconContainerActive iconContainerClickable disableTextSelection"
             data-testid="clickable"
             onClick={[Function]}
             onKeyDown={[Function]}
@@ -80,7 +80,7 @@ exports[`Combobox renders correctly when disabled 1`] = `
             </svg>
           </div>
           <div
-            className="clickable iconContainer iconContainerHasIcon disableTextSelection"
+            className="clickable iconContainer iconContainerHasIcon iconContainerClickable disableTextSelection"
             data-testid="clean-search-button_combobox-search"
             onClick={[Function]}
             onKeyDown={[Function]}
@@ -170,7 +170,7 @@ exports[`Combobox renders correctly with another noResultsMessage 1`] = `
             value=""
           />
           <div
-            className="clickable iconContainer iconContainerHasIcon iconContainerActive disableTextSelection"
+            className="clickable iconContainer iconContainerHasIcon iconContainerActive iconContainerClickable disableTextSelection"
             data-testid="clickable"
             onClick={[Function]}
             onKeyDown={[Function]}
@@ -200,7 +200,7 @@ exports[`Combobox renders correctly with another noResultsMessage 1`] = `
             </svg>
           </div>
           <div
-            className="clickable iconContainer iconContainerHasIcon disableTextSelection"
+            className="clickable iconContainer iconContainerHasIcon iconContainerClickable disableTextSelection"
             data-testid="clean-search-button_combobox-search"
             onClick={[Function]}
             onKeyDown={[Function]}
@@ -290,7 +290,7 @@ exports[`Combobox renders correctly with autoFocus 1`] = `
             value=""
           />
           <div
-            className="clickable iconContainer iconContainerHasIcon iconContainerActive disableTextSelection"
+            className="clickable iconContainer iconContainerHasIcon iconContainerActive iconContainerClickable disableTextSelection"
             data-testid="clickable"
             onClick={[Function]}
             onKeyDown={[Function]}
@@ -320,7 +320,7 @@ exports[`Combobox renders correctly with autoFocus 1`] = `
             </svg>
           </div>
           <div
-            className="clickable iconContainer iconContainerHasIcon disableTextSelection"
+            className="clickable iconContainer iconContainerHasIcon iconContainerClickable disableTextSelection"
             data-testid="clean-search-button_combobox-search"
             onClick={[Function]}
             onKeyDown={[Function]}
@@ -410,7 +410,7 @@ exports[`Combobox renders correctly with className 1`] = `
             value=""
           />
           <div
-            className="clickable iconContainer iconContainerHasIcon iconContainerActive disableTextSelection"
+            className="clickable iconContainer iconContainerHasIcon iconContainerActive iconContainerClickable disableTextSelection"
             data-testid="clickable"
             onClick={[Function]}
             onKeyDown={[Function]}
@@ -440,7 +440,7 @@ exports[`Combobox renders correctly with className 1`] = `
             </svg>
           </div>
           <div
-            className="clickable iconContainer iconContainerHasIcon disableTextSelection"
+            className="clickable iconContainer iconContainerHasIcon iconContainerClickable disableTextSelection"
             data-testid="clean-search-button_combobox-search"
             onClick={[Function]}
             onKeyDown={[Function]}
@@ -530,7 +530,7 @@ exports[`Combobox renders correctly with custom search icon 1`] = `
             value=""
           />
           <div
-            className="clickable iconContainer iconContainerHasIcon iconContainerActive disableTextSelection"
+            className="clickable iconContainer iconContainerHasIcon iconContainerActive iconContainerClickable disableTextSelection"
             data-testid="clickable"
             onClick={[Function]}
             onKeyDown={[Function]}
@@ -560,7 +560,7 @@ exports[`Combobox renders correctly with custom search icon 1`] = `
             </svg>
           </div>
           <div
-            className="clickable iconContainer iconContainerHasIcon disableTextSelection"
+            className="clickable iconContainer iconContainerHasIcon iconContainerClickable disableTextSelection"
             data-testid="clean-search-button_combobox-search"
             onClick={[Function]}
             onKeyDown={[Function]}
@@ -650,7 +650,7 @@ exports[`Combobox renders correctly with divider 1`] = `
             value=""
           />
           <div
-            className="clickable iconContainer iconContainerHasIcon iconContainerActive disableTextSelection"
+            className="clickable iconContainer iconContainerHasIcon iconContainerActive iconContainerClickable disableTextSelection"
             data-testid="clickable"
             onClick={[Function]}
             onKeyDown={[Function]}
@@ -680,7 +680,7 @@ exports[`Combobox renders correctly with divider 1`] = `
             </svg>
           </div>
           <div
-            className="clickable iconContainer iconContainerHasIcon disableTextSelection"
+            className="clickable iconContainer iconContainerHasIcon iconContainerClickable disableTextSelection"
             data-testid="clean-search-button_combobox-search"
             onClick={[Function]}
             onKeyDown={[Function]}
@@ -868,7 +868,7 @@ exports[`Combobox renders correctly with divider and colored categories 1`] = `
             value=""
           />
           <div
-            className="clickable iconContainer iconContainerHasIcon iconContainerActive disableTextSelection"
+            className="clickable iconContainer iconContainerHasIcon iconContainerActive iconContainerClickable disableTextSelection"
             data-testid="clickable"
             onClick={[Function]}
             onKeyDown={[Function]}
@@ -898,7 +898,7 @@ exports[`Combobox renders correctly with divider and colored categories 1`] = `
             </svg>
           </div>
           <div
-            className="clickable iconContainer iconContainerHasIcon disableTextSelection"
+            className="clickable iconContainer iconContainerHasIcon iconContainerClickable disableTextSelection"
             data-testid="clean-search-button_combobox-search"
             onClick={[Function]}
             onKeyDown={[Function]}
@@ -1096,7 +1096,7 @@ exports[`Combobox renders correctly with empty props 1`] = `
             value=""
           />
           <div
-            className="clickable iconContainer iconContainerHasIcon iconContainerActive disableTextSelection"
+            className="clickable iconContainer iconContainerHasIcon iconContainerActive iconContainerClickable disableTextSelection"
             data-testid="clickable"
             onClick={[Function]}
             onKeyDown={[Function]}
@@ -1126,7 +1126,7 @@ exports[`Combobox renders correctly with empty props 1`] = `
             </svg>
           </div>
           <div
-            className="clickable iconContainer iconContainerHasIcon disableTextSelection"
+            className="clickable iconContainer iconContainerHasIcon iconContainerClickable disableTextSelection"
             data-testid="clean-search-button_combobox-search"
             onClick={[Function]}
             onKeyDown={[Function]}
@@ -1216,7 +1216,7 @@ exports[`Combobox renders correctly with id 1`] = `
             value=""
           />
           <div
-            className="clickable iconContainer iconContainerHasIcon iconContainerActive disableTextSelection"
+            className="clickable iconContainer iconContainerHasIcon iconContainerActive iconContainerClickable disableTextSelection"
             data-testid="clickable"
             onClick={[Function]}
             onKeyDown={[Function]}
@@ -1246,7 +1246,7 @@ exports[`Combobox renders correctly with id 1`] = `
             </svg>
           </div>
           <div
-            className="clickable iconContainer iconContainerHasIcon disableTextSelection"
+            className="clickable iconContainer iconContainerHasIcon iconContainerClickable disableTextSelection"
             data-testid="clean-search-button_combobox-search"
             onClick={[Function]}
             onKeyDown={[Function]}
@@ -1365,7 +1365,7 @@ exports[`Combobox renders correctly with loading 1`] = `
             </div>
           </div>
           <div
-            className="clickable iconContainer iconContainerHasIcon iconContainerActive disableTextSelection"
+            className="clickable iconContainer iconContainerHasIcon iconContainerActive iconContainerClickable disableTextSelection"
             data-testid="clickable"
             onClick={[Function]}
             onKeyDown={[Function]}
@@ -1395,7 +1395,7 @@ exports[`Combobox renders correctly with loading 1`] = `
             </svg>
           </div>
           <div
-            className="clickable iconContainer iconContainerHasIcon disableTextSelection"
+            className="clickable iconContainer iconContainerHasIcon iconContainerClickable disableTextSelection"
             data-testid="clean-search-button_combobox-search"
             onClick={[Function]}
             onKeyDown={[Function]}
@@ -1485,7 +1485,7 @@ exports[`Combobox renders correctly with optionClassName 1`] = `
             value=""
           />
           <div
-            className="clickable iconContainer iconContainerHasIcon iconContainerActive disableTextSelection"
+            className="clickable iconContainer iconContainerHasIcon iconContainerActive iconContainerClickable disableTextSelection"
             data-testid="clickable"
             onClick={[Function]}
             onKeyDown={[Function]}
@@ -1515,7 +1515,7 @@ exports[`Combobox renders correctly with optionClassName 1`] = `
             </svg>
           </div>
           <div
-            className="clickable iconContainer iconContainerHasIcon disableTextSelection"
+            className="clickable iconContainer iconContainerHasIcon iconContainerClickable disableTextSelection"
             data-testid="clean-search-button_combobox-search"
             onClick={[Function]}
             onKeyDown={[Function]}
@@ -1605,7 +1605,7 @@ exports[`Combobox renders correctly with optionLineHeight 1`] = `
             value=""
           />
           <div
-            className="clickable iconContainer iconContainerHasIcon iconContainerActive disableTextSelection"
+            className="clickable iconContainer iconContainerHasIcon iconContainerActive iconContainerClickable disableTextSelection"
             data-testid="clickable"
             onClick={[Function]}
             onKeyDown={[Function]}
@@ -1635,7 +1635,7 @@ exports[`Combobox renders correctly with optionLineHeight 1`] = `
             </svg>
           </div>
           <div
-            className="clickable iconContainer iconContainerHasIcon disableTextSelection"
+            className="clickable iconContainer iconContainerHasIcon iconContainerClickable disableTextSelection"
             data-testid="clean-search-button_combobox-search"
             onClick={[Function]}
             onKeyDown={[Function]}
@@ -1725,7 +1725,7 @@ exports[`Combobox renders correctly with optionRenderer 1`] = `
             value=""
           />
           <div
-            className="clickable iconContainer iconContainerHasIcon iconContainerActive disableTextSelection"
+            className="clickable iconContainer iconContainerHasIcon iconContainerActive iconContainerClickable disableTextSelection"
             data-testid="clickable"
             onClick={[Function]}
             onKeyDown={[Function]}
@@ -1755,7 +1755,7 @@ exports[`Combobox renders correctly with optionRenderer 1`] = `
             </svg>
           </div>
           <div
-            className="clickable iconContainer iconContainerHasIcon disableTextSelection"
+            className="clickable iconContainer iconContainerHasIcon iconContainerClickable disableTextSelection"
             data-testid="clean-search-button_combobox-search"
             onClick={[Function]}
             onKeyDown={[Function]}
@@ -1898,7 +1898,7 @@ exports[`Combobox renders correctly with optionsListHeight 1`] = `
             value=""
           />
           <div
-            className="clickable iconContainer iconContainerHasIcon iconContainerActive disableTextSelection"
+            className="clickable iconContainer iconContainerHasIcon iconContainerActive iconContainerClickable disableTextSelection"
             data-testid="clickable"
             onClick={[Function]}
             onKeyDown={[Function]}
@@ -1928,7 +1928,7 @@ exports[`Combobox renders correctly with optionsListHeight 1`] = `
             </svg>
           </div>
           <div
-            className="clickable iconContainer iconContainerHasIcon disableTextSelection"
+            className="clickable iconContainer iconContainerHasIcon iconContainerClickable disableTextSelection"
             data-testid="clean-search-button_combobox-search"
             onClick={[Function]}
             onKeyDown={[Function]}
@@ -2018,7 +2018,7 @@ exports[`Combobox renders correctly with placeholder 1`] = `
             value=""
           />
           <div
-            className="clickable iconContainer iconContainerHasIcon iconContainerActive disableTextSelection"
+            className="clickable iconContainer iconContainerHasIcon iconContainerActive iconContainerClickable disableTextSelection"
             data-testid="clickable"
             onClick={[Function]}
             onKeyDown={[Function]}
@@ -2048,7 +2048,7 @@ exports[`Combobox renders correctly with placeholder 1`] = `
             </svg>
           </div>
           <div
-            className="clickable iconContainer iconContainerHasIcon disableTextSelection"
+            className="clickable iconContainer iconContainerHasIcon iconContainerClickable disableTextSelection"
             data-testid="clean-search-button_combobox-search"
             onClick={[Function]}
             onKeyDown={[Function]}
@@ -2138,7 +2138,7 @@ exports[`Combobox renders correctly with size 1`] = `
             value=""
           />
           <div
-            className="clickable iconContainer iconContainerHasIcon iconContainerActive disableTextSelection"
+            className="clickable iconContainer iconContainerHasIcon iconContainerActive iconContainerClickable disableTextSelection"
             data-testid="clickable"
             onClick={[Function]}
             onKeyDown={[Function]}
@@ -2168,7 +2168,7 @@ exports[`Combobox renders correctly with size 1`] = `
             </svg>
           </div>
           <div
-            className="clickable iconContainer iconContainerHasIcon disableTextSelection"
+            className="clickable iconContainer iconContainerHasIcon iconContainerClickable disableTextSelection"
             data-testid="clean-search-button_combobox-search"
             onClick={[Function]}
             onKeyDown={[Function]}

--- a/src/components/Search/__tests__/__snapshots__/search-snapshot-tests.jest.js.snap
+++ b/src/components/Search/__tests__/__snapshots__/search-snapshot-tests.jest.js.snap
@@ -36,7 +36,7 @@ exports[`Search renders correctly when disabled 1`] = `
         value=""
       />
       <div
-        className="clickable iconContainer iconContainerHasIcon iconContainerActive disableTextSelection"
+        className="clickable iconContainer iconContainerHasIcon iconContainerActive iconContainerClickable disableTextSelection"
         data-testid="clickable"
         onClick={[Function]}
         onKeyDown={[Function]}
@@ -66,7 +66,7 @@ exports[`Search renders correctly when disabled 1`] = `
         </svg>
       </div>
       <div
-        className="clickable iconContainer iconContainerHasIcon disableTextSelection"
+        className="clickable iconContainer iconContainerHasIcon iconContainerClickable disableTextSelection"
         data-testid="clean-search-button_search"
         onClick={[Function]}
         onKeyDown={[Function]}
@@ -136,7 +136,7 @@ exports[`Search renders correctly when underline 1`] = `
         value=""
       />
       <div
-        className="clickable iconContainer iconContainerHasIcon iconContainerActive disableTextSelection"
+        className="clickable iconContainer iconContainerHasIcon iconContainerActive iconContainerClickable disableTextSelection"
         data-testid="clickable"
         onClick={[Function]}
         onKeyDown={[Function]}
@@ -166,7 +166,7 @@ exports[`Search renders correctly when underline 1`] = `
         </svg>
       </div>
       <div
-        className="clickable iconContainer iconContainerHasIcon disableTextSelection"
+        className="clickable iconContainer iconContainerHasIcon iconContainerClickable disableTextSelection"
         data-testid="clean-search-button_search"
         onClick={[Function]}
         onKeyDown={[Function]}
@@ -236,7 +236,7 @@ exports[`Search renders correctly with className 1`] = `
         value=""
       />
       <div
-        className="clickable iconContainer iconContainerHasIcon iconContainerActive disableTextSelection"
+        className="clickable iconContainer iconContainerHasIcon iconContainerActive iconContainerClickable disableTextSelection"
         data-testid="clickable"
         onClick={[Function]}
         onKeyDown={[Function]}
@@ -266,7 +266,7 @@ exports[`Search renders correctly with className 1`] = `
         </svg>
       </div>
       <div
-        className="clickable iconContainer iconContainerHasIcon disableTextSelection"
+        className="clickable iconContainer iconContainerHasIcon iconContainerClickable disableTextSelection"
         data-testid="clean-search-button_search"
         onClick={[Function]}
         onKeyDown={[Function]}
@@ -336,7 +336,7 @@ exports[`Search renders correctly with icon 1`] = `
         value=""
       />
       <div
-        className="clickable iconContainer iconContainerHasIcon iconContainerActive disableTextSelection"
+        className="clickable iconContainer iconContainerHasIcon iconContainerActive iconContainerClickable disableTextSelection"
         data-testid="clickable"
         onClick={[Function]}
         onKeyDown={[Function]}
@@ -356,7 +356,7 @@ exports[`Search renders correctly with icon 1`] = `
         />
       </div>
       <div
-        className="clickable iconContainer iconContainerHasIcon disableTextSelection"
+        className="clickable iconContainer iconContainerHasIcon iconContainerClickable disableTextSelection"
         data-testid="clean-search-button_search"
         onClick={[Function]}
         onKeyDown={[Function]}
@@ -426,7 +426,7 @@ exports[`Search renders correctly with id 1`] = `
         value=""
       />
       <div
-        className="clickable iconContainer iconContainerHasIcon iconContainerActive disableTextSelection"
+        className="clickable iconContainer iconContainerHasIcon iconContainerActive iconContainerClickable disableTextSelection"
         data-testid="clickable"
         onClick={[Function]}
         onKeyDown={[Function]}
@@ -456,7 +456,7 @@ exports[`Search renders correctly with id 1`] = `
         </svg>
       </div>
       <div
-        className="clickable iconContainer iconContainerHasIcon disableTextSelection"
+        className="clickable iconContainer iconContainerHasIcon iconContainerClickable disableTextSelection"
         data-testid="clean-search-button_testId"
         onClick={[Function]}
         onKeyDown={[Function]}
@@ -555,7 +555,7 @@ exports[`Search renders correctly with loading 1`] = `
         </div>
       </div>
       <div
-        className="clickable iconContainer iconContainerHasIcon iconContainerActive disableTextSelection"
+        className="clickable iconContainer iconContainerHasIcon iconContainerActive iconContainerClickable disableTextSelection"
         data-testid="clickable"
         onClick={[Function]}
         onKeyDown={[Function]}
@@ -585,7 +585,7 @@ exports[`Search renders correctly with loading 1`] = `
         </svg>
       </div>
       <div
-        className="clickable iconContainer iconContainerHasIcon disableTextSelection"
+        className="clickable iconContainer iconContainerHasIcon iconContainerClickable disableTextSelection"
         data-testid="clean-search-button_search"
         onClick={[Function]}
         onKeyDown={[Function]}
@@ -655,7 +655,7 @@ exports[`Search renders correctly with placeholder 1`] = `
         value=""
       />
       <div
-        className="clickable iconContainer iconContainerHasIcon iconContainerActive disableTextSelection"
+        className="clickable iconContainer iconContainerHasIcon iconContainerActive iconContainerClickable disableTextSelection"
         data-testid="clickable"
         onClick={[Function]}
         onKeyDown={[Function]}
@@ -685,7 +685,7 @@ exports[`Search renders correctly with placeholder 1`] = `
         </svg>
       </div>
       <div
-        className="clickable iconContainer iconContainerHasIcon disableTextSelection"
+        className="clickable iconContainer iconContainerHasIcon iconContainerClickable disableTextSelection"
         data-testid="clean-search-button_search"
         onClick={[Function]}
         onKeyDown={[Function]}
@@ -755,7 +755,7 @@ exports[`Search renders correctly with secondaryIconName 1`] = `
         value=""
       />
       <div
-        className="clickable iconContainer iconContainerHasIcon iconContainerActive disableTextSelection"
+        className="clickable iconContainer iconContainerHasIcon iconContainerActive iconContainerClickable disableTextSelection"
         data-testid="clickable"
         onClick={[Function]}
         onKeyDown={[Function]}
@@ -785,7 +785,7 @@ exports[`Search renders correctly with secondaryIconName 1`] = `
         </svg>
       </div>
       <div
-        className="clickable iconContainer iconContainerHasIcon disableTextSelection"
+        className="clickable iconContainer iconContainerHasIcon iconContainerClickable disableTextSelection"
         data-testid="clean-search-button_search"
         onClick={[Function]}
         onKeyDown={[Function]}
@@ -845,7 +845,7 @@ exports[`Search renders correctly with underline type 1`] = `
         value=""
       />
       <div
-        className="clickable iconContainer iconContainerHasIcon iconContainerActive disableTextSelection"
+        className="clickable iconContainer iconContainerHasIcon iconContainerActive iconContainerClickable disableTextSelection"
         data-testid="clickable"
         onClick={[Function]}
         onKeyDown={[Function]}
@@ -875,7 +875,7 @@ exports[`Search renders correctly with underline type 1`] = `
         </svg>
       </div>
       <div
-        className="clickable iconContainer iconContainerHasIcon disableTextSelection"
+        className="clickable iconContainer iconContainerHasIcon iconContainerClickable disableTextSelection"
         data-testid="clean-search-button_search"
         onClick={[Function]}
         onKeyDown={[Function]}
@@ -945,7 +945,7 @@ exports[`Search renders correctly with validation 1`] = `
         value=""
       />
       <div
-        className="clickable iconContainer iconContainerHasIcon iconContainerActive disableTextSelection"
+        className="clickable iconContainer iconContainerHasIcon iconContainerActive iconContainerClickable disableTextSelection"
         data-testid="clickable"
         onClick={[Function]}
         onKeyDown={[Function]}
@@ -975,7 +975,7 @@ exports[`Search renders correctly with validation 1`] = `
         </svg>
       </div>
       <div
-        className="clickable iconContainer iconContainerHasIcon disableTextSelection"
+        className="clickable iconContainer iconContainerHasIcon iconContainerClickable disableTextSelection"
         data-testid="clean-search-button_search"
         onClick={[Function]}
         onKeyDown={[Function]}
@@ -1045,7 +1045,7 @@ exports[`Search renders correctly with value 1`] = `
         value="value"
       />
       <div
-        className="clickable iconContainer iconContainerHasIcon disableTextSelection"
+        className="clickable iconContainer iconContainerHasIcon iconContainerClickable disableTextSelection"
         data-testid="clickable"
         onClick={[Function]}
         onKeyDown={[Function]}
@@ -1075,7 +1075,7 @@ exports[`Search renders correctly with value 1`] = `
         </svg>
       </div>
       <div
-        className="clickable iconContainer iconContainerHasIcon iconContainerActive disableTextSelection"
+        className="clickable iconContainer iconContainerHasIcon iconContainerActive iconContainerClickable disableTextSelection"
         data-testid="clean-search-button_search"
         onClick={[Function]}
         onKeyDown={[Function]}
@@ -1145,7 +1145,7 @@ exports[`Search renders correctly with wrapperClassName 1`] = `
         value=""
       />
       <div
-        className="clickable iconContainer iconContainerHasIcon iconContainerActive disableTextSelection"
+        className="clickable iconContainer iconContainerHasIcon iconContainerActive iconContainerClickable disableTextSelection"
         data-testid="clickable"
         onClick={[Function]}
         onKeyDown={[Function]}
@@ -1175,7 +1175,7 @@ exports[`Search renders correctly with wrapperClassName 1`] = `
         </svg>
       </div>
       <div
-        className="clickable iconContainer iconContainerHasIcon disableTextSelection"
+        className="clickable iconContainer iconContainerHasIcon iconContainerClickable disableTextSelection"
         data-testid="clean-search-button_search"
         onClick={[Function]}
         onKeyDown={[Function]}
@@ -1245,7 +1245,7 @@ exports[`Search renders correctly without props 1`] = `
         value=""
       />
       <div
-        className="clickable iconContainer iconContainerHasIcon iconContainerActive disableTextSelection"
+        className="clickable iconContainer iconContainerHasIcon iconContainerActive iconContainerClickable disableTextSelection"
         data-testid="clickable"
         onClick={[Function]}
         onKeyDown={[Function]}
@@ -1275,7 +1275,7 @@ exports[`Search renders correctly without props 1`] = `
         </svg>
       </div>
       <div
-        className="clickable iconContainer iconContainerHasIcon disableTextSelection"
+        className="clickable iconContainer iconContainerHasIcon iconContainerClickable disableTextSelection"
         data-testid="clean-search-button_search"
         onClick={[Function]}
         onKeyDown={[Function]}

--- a/src/components/TextField/TextField.module.scss
+++ b/src/components/TextField/TextField.module.scss
@@ -121,20 +121,18 @@
   pointer-events: none;
 }
 
-.textField .inputWrapper .iconContainer:active,
-.textField .inputWrapper .iconContainer:focus,
-.textField .inputWrapper .iconContainer:focus-visible {
-  outline: none;
-  background-color: var(--primary-background-hover-color);
-}
-
 .textField .inputWrapper .iconContainer {
   -webkit-appearance: none;
 }
 
-.textField .inputWrapper .iconContainer.iconContainerActive.iconContainerHasIcon {
+.textField .inputWrapper .iconContainer.iconContainerActive.iconContainerHasIcon.iconContainerClickable {
   pointer-events: all;
   cursor: pointer;
+}
+
+.textField .inputWrapper .iconContainer.iconContainerActive.iconContainerHasIcon:not(.iconContainerClickable) {
+  pointer-events: none;
+  cursor: default;
 }
 
 .textField .inputWrapper .iconContainer.iconContainerActive {
@@ -147,9 +145,12 @@
   transform: rotate(0) scale(1);
 }
 
-.textField .inputWrapper .iconContainer.iconContainerHasIcon:hover,
-.textField .inputWrapper .iconContainer.iconContainerHasIcon:focus-within {
+.textField .inputWrapper .iconContainer.iconContainerHasIcon.iconContainerClickable:hover {
   background-color: var(--primary-background-hover-color);
+}
+
+.textField .inputWrapper .iconContainer.iconContainerHasIcon.iconContainerClickable:active {
+  transform: translateY(-50%) scale(0.9);
 }
 
 .textField .inputWrapper .iconContainer .icon {

--- a/src/components/TextField/TextField.tsx
+++ b/src/components/TextField/TextField.tsx
@@ -198,7 +198,9 @@ const TextField: VibeComponent<TextFieldProps, unknown> & {
       }
     }, [inputRef, autoFocus]);
 
-    return (
+      const isIconContainerClickable = onIconClick !== NOOP || clearOnIconClick;
+
+      return (
       <div
         className={cx(styles.textField, wrapperClassName, {
           [styles.disabled]: disabled,
@@ -261,7 +263,7 @@ const TextField: VibeComponent<TextFieldProps, unknown> & {
               className={cx(styles.iconContainer, {
                 [styles.iconContainerHasIcon]: hasIcon,
                 [styles.iconContainerActive]: isPrimary,
-                [styles.iconContainerClickable]: onIconClick !== NOOP || clearOnIconClick
+                [styles.iconContainerClickable]: isIconContainerClickable
               })}
               onClick={onIconClickCallback}
               tabIndex={onIconClick !== NOOP && inputValue && iconName.length && isPrimary ? "0" : "-1"}
@@ -280,7 +282,7 @@ const TextField: VibeComponent<TextFieldProps, unknown> & {
               className={cx(styles.iconContainer, {
                 [styles.iconContainerHasIcon]: hasIcon,
                 [styles.iconContainerActive]: isSecondary,
-                [styles.iconContainerClickable]: onIconClick !== NOOP || clearOnIconClick
+                [styles.iconContainerClickable]: isIconContainerClickable
               })}
               onClick={onIconClickCallback}
               tabIndex={!shouldFocusOnSecondaryIcon ? "-1" : "0"}

--- a/src/components/TextField/TextField.tsx
+++ b/src/components/TextField/TextField.tsx
@@ -260,7 +260,8 @@ const TextField: VibeComponent<TextFieldProps, unknown> & {
             <Clickable
               className={cx(styles.iconContainer, {
                 [styles.iconContainerHasIcon]: hasIcon,
-                [styles.iconContainerActive]: isPrimary
+                [styles.iconContainerActive]: isPrimary,
+                [styles.iconContainerClickable]: onIconClick !== NOOP
               })}
               onClick={onIconClickCallback}
               tabIndex={onIconClick !== NOOP && inputValue && iconName.length && isPrimary ? "0" : "-1"}

--- a/src/components/TextField/TextField.tsx
+++ b/src/components/TextField/TextField.tsx
@@ -198,9 +198,9 @@ const TextField: VibeComponent<TextFieldProps, unknown> & {
       }
     }, [inputRef, autoFocus]);
 
-      const isIconContainerClickable = onIconClick !== NOOP || clearOnIconClick;
+    const isIconContainerClickable = onIconClick !== NOOP || clearOnIconClick;
 
-      return (
+    return (
       <div
         className={cx(styles.textField, wrapperClassName, {
           [styles.disabled]: disabled,

--- a/src/components/TextField/TextField.tsx
+++ b/src/components/TextField/TextField.tsx
@@ -261,7 +261,7 @@ const TextField: VibeComponent<TextFieldProps, unknown> & {
               className={cx(styles.iconContainer, {
                 [styles.iconContainerHasIcon]: hasIcon,
                 [styles.iconContainerActive]: isPrimary,
-                [styles.iconContainerClickable]: onIconClick !== NOOP
+                [styles.iconContainerClickable]: onIconClick !== NOOP || clearOnIconClick
               })}
               onClick={onIconClickCallback}
               tabIndex={onIconClick !== NOOP && inputValue && iconName.length && isPrimary ? "0" : "-1"}
@@ -279,7 +279,8 @@ const TextField: VibeComponent<TextFieldProps, unknown> & {
             <Clickable
               className={cx(styles.iconContainer, {
                 [styles.iconContainerHasIcon]: hasIcon,
-                [styles.iconContainerActive]: isSecondary
+                [styles.iconContainerActive]: isSecondary,
+                [styles.iconContainerClickable]: onIconClick !== NOOP || clearOnIconClick
               })}
               onClick={onIconClickCallback}
               tabIndex={!shouldFocusOnSecondaryIcon ? "-1" : "0"}

--- a/src/components/TextField/__stories__/TextField.stories.mdx
+++ b/src/components/TextField/__stories__/TextField.stories.mdx
@@ -95,6 +95,7 @@ There are three sizes available: Small (32px), Medium (40px) and Large (48px).
       <div className="monday-storybook-text-field_column-wrapper monday-storybook-text-field_spacing">
         <TextField placeholder="Disabled" size={TextField.sizes.MEDIUM} disabled />
         <TextField placeholder="With icon" iconName={Email} size={TextField.sizes.MEDIUM} />
+        <TextField placeholder="With clickable icon" iconName={Email} onIconClick={() => {}} size={TextField.sizes.MEDIUM} />
       </div>
       <div className="monday-storybook-text-field_column-wrapper">
         <TextField placeholder="With field label" title="Name" size={TextField.sizes.MEDIUM} />


### PR DESCRIPTION
https://monday.monday.com/boards/3532714909/pulses/5466372603

Issue:
https://github.com/mondaycom/monday-ui-react-core/assets/25477901/e729fd60-ea96-4077-b99b-a004e793ade1


- Removed any hover/active interaction on `TextField` icon when `onIconClick` is not supplied
- Modfied the `:active` interaction style on `TextField onIconClick` to be unified with other button interaction (scale)