### PR TITLE
style(Tooltip): Explicitly expose zIndex prop in component

### DIFF
--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -111,6 +111,10 @@ interface TooltipBaseProps extends VibeComponentProps {
    * set the state of the tooltip - open/close - controlled component
    */
   open?: boolean;
+  /**
+   * Classname to be added to the content container
+   */
+  wrapperClassName?: string;
 }
 // When last tooltip was shown in the last 1.5 second - the next tooltip will be shown immediately
 const IMMEDIATE_SHOW_THRESHOLD_MS = 1500;
@@ -149,7 +153,8 @@ export default class Tooltip extends PureComponent<TooltipProps> {
     showOnDialogEnter: false,
     referenceWrapperClassName: "",
     addKeyboardHideShowTriggersByDefault: false,
-    open: false
+    open: false,
+    wrapperClassName: ""
   };
   constructor(props: TooltipProps) {
     super(props);
@@ -243,7 +248,6 @@ export default class Tooltip extends PureComponent<TooltipProps> {
   render() {
     const {
       withoutDialog,
-      moveBy,
       justify,
       children,
       forceRenderWithoutChildren,
@@ -251,11 +255,6 @@ export default class Tooltip extends PureComponent<TooltipProps> {
       theme,
       paddingSize,
       tip,
-      showTrigger,
-      hideTrigger,
-      showOnDialogEnter,
-      addKeyboardHideShowTriggersByDefault,
-      open,
       arrowClassName,
       id,
       "data-testid": dataTestId
@@ -273,12 +272,10 @@ export default class Tooltip extends PureComponent<TooltipProps> {
     const dialogProps = {
       ...this.props,
       "data-testid": dataTestId || getTestId(ComponentDefaultTestId.TOOLTIP, id),
-      open,
       startingEdge: justify,
       tooltip: tip,
       content,
       getContainer: getContainer || this.getContainer,
-      moveBy,
       tooltipClassName: cx(
         styles.arrow,
         getStyle(styles, theme),
@@ -289,10 +286,6 @@ export default class Tooltip extends PureComponent<TooltipProps> {
       onDialogDidHide: this.onTooltipHide,
       onDialogDidShow: this.onTooltipShow,
       getDynamicShowDelay: this.getShowDelay,
-      showTrigger,
-      hideTrigger,
-      showOnDialogEnter,
-      addKeyboardHideShowTriggersByDefault
     };
     return <Dialog {...dialogProps}>{children}</Dialog>;
   }

--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -112,9 +112,9 @@ interface TooltipBaseProps extends VibeComponentProps {
    */
   open?: boolean;
   /**
-   * Classname to be added to the content container
+   * Overwrites z-index of the tooltip
    */
-  wrapperClassName?: string;
+  zIndex?: number;
 }
 // When last tooltip was shown in the last 1.5 second - the next tooltip will be shown immediately
 const IMMEDIATE_SHOW_THRESHOLD_MS = 1500;
@@ -153,8 +153,7 @@ export default class Tooltip extends PureComponent<TooltipProps> {
     showOnDialogEnter: false,
     referenceWrapperClassName: "",
     addKeyboardHideShowTriggersByDefault: false,
-    open: false,
-    wrapperClassName: ""
+    open: false
   };
   constructor(props: TooltipProps) {
     super(props);
@@ -285,7 +284,7 @@ export default class Tooltip extends PureComponent<TooltipProps> {
       animationType: AnimationType.EXPAND,
       onDialogDidHide: this.onTooltipHide,
       onDialogDidShow: this.onTooltipShow,
-      getDynamicShowDelay: this.getShowDelay,
+      getDynamicShowDelay: this.getShowDelay
     };
     return <Dialog {...dialogProps}>{children}</Dialog>;
   }


### PR DESCRIPTION
- `zIndex` added to Tooltip to expose this property from Dialog component
- functionally nothing changes, but usage of that parameter from typescript code no longer require ignoring type checking

https://monday.monday.com/boards/3938308886/pulses/5599287179