### PR TITLE
docs(README): fix npm link

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 Install the component library
 
 ```
-$ npm install monday-ui-react-core
+npm install monday-ui-react-core
 ```
 
 ## Usage


### PR DESCRIPTION
Remove special characters to allow the script to work when copied to the clipboard and paste it into the terminal.

