### PR TITLE
chore(playground-addon): support next components and add an initial code example

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import * as VibeComponents from "../src/components/index";
+import * as VibeComponentsNext from "../src/next";
 import * as VibeIcons from "../src/components/Icon/Icons/index";
 import { Preview } from "@storybook/react";
 import isChromatic from "chromatic/isChromatic";
@@ -98,7 +99,7 @@ const preview: Preview = {
     },
     playground: {
       playgroundStoryId: "playground",
-      components: { ...VibeComponents, VibeIcons }
+      components: { ...VibeComponents, VibeIcons, VibeNext: VibeComponentsNext }
     }
   },
   decorators: [

--- a/src/next.ts
+++ b/src/next.ts
@@ -1,6 +1,5 @@
 export * from "./components/Heading/Heading";
 import Heading from "./components/Heading/Heading";
-
 export * from "./components/EditableHeading/EditableHeading";
 import EditableHeading from "./components/EditableHeading/EditableHeading";
 

--- a/src/next.ts
+++ b/src/next.ts
@@ -1,2 +1,7 @@
-export * as Heading from "./components/Heading/Heading";
-export * as EditableHeading from "./components/EditableHeading/EditableHeading";
+export * from "./components/Heading/Heading";
+import Heading from "./components/Heading/Heading";
+
+export * from "./components/EditableHeading/EditableHeading";
+import EditableHeading from "./components/EditableHeading/EditableHeading";
+
+export { Heading, EditableHeading };

--- a/src/storybook/stand-alone-documentaion/playground/Playground.stories.ts
+++ b/src/storybook/stand-alone-documentaion/playground/Playground.stories.ts
@@ -8,14 +8,20 @@ export default {
 export const Playground = {
   args: {
     code: {
-      jsx: `
-<div style={{display: 'flex', flexDirection: 'column', gap: '12px'}}>
+      jsx: `<div style={{ display: "flex", flexDirection: "column", gap: "12px" }}>
   <div>
     <VibeNext.Heading>Online Playground</VibeNext.Heading>
-    <VibeNext.Heading type="h3" color="secondary">Prototype with actual components.</VibeNext.Heading>
+    <VibeNext.Heading type="h3" color="secondary">
+      Prototype with actual components.
+    </VibeNext.Heading>
   </div>
-  <div>  
-    <Text>Can't see the code editor?<br/>Click on the <VibeIcons.Settings/> button on the left panel and select the <b>"Change Addons Orientation"</b> </Text>
+  <div>
+    <Text>
+      Can't see the code editor?
+      <br />
+      Click on the <VibeIcons.Settings /> button on the left panel and select
+      the <b>"Change Addons Orientation"</b>{" "}
+    </Text>
   </div>
   <div>
     <Button onClick={() => alert("isn't that nice?")}>Click me</Button>

--- a/src/storybook/stand-alone-documentaion/playground/Playground.stories.ts
+++ b/src/storybook/stand-alone-documentaion/playground/Playground.stories.ts
@@ -12,7 +12,7 @@ export const Playground = {
   <div>
     <VibeNext.Heading>Online Playground</VibeNext.Heading>
     <VibeNext.Heading type="h3" color="secondary">
-      Prototype with actual components.
+      Prototype with actual components
     </VibeNext.Heading>
   </div>
   <div>

--- a/src/storybook/stand-alone-documentaion/playground/Playground.stories.ts
+++ b/src/storybook/stand-alone-documentaion/playground/Playground.stories.ts
@@ -5,4 +5,22 @@ export default {
   decorators: [withPlaygroundRenderer]
 };
 
-export const Playground = {};
+export const Playground = {
+  args: {
+    code: {
+      jsx: `
+<div style={{display: 'flex', flexDirection: 'column', gap: '12px'}}>
+  <div>
+    <VibeNext.Heading>Online Playground</VibeNext.Heading>
+    <VibeNext.Heading type="h3" color="secondary">Prototype with actual components.</VibeNext.Heading>
+  </div>
+  <div>  
+    <Text>Can't see the code editor?<br/>Click on the <VibeIcons.Settings/> button on the left panel and select the <b>"Change Addons Orientation"</b> </Text>
+  </div>
+  <div>
+    <Button onClick={() => alert("isn't that nice?")}>Click me</Button>
+  </div>
+</div>`
+    }
+  }
+};

--- a/src/storybook/stand-alone-documentaion/playground/Playground.stories.ts
+++ b/src/storybook/stand-alone-documentaion/playground/Playground.stories.ts
@@ -8,7 +8,7 @@ export default {
 export const Playground = {
   args: {
     code: {
-      jsx: `<div style={{ display: "flex", flexDirection: "column", gap: "12px" }}>
+      jsx: `<div className="container">
   <div>
     <VibeNext.Heading>Online Playground</VibeNext.Heading>
     <VibeNext.Heading type="h3" color="secondary">
@@ -26,7 +26,12 @@ export const Playground = {
   <div>
     <Button onClick={() => alert("isn't that nice?")}>Click me</Button>
   </div>
-</div>`
+</div>`,
+      css: `.container {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}`
     }
   }
 };


### PR DESCRIPTION
I made some change in the `next` entry that could be risky, so please verify it

<img width="1511" alt="image" src="https://github.com/mondaycom/monday-ui-react-core/assets/6093192/2b6fc5f1-2093-4588-8a40-7a27aed1beab">
