### PR TITLE
fix: fix rollup build

### DIFF
--- a/packages/core/rollup.config.js
+++ b/packages/core/rollup.config.js
@@ -60,6 +60,7 @@ export default {
     strict: false,
     exports: "named",
     preserveModules: true,
+    preserveModulesRoot: ".",
     sourcemap: true
   },
   input: {


### PR DESCRIPTION
I use semantic fix here, and not semantic ci, to bump a patch since you cannot republish an unpublished version or overwrite a published version