### PR TITLE
Split button alignment fix

### DIFF
--- a/src/components/Dialog/Dialog.tsx
+++ b/src/components/Dialog/Dialog.tsx
@@ -18,7 +18,7 @@ import { ComponentDefaultTestId, getTestId } from "../../tests/test-ids-utils";
 
 export interface DialogProps extends VibeComponentProps {
   /**
-   * A Classname to be added to <spam> element which wraps the children
+   * A Classname to be added to <span> element which wraps the children
    */
   referenceWrapperClassName?: string;
   /**

--- a/src/components/SplitButton/SplitButton.module.scss
+++ b/src/components/SplitButton/SplitButton.module.scss
@@ -1,6 +1,5 @@
 .button {
   display: inline-flex;
-  align-items: center;
   border-radius: var(--border-radius-small);
   transition: var(--motion-productive-short) transform,
     var(--motion-productive-medium) var(--motion-timing-transition) min-width;


### PR DESCRIPTION
The SplitButton is constructed of two elements: Button, and a Button that is wrapped as a Dialog, which actually make the component wrapper have two elements: Button, and a div (dialog+button). The Button has a line height but the div doesn't. The div inherits line-height (different than 1/normal) which makes the entire components break alignment.
The solution would be to remove `align-items: center` to align it normally without letting external line height to affect. In any way, no need to align it to the center anyway.

https://monday.monday.com/boards/3532714909/pulses/5718731997