### PR TITLE
fix(TableVirtualizedBody): take height of header into consideration

### DIFF
--- a/src/components/Table/TableVirtualizedBody/TableVirtualizedBody.module.scss
+++ b/src/components/Table/TableVirtualizedBody/TableVirtualizedBody.module.scss
@@ -1,0 +1,3 @@
+.tableBody {
+  height: calc(100% - var(--table-row-size));
+}

--- a/src/components/Table/TableVirtualizedBody/TableVirtualizedBody.module.scss
+++ b/src/components/Table/TableVirtualizedBody/TableVirtualizedBody.module.scss
@@ -1,3 +1,4 @@
 .tableBody {
+  // Take into consideration header's height since VirtualizedBody sets a static height
   height: calc(100% - var(--table-row-size));
 }

--- a/src/components/Table/TableVirtualizedBody/TableVirtualizedBody.tsx
+++ b/src/components/Table/TableVirtualizedBody/TableVirtualizedBody.tsx
@@ -2,6 +2,7 @@ import React, { ComponentProps, CSSProperties, FC, useCallback } from "react";
 import { VibeComponentProps } from "../../../types";
 import VirtualizedList, { VirtualizedListItem } from "../../VirtualizedList/VirtualizedList";
 import TableBody from "../TableBody/TableBody";
+import styles from "./TableVirtualizedBody.module.scss";
 
 export interface ITableVirtualizedBodyProps extends VibeComponentProps {
   items: ComponentProps<typeof VirtualizedList>["items"];
@@ -18,7 +19,7 @@ const TableVirtualizedBody: FC<ITableVirtualizedBodyProps> = ({ items, rowRender
   );
 
   return (
-    <TableBody>
+    <TableBody className={styles.tableBody}>
       <VirtualizedList items={items} itemRenderer={itemRenderer} getItemHeight={() => 40} layout="vertical" />
     </TableBody>
   );


### PR DESCRIPTION
The Virtualized list doesn't take the Header into consideration in the height calculation so I've added it. Not sure it's the best solution, would love to hear thoughts.
https://monday.monday.com/boards/3532714909/pulses/5840033094
Before:
<img width="893" alt="Screenshot 2024-01-11 at 19 35 46" src="https://github.com/mondaycom/monday-ui-react-core/assets/18269880/e2ac46c4-e019-461b-97f4-56310e0f02a8">
After:
<img width="892" alt="Screenshot 2024-01-11 at 19 35 32" src="https://github.com/mondaycom/monday-ui-react-core/assets/18269880/4afa0062-8ef8-4988-8930-6314622e62e2">
