### PR TITLE
fix(MenuItem): split menu items does not open sub-menu when navigating directly between two split menus

### DIFF
--- a/src/components/Menu/MenuItem/hooks/useMenuItemMouseEvents.ts
+++ b/src/components/Menu/MenuItem/hooks/useMenuItemMouseEvents.ts
@@ -40,16 +40,11 @@ export default function useMenuItemMouseEvents({
     }
   }, [
     setSubMenuIsOpenByIndex,
-    splitMenuItemIconButtonRef,
     index,
-    hasChildren,
-    splitMenuItem,
     isMouseEnterOnIconButton,
     prevIsMouseEnterOnIconButton,
     isActive,
-    resetOpenSubMenuIndex,
-    setActiveItemIndex,
-    isMouseEnter
+    resetOpenSubMenuIndex
   ]);
 
   useLayoutEffect(() => {
@@ -78,11 +73,16 @@ export default function useMenuItemMouseEvents({
 
     if (!isActive && splitMenuItem) {
       setActiveItemIndex(index);
+
+      if (isMouseEnterOnIconButton) {
+        setSubMenuIsOpenByIndex(index, true);
+      }
     }
   }, [
     resetOpenSubMenuIndex,
     prevIsMouseEnter,
     isMouseEnter,
+    isMouseEnterOnIconButton,
     setSubMenuIsOpenByIndex,
     isActive,
     setActiveItemIndex,


### PR DESCRIPTION
https://monday.monday.com/boards/2520706822/pulses/5699284655

split menu item doesn't open consistently when hovering between menu items.
isActive is not turning to true even though the mouse is over the correct menu item.
isActive ---> index === activeIndex ---> true
looks like there is missing a render cycle for the menu item in order to update the isActive value so that hover on the split menu item will result in opening the sub menu.

before:
![ScreenRecording2024-01-21at11 59 48-ezgif com-video-to-gif-converter](https://github.com/mondaycom/monday-ui-react-core/assets/139220157/ee0a33e5-2cd7-411f-8fa5-10fa61e37e89)

after:
![ScreenRecording2024-01-21at11 56 15-ezgif com-video-to-gif-converter](https://github.com/mondaycom/monday-ui-react-core/assets/139220157/4342c100-9e1f-496a-a4b5-6990bd5d2052)
