### PR TITLE
fix: <Dropdown> Control - use --primary-color on focus-within instead of default color from react-select

### DIFF
--- a/src/components/Dropdown/Dropdown.styles.js
+++ b/src/components/Dropdown/Dropdown.styles.js
@@ -150,6 +150,9 @@ const control =
       minHeight: "30px",
       border: "0 solid transparent",
       borderRadius: getCSSVar("border-radius-small"),
+      ":focus-within": {
+        boxShadow: `0 0 0 1px ${getCSSVar("primary-color")}`
+      },
       ...(!isDisabled && {
         ":hover": {
           borderColor: "transparent",


### PR DESCRIPTION
https://monday.monday.com/boards/3532714909/pulses/5570522551

Resolves https://github.com/mondaycom/monday-ui-react-core/issues/1767