### PR TITLE
feat: add warning color LinearProgressBar

### DIFF
--- a/src/components/ProgressBars/LinearProgressBar/Bar/Bar.module.scss
+++ b/src/components/ProgressBars/LinearProgressBar/Bar/Bar.module.scss
@@ -21,6 +21,10 @@
   background-color: var(--negative-color);
 }
 
+.typePrimaryWarning {
+  background-color: var(--warning-color);
+}
+
 .typeSecondaryPrimary {
   background-color: var(--primary-selected-color);
 }
@@ -35,6 +39,10 @@
 
 .typeSecondaryNegative {
   background-color: var(--negative-color-selected);
+}
+
+.typeSecondaryWarning {
+  background-color: var(--warning-color-selected);
 }
 
 .animate {

--- a/src/components/ProgressBars/LinearProgressBar/LinearProgressBarConstants.ts
+++ b/src/components/ProgressBars/LinearProgressBar/LinearProgressBarConstants.ts
@@ -8,5 +8,6 @@ export enum ProgressBarStyle {
   SECONDARY = "secondary",
   POSITIVE = "positive",
   NEGATIVE = "negative",
+  WARNING= "warning",
   NONE = "none"
 }

--- a/src/components/ProgressBars/LinearProgressBar/LinearProgressBarConstants.ts
+++ b/src/components/ProgressBars/LinearProgressBar/LinearProgressBarConstants.ts
@@ -8,6 +8,6 @@ export enum ProgressBarStyle {
   SECONDARY = "secondary",
   POSITIVE = "positive",
   NEGATIVE = "negative",
-  WARNING= "warning",
+  WARNING = "warning",
   NONE = "none"
 }


### PR DESCRIPTION
Added warning color + secondary to `LinearProgressBar`

<img width="1173" alt="image" src="https://github.com/mondaycom/monday-ui-react-core/assets/110092603/54fd2490-4c2d-4913-b0a9-be9c3e655867">


<!--

Please go over the checklist and make sure all conditions are met.

--->

#### Basic

- [x] Used plop (`npm run plop`) to create a new component.
- [x] PR has description.
- [x] New component is functional and uses Hooks.
- [x] Component is written in TypeScript.

#### Style

- [x] Styles are added to `NewComponent.modules.scss` file inside the `NewComponent` folder.
- [x] Component uses CSS Modules.
- [x] Design is compatible with [Monday Design System](https://design.monday.com/).
- [x] Styles are defined using [monday-ui-style](https://github.com/mondaycom/monday-ui-style) tokens
- [x] Displays correctly in all the themes

#### Storybook

- [x] Stories were added to `/src/components/NewComponent/__stories__/NewComponent.mdx` file.
- [x] Stories include all flows of using the component.
- [x] Stories implemented using [vibe-storybook-components](https://github.com/mondaycom/vibe-storybook-components) components and tokens.

#### Tests

- [x] Tests are compliant with [TESTING_README.md](TESTING_README.md) instructions.

#### Accessibility

- [x] Component is accessible.
- [x] Component is compatible with [Vibe Accessibility Guidelines](https://style.monday.com/?path=/docs/foundations-accessibility--docs)
