### PR TITLE
feat: add a Finish button to Steps

### DIFF
--- a/src/components/Steps/Steps.tsx
+++ b/src/components/Steps/Steps.tsx
@@ -27,7 +27,7 @@ export interface StepsProps extends VibeComponentProps {
   backButtonProps?: ButtonProps;
   nextButtonProps?: ButtonProps;
   finishButtonProps?: ButtonProps;
-  onFinish?: (e: React.MouseEvent) => void;
+  onFinish?: (e: React.MouseEvent | React.KeyboardEvent) => void;
 }
 
 const Steps: VibeComponent<StepsProps> & { types?: typeof StepsType } = forwardRef(

--- a/src/components/Steps/Steps.tsx
+++ b/src/components/Steps/Steps.tsx
@@ -26,6 +26,8 @@ export interface StepsProps extends VibeComponentProps {
   areButtonsIconsHidden?: boolean;
   backButtonProps?: ButtonProps;
   nextButtonProps?: ButtonProps;
+  finishButtonProps?: ButtonProps;
+  onFinish?: (e: React.MouseEvent) => void;
 }
 
 const Steps: VibeComponent<StepsProps> & { types?: typeof StepsType } = forwardRef(
@@ -38,11 +40,13 @@ const Steps: VibeComponent<StepsProps> & { types?: typeof StepsType } = forwardR
       activeStepIndex = 0,
       type = StepsType.GALLERY,
       onChangeActiveStep = NOOP,
+      onFinish,
       isOnPrimary = false,
       areNavigationButtonsHidden = false,
       isContentOnTop = false,
       backButtonProps = {},
       nextButtonProps = {},
+      finishButtonProps = {},
       areButtonsIconsHidden = false
     },
     ref
@@ -66,7 +70,9 @@ const Steps: VibeComponent<StepsProps> & { types?: typeof StepsType } = forwardR
           isOnPrimary={isOnPrimary}
           backButtonProps={backButtonProps}
           nextButtonProps={nextButtonProps}
+          finishButtonProps={finishButtonProps}
           areButtonsIconsHidden={areButtonsIconsHidden}
+          onFinish={onFinish}
           className={cx({
             [styles.contentOnTop]: isContentOnTop,
             [styles.contentOnBottom]: !isContentOnTop

--- a/src/components/Steps/StepsCommand.module.scss
+++ b/src/components/Steps/StepsCommand.module.scss
@@ -1,24 +1,10 @@
 .command {
   display: flex;
   align-items: center;
-}
+  gap: 12px;
 
-.backward {
-  &.command {
-    margin-right: var(--spacing-small);
+  &.backward {
     flex-direction: row-reverse;
-  }
-  &.icon {
-    margin-right: 12px;
-  }
-}
-
-.forward {
-  &.command {
-    margin-left: var(--spacing-small);
-  }
-  &.icon {
-    margin-left: 12px;
   }
 }
 

--- a/src/components/Steps/StepsCommand.tsx
+++ b/src/components/Steps/StepsCommand.tsx
@@ -5,7 +5,7 @@ import NavigationChevronLeft from "../../components/Icon/Icons/components/Naviga
 import Icon from "../../components/Icon/Icon";
 import Button, { ButtonProps } from "../../components/Button/Button";
 import { NOOP } from "../../utils/function-utils";
-import { BACK_DESCRIPTION, NEXT_DESCRIPTION } from "./StepsConstants";
+import { BACK_TEXT, NEXT_TEXT } from "./StepsConstants";
 import VibeComponentProps from "../../types/VibeComponentProps";
 import { ComponentDefaultTestId } from "../../tests/constants";
 import styles from "./StepsCommand.module.scss";
@@ -32,7 +32,7 @@ export const StepsCommand: FC<StepsCommandProps> = ({
   const { children: buttonChildren, ...otherButtonProps } = buttonProps;
   const description = useMemo(() => {
     if (buttonChildren) return buttonChildren;
-    return isNext ? NEXT_DESCRIPTION : BACK_DESCRIPTION;
+    return isNext ? NEXT_TEXT : BACK_TEXT;
   }, [isNext, buttonChildren]);
   const buttonBaseColor = isOnPrimary ? Button.colors.ON_PRIMARY_COLOR : undefined;
   const newStepIndex = isNext ? activeStepIndex + 1 : activeStepIndex - 1;
@@ -45,7 +45,7 @@ export const StepsCommand: FC<StepsCommandProps> = ({
   const icon = isNext ? NavigationChevronRight : NavigationChevronLeft;
   return (
     <Button
-      className={cx(styles.command, { [styles.forward]: isNext, [styles.backward]: !isNext })}
+      className={cx(styles.command, { [styles.backward]: !isNext })}
       data-testid={
         isNext ? ComponentDefaultTestId.STEPS_FORWARD_COMMAND : ComponentDefaultTestId.STEPS_BACKWARD_COMMAND
       }
@@ -62,9 +62,7 @@ export const StepsCommand: FC<StepsCommandProps> = ({
           clickable={false}
           className={cx(styles.icon, {
             [styles.disabled]: isDisabled,
-            [styles.onPrimary]: isOnPrimary,
-            [styles.forward]: isNext,
-            [styles.backward]: !isNext
+            [styles.onPrimary]: isOnPrimary
           })}
         />
       )}

--- a/src/components/Steps/StepsConstants.ts
+++ b/src/components/Steps/StepsConstants.ts
@@ -1,5 +1,6 @@
-export const NEXT_DESCRIPTION = "Next";
-export const BACK_DESCRIPTION = "Back";
+export const NEXT_TEXT = "Next";
+export const BACK_TEXT = "Back";
+export const FINISH_TEXT = "Finish";
 
 export enum StepsType {
   NUMBERS = "numbers",

--- a/src/components/Steps/StepsHeader.module.scss
+++ b/src/components/Steps/StepsHeader.module.scss
@@ -2,4 +2,5 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
+  gap: var(--spacing-small);
 }

--- a/src/components/Steps/StepsHeader.tsx
+++ b/src/components/Steps/StepsHeader.tsx
@@ -39,6 +39,7 @@ export const StepsHeader: FC<StepsHeaderProps> = ({
   const SubHeaderComponent: FC<StepsGalleryHeaderProps | StepsNumbersHeaderProps> =
     type === StepsType.GALLERY ? StepsGalleryHeader : StepsNumbersHeader;
 
+  // TODO: make finish button as default in next major
   const showFinishButton = useMemo(() => {
     if (!onFinish) {
       return;

--- a/src/components/Steps/StepsHeader.tsx
+++ b/src/components/Steps/StepsHeader.tsx
@@ -1,11 +1,11 @@
-import React, { FC } from "react";
+import React, { FC, useMemo } from "react";
 import cx from "classnames";
 import { StepsCommand } from "./StepsCommand";
 import { StepsGalleryHeader, StepsGalleryHeaderProps } from "./StepsGalleryHeader";
 import { StepsNumbersHeader, StepsNumbersHeaderProps } from "./StepsNumbersHeader";
-import { StepsType } from "./StepsConstants";
+import { StepsType, FINISH_TEXT } from "./StepsConstants";
 import VibeComponentProps from "../../types/VibeComponentProps";
-import { ButtonProps } from "../Button/Button";
+import Button, { ButtonProps } from "../Button/Button";
 import styles from "./StepsHeader.module.scss";
 
 export interface StepsHeaderProps extends VibeComponentProps {
@@ -16,8 +16,10 @@ export interface StepsHeaderProps extends VibeComponentProps {
   areNavigationButtonsHidden: boolean;
   backButtonProps: ButtonProps;
   nextButtonProps: ButtonProps;
+  finishButtonProps: ButtonProps;
   areButtonsIconsHidden: boolean;
   isOnPrimary: boolean;
+  onFinish?: (e: React.MouseEvent) => void;
 }
 
 export const StepsHeader: FC<StepsHeaderProps> = ({
@@ -28,12 +30,21 @@ export const StepsHeader: FC<StepsHeaderProps> = ({
   areNavigationButtonsHidden,
   backButtonProps,
   nextButtonProps,
+  finishButtonProps,
   areButtonsIconsHidden,
   isOnPrimary,
+  onFinish,
   className
 }) => {
   const SubHeaderComponent: FC<StepsGalleryHeaderProps | StepsNumbersHeaderProps> =
     type === StepsType.GALLERY ? StepsGalleryHeader : StepsNumbersHeader;
+
+  const showFinishButton = useMemo(() => {
+    if (!onFinish) {
+      return;
+    }
+    return activeStepIndex === stepsCount - 1;
+  }, [activeStepIndex, onFinish, stepsCount]);
 
   return (
     <div className={cx(styles.header, className)}>
@@ -55,15 +66,27 @@ export const StepsHeader: FC<StepsHeaderProps> = ({
         isOnPrimary={isOnPrimary}
       />
       {areNavigationButtonsHidden ? null : (
-        <StepsCommand
-          isNext
-          isIconHidden={areButtonsIconsHidden}
-          activeStepIndex={activeStepIndex}
-          onChangeActiveStep={onChangeActiveStep}
-          stepsCount={stepsCount}
-          buttonProps={nextButtonProps}
-          isOnPrimary={isOnPrimary}
-        />
+        <>
+          {showFinishButton ? (
+            <Button
+              onClick={onFinish}
+              color={isOnPrimary ? Button.colors.ON_PRIMARY_COLOR : undefined}
+              {...finishButtonProps}
+            >
+              {finishButtonProps?.children || FINISH_TEXT}
+            </Button>
+          ) : (
+            <StepsCommand
+              isNext
+              isIconHidden={areButtonsIconsHidden}
+              activeStepIndex={activeStepIndex}
+              onChangeActiveStep={onChangeActiveStep}
+              stepsCount={stepsCount}
+              buttonProps={nextButtonProps}
+              isOnPrimary={isOnPrimary}
+            />
+          )}
+        </>
       )}
     </div>
   );

--- a/src/components/Steps/__stories__/steps.stories.helpers.js
+++ b/src/components/Steps/__stories__/steps.stories.helpers.js
@@ -42,6 +42,7 @@ export const StepsNumbersDoTemplate = () => {
       nextButtonProps={{
         onClick: stepNext
       }}
+      onFinish={() => {}}
     />
   );
 };
@@ -68,6 +69,7 @@ export const StepsGalleryDontTemplate = () => {
       nextButtonProps={{
         onClick: stepNext
       }}
+      onFinish={() => {}}
     />
   );
 };

--- a/src/components/Steps/__stories__/steps.stories.js
+++ b/src/components/Steps/__stories__/steps.stories.js
@@ -46,6 +46,7 @@ const NavigableStepsTemplate = args => {
       }}
       {...args}
       onChangeActiveStep={onChangeActiveStep}
+      onFinish={() => {}}
     />
   );
 };
@@ -118,6 +119,7 @@ export const NavigableSteps = {
           nextButtonProps={{
             onClick: stepNext
           }}
+          onFinish={() => {}}
         />
       </div>
     );
@@ -171,6 +173,7 @@ export const StepsInsideATipseen = {
                 size: Button.sizes.SMALL,
                 onClick: stepNext
               }}
+              onFinish={() => {}}
             />
           }
         >

--- a/src/components/Steps/__tests__/__snapshots__/steps-snapshot-tests.jest.js.snap
+++ b/src/components/Steps/__tests__/__snapshots__/steps-snapshot-tests.jest.js.snap
@@ -44,7 +44,7 @@ exports[`Steps with gallery type renders correctly when hide navigations icons 1
     <button
       aria-busy={false}
       aria-disabled={true}
-      className="command forward button sizeMedium kindTertiary colorPrimary disabled"
+      className="command button sizeMedium kindTertiary colorPrimary disabled"
       data-testid="steps-forward-command"
       onBlur={[Function]}
       onClick={[Function]}
@@ -122,7 +122,7 @@ exports[`Steps with gallery type renders correctly when steps content is on top 
       Back
       <svg
         aria-hidden={true}
-        className="icon icon backward"
+        className="icon icon"
         data-testid="icon"
         fill="currentColor"
         height="16"
@@ -160,7 +160,7 @@ exports[`Steps with gallery type renders correctly when steps content is on top 
     <button
       aria-busy={false}
       aria-disabled={true}
-      className="command forward button sizeMedium kindTertiary colorPrimary disabled"
+      className="command button sizeMedium kindTertiary colorPrimary disabled"
       data-testid="steps-forward-command"
       onBlur={[Function]}
       onClick={[Function]}
@@ -172,7 +172,7 @@ exports[`Steps with gallery type renders correctly when steps content is on top 
       Next
       <svg
         aria-hidden={true}
-        className="icon icon disabled forward"
+        className="icon icon disabled"
         data-testid="icon"
         fill="currentColor"
         height="16"
@@ -215,7 +215,7 @@ exports[`Steps with gallery type renders correctly when viewing first step 1`] =
       Back
       <svg
         aria-hidden={true}
-        className="icon icon disabled backward"
+        className="icon icon disabled"
         data-testid="icon"
         fill="currentColor"
         height="16"
@@ -253,7 +253,7 @@ exports[`Steps with gallery type renders correctly when viewing first step 1`] =
     <button
       aria-busy={false}
       aria-disabled={false}
-      className="command forward button sizeMedium kindTertiary colorPrimary"
+      className="command button sizeMedium kindTertiary colorPrimary"
       data-testid="steps-forward-command"
       onBlur={[Function]}
       onClick={[Function]}
@@ -265,7 +265,7 @@ exports[`Steps with gallery type renders correctly when viewing first step 1`] =
       Next
       <svg
         aria-hidden={true}
-        className="icon icon forward"
+        className="icon icon"
         data-testid="icon"
         fill="currentColor"
         height="16"
@@ -311,7 +311,7 @@ exports[`Steps with gallery type renders correctly when viewing last step 1`] = 
       Back
       <svg
         aria-hidden={true}
-        className="icon icon backward"
+        className="icon icon"
         data-testid="icon"
         fill="currentColor"
         height="16"
@@ -349,7 +349,7 @@ exports[`Steps with gallery type renders correctly when viewing last step 1`] = 
     <button
       aria-busy={false}
       aria-disabled={true}
-      className="command forward button sizeMedium kindTertiary colorPrimary disabled"
+      className="command button sizeMedium kindTertiary colorPrimary disabled"
       data-testid="steps-forward-command"
       onBlur={[Function]}
       onClick={[Function]}
@@ -361,7 +361,7 @@ exports[`Steps with gallery type renders correctly when viewing last step 1`] = 
       Next
       <svg
         aria-hidden={true}
-        className="icon icon disabled forward"
+        className="icon icon disabled"
         data-testid="icon"
         fill="currentColor"
         height="16"
@@ -407,7 +407,7 @@ exports[`Steps with gallery type renders correctly with regular props 1`] = `
       Back
       <svg
         aria-hidden={true}
-        className="icon icon disabled backward"
+        className="icon icon disabled"
         data-testid="icon"
         fill="currentColor"
         height="16"
@@ -445,7 +445,7 @@ exports[`Steps with gallery type renders correctly with regular props 1`] = `
     <button
       aria-busy={false}
       aria-disabled={false}
-      className="command forward button sizeMedium kindTertiary colorPrimary"
+      className="command button sizeMedium kindTertiary colorPrimary"
       data-testid="steps-forward-command"
       onBlur={[Function]}
       onClick={[Function]}
@@ -457,7 +457,7 @@ exports[`Steps with gallery type renders correctly with regular props 1`] = `
       Next
       <svg
         aria-hidden={true}
-        className="icon icon forward"
+        className="icon icon"
         data-testid="icon"
         fill="currentColor"
         height="16"
@@ -511,7 +511,7 @@ exports[`Steps with numeric type renders correctly when hide navigations icons 1
     <button
       aria-busy={false}
       aria-disabled={true}
-      className="command forward button sizeMedium kindTertiary colorPrimary disabled"
+      className="command button sizeMedium kindTertiary colorPrimary disabled"
       data-testid="steps-forward-command"
       onBlur={[Function]}
       onClick={[Function]}
@@ -555,7 +555,7 @@ exports[`Steps with numeric type renders correctly when steps content is on top 
       Back
       <svg
         aria-hidden={true}
-        className="icon icon backward"
+        className="icon icon"
         data-testid="icon"
         fill="currentColor"
         height="16"
@@ -580,7 +580,7 @@ exports[`Steps with numeric type renders correctly when steps content is on top 
     <button
       aria-busy={false}
       aria-disabled={true}
-      className="command forward button sizeMedium kindTertiary colorPrimary disabled"
+      className="command button sizeMedium kindTertiary colorPrimary disabled"
       data-testid="steps-forward-command"
       onBlur={[Function]}
       onClick={[Function]}
@@ -592,7 +592,7 @@ exports[`Steps with numeric type renders correctly when steps content is on top 
       Next
       <svg
         aria-hidden={true}
-        className="icon icon disabled forward"
+        className="icon icon disabled"
         data-testid="icon"
         fill="currentColor"
         height="16"
@@ -635,7 +635,7 @@ exports[`Steps with numeric type renders correctly when viewing first step 1`] =
       Back
       <svg
         aria-hidden={true}
-        className="icon icon disabled backward"
+        className="icon icon disabled"
         data-testid="icon"
         fill="currentColor"
         height="16"
@@ -660,7 +660,7 @@ exports[`Steps with numeric type renders correctly when viewing first step 1`] =
     <button
       aria-busy={false}
       aria-disabled={false}
-      className="command forward button sizeMedium kindTertiary colorPrimary"
+      className="command button sizeMedium kindTertiary colorPrimary"
       data-testid="steps-forward-command"
       onBlur={[Function]}
       onClick={[Function]}
@@ -672,7 +672,7 @@ exports[`Steps with numeric type renders correctly when viewing first step 1`] =
       Next
       <svg
         aria-hidden={true}
-        className="icon icon forward"
+        className="icon icon"
         data-testid="icon"
         fill="currentColor"
         height="16"
@@ -718,7 +718,7 @@ exports[`Steps with numeric type renders correctly when viewing last step 1`] = 
       Back
       <svg
         aria-hidden={true}
-        className="icon icon backward"
+        className="icon icon"
         data-testid="icon"
         fill="currentColor"
         height="16"
@@ -743,7 +743,7 @@ exports[`Steps with numeric type renders correctly when viewing last step 1`] = 
     <button
       aria-busy={false}
       aria-disabled={true}
-      className="command forward button sizeMedium kindTertiary colorPrimary disabled"
+      className="command button sizeMedium kindTertiary colorPrimary disabled"
       data-testid="steps-forward-command"
       onBlur={[Function]}
       onClick={[Function]}
@@ -755,7 +755,7 @@ exports[`Steps with numeric type renders correctly when viewing last step 1`] = 
       Next
       <svg
         aria-hidden={true}
-        className="icon icon disabled forward"
+        className="icon icon disabled"
         data-testid="icon"
         fill="currentColor"
         height="16"
@@ -801,7 +801,7 @@ exports[`Steps with numeric type renders correctly with regular props 1`] = `
       Back
       <svg
         aria-hidden={true}
-        className="icon icon disabled backward"
+        className="icon icon disabled"
         data-testid="icon"
         fill="currentColor"
         height="16"
@@ -826,7 +826,7 @@ exports[`Steps with numeric type renders correctly with regular props 1`] = `
     <button
       aria-busy={false}
       aria-disabled={false}
-      className="command forward button sizeMedium kindTertiary colorPrimary"
+      className="command button sizeMedium kindTertiary colorPrimary"
       data-testid="steps-forward-command"
       onBlur={[Function]}
       onClick={[Function]}
@@ -838,7 +838,7 @@ exports[`Steps with numeric type renders correctly with regular props 1`] = `
       Next
       <svg
         aria-hidden={true}
-        className="icon icon forward"
+        className="icon icon"
         data-testid="icon"
         fill="currentColor"
         height="16"

--- a/src/components/Steps/__tests__/steps-tests.jest.js
+++ b/src/components/Steps/__tests__/steps-tests.jest.js
@@ -2,7 +2,7 @@ import React from "react";
 import { fireEvent, render } from "@testing-library/react";
 import { act } from "@testing-library/react-hooks";
 import Steps from "../Steps";
-import { NEXT_DESCRIPTION, BACK_DESCRIPTION } from "../StepsConstants";
+import { NEXT_TEXT, BACK_TEXT } from "../StepsConstants";
 
 jest.useFakeTimers();
 
@@ -25,7 +25,7 @@ describe("Steps tests", () => {
       onChangeActiveStep: onClickMock,
       activeStepIndex: stepsContent.length - 1
     });
-    const backwardButton = steps.getByText(BACK_DESCRIPTION);
+    const backwardButton = steps.getByText(BACK_TEXT);
 
     act(() => {
       fireEvent.click(backwardButton);
@@ -39,7 +39,7 @@ describe("Steps tests", () => {
       onChangeActiveStep: onClickMock,
       activeStepIndex: 0
     });
-    const forwardButton = steps.getByText(NEXT_DESCRIPTION);
+    const forwardButton = steps.getByText(NEXT_TEXT);
 
     act(() => {
       fireEvent.click(forwardButton);
@@ -54,7 +54,7 @@ describe("Steps tests", () => {
       onChangeActiveStep: onClickMock,
       activeStepIndex: 0
     });
-    const backwardButton = steps.getByText(BACK_DESCRIPTION);
+    const backwardButton = steps.getByText(BACK_TEXT);
 
     act(() => {
       fireEvent.click(backwardButton);
@@ -69,7 +69,7 @@ describe("Steps tests", () => {
       onChangeActiveStep: onClickMock,
       activeStepIndex: stepsContent.length - 1
     });
-    const forwardButton = steps.getByText(NEXT_DESCRIPTION);
+    const forwardButton = steps.getByText(NEXT_TEXT);
 
     act(() => {
       fireEvent.click(forwardButton);

--- a/src/components/Tipseen/TipseenWizard.tsx
+++ b/src/components/Tipseen/TipseenWizard.tsx
@@ -5,15 +5,18 @@ import Button from "../../components/Button/Button";
 import TipseenBasicContent from "./TipseenBasicContent";
 import styles from "./TipseenWizard.module.scss";
 
+const FINISH_TEXT = "Got it";
+
 interface TipseenWizardProps extends StepsProps {
   title?: string;
   /**
    * Classname for overriding TipseenTitle styles
    */
   titleClassName?: string;
+  onFinish?: (e: React.MouseEvent) => void;
 }
 
-const TipseenWizard: FC<TipseenWizardProps> = ({ id, title, titleClassName, className, ...stepsProps }) => {
+const TipseenWizard: FC<TipseenWizardProps> = ({ id, title, onFinish, titleClassName, className, ...stepsProps }) => {
   const overrideStepsProps = stepsProps as StepsProps;
   const nextButtonProps = useMemo(
     () => ({
@@ -25,6 +28,14 @@ const TipseenWizard: FC<TipseenWizardProps> = ({ id, title, titleClassName, clas
   const backButtonProps = useMemo(
     () => ({
       size: Button.sizes.SMALL
+    }),
+    []
+  );
+  const finishButtonProps = useMemo(
+    () => ({
+      kind: Button.kinds.PRIMARY,
+      size: Button.sizes.SMALL,
+      children: FINISH_TEXT
     }),
     []
   );
@@ -42,6 +53,8 @@ const TipseenWizard: FC<TipseenWizardProps> = ({ id, title, titleClassName, clas
         areButtonsIconsHidden
         backButtonProps={backButtonProps}
         nextButtonProps={nextButtonProps}
+        finishButtonProps={finishButtonProps}
+        onFinish={onFinish}
         {...overrideStepsProps}
       />
     </TipseenBasicContent>

--- a/src/components/Tipseen/TipseenWizard.tsx
+++ b/src/components/Tipseen/TipseenWizard.tsx
@@ -13,7 +13,7 @@ interface TipseenWizardProps extends StepsProps {
    * Classname for overriding TipseenTitle styles
    */
   titleClassName?: string;
-  onFinish?: (e: React.MouseEvent) => void;
+  onFinish?: (e: React.MouseEvent | React.KeyboardEvent) => void;
 }
 
 const TipseenWizard: FC<TipseenWizardProps> = ({ id, title, onFinish, titleClassName, className, ...stepsProps }) => {

--- a/src/components/Tipseen/__stories__/tipseen.mdx
+++ b/src/components/Tipseen/__stories__/tipseen.mdx
@@ -60,7 +60,7 @@ Tipseen is a virtual unboxing experience that helps users get started with the s
 
 ### Tipseen with a wizard
 
-Use when the tip is too long or when you want to teach something in steps.
+Use Tipseen with a wizard when you want to teach something in steps.
 
 <Canvas>
   <Story of={TipseenStories.TipseenWithAWizard} />

--- a/src/components/Tipseen/__stories__/tipseen.stories.js
+++ b/src/components/Tipseen/__stories__/tipseen.stories.js
@@ -110,6 +110,7 @@ export const TipseenWithAWizard = {
               steps={content}
               activeStepIndex={activeStepIndex}
               onChangeActiveStep={onChangeActiveStep}
+              onFinish={() => {}}
             />
           }
         >


### PR DESCRIPTION
- The button appears only for the last step, if `onFinish` prop is provided
- It's opt-in because adding it as default is breaking because the component is controlled, so adding a button that doesn't do anything is bad for UX
- Added TODO to make it the default in next major
https://monday.monday.com/boards/3532714909/pulses/5636406872