### PR TITLE
docs: remove unneeded callbacks

### DIFF
--- a/src/storybook/components/related-components/descriptions/tipseen-description.jsx
+++ b/src/storybook/components/related-components/descriptions/tipseen-description.jsx
@@ -6,14 +6,6 @@ import TipseenWizard from "../../../../components/Tipseen/TipseenWizard";
 export const TipseenDescription = () => {
   const [activeStepIndex, setActiveStepIndex] = useState(2);
 
-  const stepPrev = useCallback(() => {
-    setActiveStepIndex(prevState => prevState - 1);
-  }, []);
-
-  const stepNext = useCallback(() => {
-    setActiveStepIndex(prevState => prevState + 1);
-  }, []);
-
   const onChangeActiveStep = useCallback((_e, stepIndex) => {
     setActiveStepIndex(stepIndex);
   }, []);
@@ -57,9 +49,8 @@ export const TipseenDescription = () => {
               title="This is a title"
               steps={content}
               activeStepIndex={activeStepIndex}
-              backButtonProps={{ onClick: stepPrev }}
-              nextButtonProps={{ onClick: stepNext }}
               onChangeActiveStep={onChangeActiveStep}
+              onFinish={() => {}}
             />
           }
         >
@@ -67,7 +58,7 @@ export const TipseenDescription = () => {
         </Tipseen>
       </div>
     );
-  }, [activeStepIndex, stepPrev, stepNext, onChangeActiveStep]);
+  }, [activeStepIndex, onChangeActiveStep]);
   return (
     <RelatedComponent
       component={component}


### PR DESCRIPTION
https://monday.monday.com/boards/3532714909/pulses/5762803720

We have a bug that `backButtonProps` and `nextButtonProps` override the other buttons props, opened a backlog task, but anyway it's not needed because `onChangeActiveStep` can control the state alone