### PR TITLE
feat(IconButton): add ariaPressed a11y property

### DIFF
--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -64,6 +64,8 @@ export interface ButtonProps extends VibeComponentProps {
   ariaLabeledBy?: string;
   /** aria label to provide important when providing only Icon */
   ariaLabel?: string;
+  /** aria for if the button is pressed */
+  ariaPressed?: boolean;
   /** aria for a button popup */
   ariaHasPopup?: React.HTMLProps<HTMLButtonElement>["aria-haspopup"];
   /** aria to be set if the popup is open */
@@ -124,6 +126,7 @@ const Button: VibeComponent<ButtonProps, unknown> & {
       type,
       onMouseDown,
       ariaLabel,
+      ariaPressed,
       rightFlat,
       leftFlat,
       preventClickAnimation,
@@ -258,6 +261,7 @@ const Button: VibeComponent<ButtonProps, unknown> & {
         "aria-busy": loading,
         "aria-labelledby": ariaLabeledBy,
         "aria-label": ariaLabel,
+        "aria-pressed": ariaPressed,
         "aria-haspopup": ariaHasPopup,
         "aria-expanded": ariaExpanded,
         "aria-controls": ariaControls,
@@ -282,6 +286,7 @@ const Button: VibeComponent<ButtonProps, unknown> & {
       loading,
       ariaLabeledBy,
       ariaLabel,
+      ariaPressed,
       ariaHasPopup,
       ariaExpanded,
       ariaControls,
@@ -417,6 +422,7 @@ Button.defaultProps = {
   ariaControls: undefined,
   ariaLabel: undefined,
   ariaLabeledBy: undefined,
+  ariaPressed: undefined,
   insetFocus: false
 };
 

--- a/src/components/Button/__tests__/__snapshots__/button-snapshot-tests.jest.js.snap
+++ b/src/components/Button/__tests__/__snapshots__/button-snapshot-tests.jest.js.snap
@@ -9,6 +9,7 @@ exports[`Button renders correctly a11y renders correctly with a11y props (false)
   aria-haspopup={false}
   aria-label="text"
   aria-labelledby="id"
+  aria-pressed={false}
   className="button sizeMedium kindPrimary colorPrimary"
   data-testid="button"
   onBlur={[Function]}
@@ -31,6 +32,7 @@ exports[`Button renders correctly a11y renders correctly with a11y props (true) 
   aria-haspopup={true}
   aria-label="text"
   aria-labelledby="id"
+  aria-pressed={true}
   className="button sizeMedium kindPrimary colorPrimary"
   data-testid="button"
   onBlur={[Function]}

--- a/src/components/Button/__tests__/button-snapshot-tests.jest.js
+++ b/src/components/Button/__tests__/button-snapshot-tests.jest.js
@@ -78,7 +78,14 @@ describe("Button renders correctly", () => {
     it("renders correctly with a11y props (false)", () => {
       const tree = renderer
         .create(
-          <Button ariaLabel="text" ariaControls="area" ariaExpanded={false} ariaLabeledBy="id" ariaHasPopup={false}>
+          <Button
+            ariaLabel="text"
+            ariaControls="area"
+            ariaExpanded={false}
+            ariaLabeledBy="id"
+            ariaPressed={false}
+            ariaHasPopup={false}
+          >
             Button
           </Button>
         )
@@ -89,7 +96,14 @@ describe("Button renders correctly", () => {
     it("renders correctly with a11y props (true)", () => {
       const tree = renderer
         .create(
-          <Button ariaLabel="text" ariaControls="area" ariaExpanded={true} ariaLabeledBy="id" ariaHasPopup={true}>
+          <Button
+            ariaLabel="text"
+            ariaControls="area"
+            ariaExpanded={true}
+            ariaLabeledBy="id"
+            ariaPressed={true}
+            ariaHasPopup={true}
+          >
             Button
           </Button>
         )

--- a/src/components/IconButton/IconButton.tsx
+++ b/src/components/IconButton/IconButton.tsx
@@ -40,6 +40,10 @@ export interface IconButtonProps extends VibeComponentProps {
    */
   ariaLabel?: string;
   /**
+   * a11y property to be added, used for screen reader to know if a button is pressed
+   */
+  ariaPressed?: boolean;
+  /**
    * a11y property to be added, used for screen reader to know if the button is expanded
    */
   ariaExpanded?: boolean;
@@ -100,6 +104,7 @@ const IconButton: VibeComponent<IconButtonProps> & {
       tooltipProps = {} as TooltipProps,
       tooltipContent,
       ariaLabel,
+      ariaPressed,
       ariaExpanded,
       hideTooltip = false,
       kind = IconButton.kinds.TERTIARY,
@@ -182,6 +187,7 @@ const IconButton: VibeComponent<IconButtonProps> & {
             color={color}
             kind={kind}
             ariaLabel={buttonAriaLabel}
+            ariaPressed={ariaPressed}
             ariaExpanded={ariaExpanded}
             ref={mergedRef}
             id={id}

--- a/src/components/IconButton/__tests__/__snapshots__/iconButton-snapshot-tests.jest.tsx.snap
+++ b/src/components/IconButton/__tests__/__snapshots__/iconButton-snapshot-tests.jest.tsx.snap
@@ -138,6 +138,92 @@ exports[`IconButton renders correctly with aria label 1`] = `
 </span>
 `;
 
+exports[`IconButton renders correctly with aria pressed false 1`] = `
+<button
+  aria-busy={false}
+  aria-disabled={false}
+  aria-pressed={false}
+  className="button sizeMedium kindTertiary colorPrimary noSidePadding"
+  data-testid="icon-button"
+  onBlur={[Function]}
+  onClick={[Function]}
+  onFocus={[Function]}
+  onMouseDown={[Function]}
+  onMouseUp={[Function]}
+  style={
+    Object {
+      "alignItems": "center",
+      "height": "40px",
+      "justifyContent": "center",
+      "padding": 0,
+      "width": "40px",
+    }
+  }
+  type="button"
+>
+  <svg
+    aria-hidden={true}
+    className="icon noFocusStyle"
+    data-testid="icon"
+    fill="currentColor"
+    height="20"
+    onClick={[Function]}
+    viewBox="0 0 20 20"
+    width="20"
+  >
+    <path
+      clipRule="evenodd"
+      d="M10.75 6C10.75 5.58579 10.4142 5.25 10 5.25C9.58579 5.25 9.25 5.58579 9.25 6V9.25H6C5.58579 9.25 5.25 9.58579 5.25 10C5.25 10.4142 5.58579 10.75 6 10.75H9.25V14C9.25 14.4142 9.58579 14.75 10 14.75C10.4142 14.75 10.75 14.4142 10.75 14V10.75H14C14.4142 10.75 14.75 10.4142 14.75 10C14.75 9.58579 14.4142 9.25 14 9.25H10.75V6Z"
+      fill="currentColor"
+      fillRule="evenodd"
+    />
+  </svg>
+</button>
+`;
+
+exports[`IconButton renders correctly with aria pressed true 1`] = `
+<button
+  aria-busy={false}
+  aria-disabled={false}
+  aria-pressed={true}
+  className="button sizeMedium kindTertiary colorPrimary noSidePadding"
+  data-testid="icon-button"
+  onBlur={[Function]}
+  onClick={[Function]}
+  onFocus={[Function]}
+  onMouseDown={[Function]}
+  onMouseUp={[Function]}
+  style={
+    Object {
+      "alignItems": "center",
+      "height": "40px",
+      "justifyContent": "center",
+      "padding": 0,
+      "width": "40px",
+    }
+  }
+  type="button"
+>
+  <svg
+    aria-hidden={true}
+    className="icon noFocusStyle"
+    data-testid="icon"
+    fill="currentColor"
+    height="20"
+    onClick={[Function]}
+    viewBox="0 0 20 20"
+    width="20"
+  >
+    <path
+      clipRule="evenodd"
+      d="M10.75 6C10.75 5.58579 10.4142 5.25 10 5.25C9.58579 5.25 9.25 5.58579 9.25 6V9.25H6C5.58579 9.25 5.25 9.58579 5.25 10C5.25 10.4142 5.58579 10.75 6 10.75H9.25V14C9.25 14.4142 9.58579 14.75 10 14.75C10.4142 14.75 10.75 14.4142 10.75 14V10.75H14C14.4142 10.75 14.75 10.4142 14.75 10C14.75 9.58579 14.4142 9.25 14 9.25H10.75V6Z"
+      fill="currentColor"
+      fillRule="evenodd"
+    />
+  </svg>
+</button>
+`;
+
 exports[`IconButton renders correctly with disabled 1`] = `
 <button
   aria-busy={false}

--- a/src/components/IconButton/__tests__/iconButton-snapshot-tests.jest.tsx
+++ b/src/components/IconButton/__tests__/iconButton-snapshot-tests.jest.tsx
@@ -76,6 +76,16 @@ describe("IconButton renders correctly", () => {
     expect(tree).toMatchSnapshot();
   });
 
+  it("with aria pressed true", () => {
+    const tree = renderer.create(<IconButton ariaPressed={true} />).toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
+  it("with aria pressed false", () => {
+    const tree = renderer.create(<IconButton ariaPressed={false} />).toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
   it("with active", () => {
     const tree = renderer.create(<IconButton active />).toJSON();
     expect(tree).toMatchSnapshot();


### PR DESCRIPTION
This PR adds the ariaPressed a11y property for IconButton, and from there into the Button component too.

#### Basic

- [x] Used plop (`npm run plop`) to create a new component.
- [x] PR has description.
- [x] New component is functional and uses Hooks.
- [x] Component is written in TypeScript.

#### Style

- [x] Styles are added to `NewComponent.modules.scss` file inside the `NewComponent` folder.
- [x] Component uses CSS Modules.
- [x] Design is compatible with [Monday Design System](https://design.monday.com/).
- [x] Styles are defined using [monday-ui-style](https://github.com/mondaycom/monday-ui-style) tokens
- [x] Displays correctly in all the themes

#### Storybook

- [x] Stories were added to `/src/components/NewComponent/__stories__/NewComponent.mdx` file.
- [x] Stories include all flows of using the component.
- [x] Stories implemented using [vibe-storybook-components](https://github.com/mondaycom/vibe-storybook-components) components and tokens.

#### Tests

- [x] Tests are compliant with [TESTING_README.md](TESTING_README.md) instructions.

#### Accessibility

- [x] Component is accessible.
- [x] Component is compatible with [Vibe Accessibility Guidelines](https://style.monday.com/?path=/docs/foundations-accessibility--docs)
