### PR TITLE
fix: typography vertical overflow tolerance

### DIFF
--- a/src/components/Heading/Heading.tsx
+++ b/src/components/Heading/Heading.tsx
@@ -10,6 +10,7 @@ import { getStyle } from "../../helpers/typesciptCssModulesHelper";
 import styles from "./Heading.module.scss";
 import { TypographyContext } from "../Typography/utils/TypographyContext";
 
+const OVERFLOW_TOLERANCE_IN_PX = 4;
 export interface HeadingProps extends TypographyProps {
   type?: HeadingType;
   weight?: HeadingWeight;
@@ -25,7 +26,7 @@ const Heading: VibeComponent<HeadingProps, HTMLElement> & {
   align?: typeof TypographyAlign;
 } = forwardRef(({ className, type = HeadingType.H1, weight = HeadingWeight.NORMAL, ...typographyProps }, ref) => {
   return (
-    <TypographyContext.Provider value={{ overflowTolerance: 4 }}>
+    <TypographyContext.Provider value={{ overflowTolerance: OVERFLOW_TOLERANCE_IN_PX }}>
       <Typography
         element={type}
         ref={ref}

--- a/src/components/Heading/Heading.tsx
+++ b/src/components/Heading/Heading.tsx
@@ -25,7 +25,7 @@ const Heading: VibeComponent<HeadingProps, HTMLElement> & {
   align?: typeof TypographyAlign;
 } = forwardRef(({ className, type = HeadingType.H1, weight = HeadingWeight.NORMAL, ...typographyProps }, ref) => {
   return (
-    <TypographyContext.Provider value={{ ignoreHeightOverflow: true }}>
+    <TypographyContext.Provider value={{ overflowTolerance: 4 }}>
       <Typography
         element={type}
         ref={ref}

--- a/src/components/Heading/__stories__/Heading.stories.mdx
+++ b/src/components/Heading/__stories__/Heading.stories.mdx
@@ -180,12 +180,9 @@ We support two kinds of ellipsis: single-line ellipsis with a tooltip displayed 
       align={Flex.align.STRETCH}
       style={{ width: "480px" }}
     >
-      <Heading type={Heading.types.H2} ellipsis={false}>
-        Heading without overflow
-      </Heading>
+      <Heading type={Heading.types.H2}>Heading without overflow</Heading>
       <Heading
         type={Heading.types.H2}
-        ellipsis
         /**for testing purposes**/
         data-testid={ONE_LINE_ELLIPSIS_TEST_ID}
         tooltipProps={{
@@ -195,10 +192,9 @@ We support two kinds of ellipsis: single-line ellipsis with a tooltip displayed 
         Heading with ellipsis and tooltip when hovering
       </Heading>
       <div>
-        <Heading type={Heading.types.H2} ellipsis withoutTooltip maxLines={2}>
-          Heading with two lines overflow heading without tooltip heading with two lines overflow heading without
-          tooltip heading with two lines overflow heading without tooltip heading with two lines overflow heading
-          without tooltip
+        <Heading type={Heading.types.H2} maxLines={2}>
+          Heading with two lines overflow and a tooltip. Heading with two lines overflow and a tooltip. Heading with two
+          lines overflow and a tooltip.
         </Heading>
       </div>
     </Flex>

--- a/src/components/Text/Text.tsx
+++ b/src/components/Text/Text.tsx
@@ -6,7 +6,6 @@ import VibeComponent from "../../types/VibeComponent";
 import { TextType, TextWeight } from "./TextConstants";
 import Typography, { TypographyProps } from "../Typography/Typography";
 import { TypographyAlign, TypographyColor } from "../Typography/TypographyConstants";
-import { TypographyContext } from "../Typography/utils/TypographyContext";
 import { withStaticProps } from "../../types";
 import styles from "./Text.module.scss";
 
@@ -36,17 +35,15 @@ const Text: VibeComponent<TextProps, HTMLElement> & {
   ) => {
     const overrideEllipsis = ellipsis ?? element !== "p";
     return (
-      <TypographyContext.Provider value={{ ignoreHeightOverflow: false }}>
-        <Typography
-          ref={ref}
-          className={cx(styles.text, getStyle(styles, camelCase(type + "-" + weight)), className)}
-          ellipsis={overrideEllipsis}
-          element={element}
-          {...typographyProps}
-        >
-          {children}
-        </Typography>
-      </TypographyContext.Provider>
+      <Typography
+        ref={ref}
+        className={cx(styles.text, getStyle(styles, camelCase(type + "-" + weight)), className)}
+        ellipsis={overrideEllipsis}
+        element={element}
+        {...typographyProps}
+      >
+        {children}
+      </Typography>
     );
   }
 );

--- a/src/components/Text/__stories__/Text.stories.mdx
+++ b/src/components/Text/__stories__/Text.stories.mdx
@@ -164,7 +164,6 @@ We support two kinds of ellipsis: single-line ellipsis with a tooltip displayed 
       style={{ width: "480px" }}
     >
       <Text
-        ellipsis
         data-testid={ONE_LINE_ELLIPSIS_TEST_ID}
         /**for testing purposes**/
         tooltipProps={{
@@ -174,7 +173,7 @@ We support two kinds of ellipsis: single-line ellipsis with a tooltip displayed 
         This is an example of text with overflow and a Tooltip to help or provide information about specific components
         when a user hovers over them.
       </Text>
-      <Text ellipsis maxLines={2}>
+      <Text maxLines={2}>
         This is an example of text with ellipsis which displayed after two full lines of content this is an example of
         text with ellipsis which displayed after two full lines of content
       </Text>

--- a/src/components/Typography/Typography.tsx
+++ b/src/components/Typography/Typography.tsx
@@ -60,9 +60,10 @@ const Typography: VibeComponent<TypographyProps, HTMLElement> = forwardRef(
     },
     ref
   ) => {
-    const { ignoreHeightOverflow } = useContext(TypographyContext);
+    const { overflowTolerance } = useContext(TypographyContext);
     const componentRef = useRef(null);
     const mergedRef = useMergeRefs({ refs: [ref, componentRef] });
+    const ignoreHeightOverflow = maxLines === 1;
     const { ref: overrideRef, class: ellipsisClass } = useEllipsisClass(mergedRef, ellipsis, maxLines);
     const overrideTooltipProps = useTooltipProps(
       componentRef,
@@ -70,7 +71,8 @@ const Typography: VibeComponent<TypographyProps, HTMLElement> = forwardRef(
       ellipsis,
       tooltipProps,
       children,
-      ignoreHeightOverflow
+      ignoreHeightOverflow,
+      overflowTolerance
     ) as TooltipProps;
 
     return (

--- a/src/components/Typography/TypographyHooks.tsx
+++ b/src/components/Typography/TypographyHooks.tsx
@@ -25,9 +25,14 @@ export function useTooltipProps(
   ellipsis: boolean,
   tooltipProps: TooltipProps,
   children: ElementContent,
-  ignoreHeightOverflow: boolean
+  ignoreHeightOverflow: boolean,
+  overflowTolerance: number
 ) {
-  const isOverflowing = useIsOverflowing({ ref: ellipsis ? ref : null, ignoreHeightOverflow });
+  const isOverflowing = useIsOverflowing({
+    ref: ellipsis ? ref : null,
+    ignoreHeightOverflow,
+    tolerance: overflowTolerance
+  });
   const isTooltipRendered = !withoutTooltip && ellipsis && isOverflowing && typeof children === "string";
   return isTooltipRendered ? { ...tooltipProps, content: children } : {};
 }

--- a/src/components/Typography/utils/TypographyContext.ts
+++ b/src/components/Typography/utils/TypographyContext.ts
@@ -1,7 +1,11 @@
 import React from "react";
 
 type TypographyContext = {
-  ignoreHeightOverflow: boolean;
+  /**
+   * Sets a tolerance for vertical overflow to avoid undeed detetction of overflow
+   * Useful for cases where line-height is set and it's smaller than the font's line-height
+   */
+  overflowTolerance: number;
 };
 
-export const TypographyContext = React.createContext<TypographyContext>({ ignoreHeightOverflow: false });
+export const TypographyContext = React.createContext<TypographyContext>({ overflowTolerance: 0 });

--- a/src/hooks/useIsOverflowing/useIsOverflowing.ts
+++ b/src/hooks/useIsOverflowing/useIsOverflowing.ts
@@ -22,14 +22,14 @@ export default function useIsOverflowing({
 }: {
   ref: RefObject<HTMLElement>;
   ignoreHeightOverflow?: boolean;
-  tolerance: number;
+  tolerance?: number;
 }) {
   const [isOverflowing, setIsOverflowing] = useState<boolean>(() =>
     checkOverflow(ref?.current, ignoreHeightOverflow, tolerance)
   );
   const callback = useCallback(() => {
-    setIsOverflowing(checkOverflow(ref?.current, ignoreHeightOverflow));
-  }, [ignoreHeightOverflow, ref]);
+    setIsOverflowing(checkOverflow(ref?.current, ignoreHeightOverflow, tolerance));
+  }, [ignoreHeightOverflow, ref, tolerance]);
 
   useResizeObserver({
     ref,

--- a/src/hooks/useIsOverflowing/useIsOverflowing.ts
+++ b/src/hooks/useIsOverflowing/useIsOverflowing.ts
@@ -2,26 +2,31 @@
 import { RefObject, useCallback, useState } from "react";
 import useResizeObserver from "../useResizeObserver";
 
-function checkOverflow(element: HTMLElement, ignoreHeightOverflow: boolean) {
+function checkOverflow(element: HTMLElement, ignoreHeightOverflow: boolean, tolerance = 0) {
   if (!element) {
     return false;
   }
   const curOverflow = element.style.overflow;
   if (!curOverflow || curOverflow === "visible") element.style.overflow = "hidden";
   const isOverflowing =
-    element.clientWidth < element.scrollWidth || (!ignoreHeightOverflow && element.clientHeight < element.scrollHeight);
+    element.clientWidth < element.scrollWidth ||
+    (!ignoreHeightOverflow && element.clientHeight + tolerance < element.scrollHeight);
   element.style.overflow = curOverflow;
   return isOverflowing;
 }
 
 export default function useIsOverflowing({
   ref,
-  ignoreHeightOverflow = false
+  ignoreHeightOverflow = false,
+  tolerance
 }: {
   ref: RefObject<HTMLElement>;
   ignoreHeightOverflow?: boolean;
+  tolerance: number;
 }) {
-  const [isOverflowing, setIsOverflowing] = useState<boolean>(() => checkOverflow(ref?.current, ignoreHeightOverflow));
+  const [isOverflowing, setIsOverflowing] = useState<boolean>(() =>
+    checkOverflow(ref?.current, ignoreHeightOverflow, tolerance)
+  );
   const callback = useCallback(() => {
     setIsOverflowing(checkOverflow(ref?.current, ignoreHeightOverflow));
   }, [ignoreHeightOverflow, ref]);


### PR DESCRIPTION
Since we set a line-height which is smaller than the font's normal line-height in the `Heading` component, whenever we check for vertical overflow - it returns true even if it doesn't seem to be overflowing. There's a 2-3px gap.
To avoid it, and instead of setting `line-height: normal` on `Heading`, we:
1. Ignore vertical overflow when it's unneeded, when `maxLines` is 1 (default).
2. Set a tolerance value to "close the gap" as described above. 4px is enough for this case. 

Also we no longer need to pass `ignoreHeightOverflow` prop to the context, I use it for the tolerance now instead.

This is kinda 🤮 but that's the best we can do.

https://monday.monday.com/boards/3532714909/pulses/5413034707