### PR TITLE
fix: <Dropdown> disabled option - fix keyboard focused style

### DIFF
--- a/src/components/Dropdown/Dropdown.styles.js
+++ b/src/components/Dropdown/Dropdown.styles.js
@@ -84,7 +84,10 @@ const getOptionStyle = (provided, { isDisabled, isSelected, isFocused }) => {
       ...general,
       backgroundColor: "transparent",
       color: getCSSVar("disabled-text-color"),
-      cursor: "not-allowed"
+      cursor: "not-allowed",
+      ...(isFocused && {
+        backgroundColor: getCSSVar("primary-background-hover-color")
+      })
     };
   }
   if (isSelected) {


### PR DESCRIPTION
https://monday.monday.com/boards/3532714909/pulses/5536525264

Applying keyboard focus style (background-color) to disabled options as well
![image](https://github.com/mondaycom/monday-ui-react-core/assets/104433616/65140b7c-3ff9-4507-8b0f-b700442b7908)

Following this request from ask-vibe - https://monday.slack.com/archives/C02S6F817JQ/p1700392102790859