### PR TITLE
ci: use lerna version exact

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -30,7 +30,7 @@ jobs:
           normalized_branch_name=$(git rev-parse --abbrev-ref HEAD | tr -dc '[:alnum:]\n\r' | tr '[:upper:]' '[:lower:]')
           echo "BRANCH=$normalized_branch_name" >> $GITHUB_ENV
       - name: Generate new versions
-        run: yarn lerna version --conventional-commits --conventional-prerelease --no-changelog --no-push --preid $BRANCH -y
+        run: yarn lerna version --exact --conventional-commits --conventional-prerelease --no-changelog --no-push --preid $BRANCH -y
       - run: yarn config set registry https://registry.npmjs.org/
       - name: Setup .npmrc for publish
         run: npm set "//registry.npmjs.org/:_authToken=$NODE_AUTH_TOKEN"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,7 +46,7 @@ jobs:
         shell: bash
         run: yarn lerna run build --since --include-dependencies
       - name: Generate new versions
-        run: yarn lerna version --conventional-commits -y
+        run: yarn lerna version --exact --conventional-commits -y
       - run: yarn config set registry https://registry.npmjs.org/
       - name: Setup .npmrc for publish
         id: setup-npmrc


### PR DESCRIPTION
Lerna updates dependencies as semver compatible (with a ^) which automatically add the caret, the `--exact` flags make it use a fixed version. See [this](https://github.com/lerna/lerna/tree/main/libs/commands/version#--exact). See [this revision](https://github.com/mondaycom/monday-ui-react-core/pull/1953/files#diff-0b810c38f3c138a3d5e44854edefd5eb966617ca84e62f06511f60acc40546c7) for example: 

![Screenshot 2024-02-19 at 18 05 34](https://github.com/mondaycom/monday-ui-react-core/assets/18269880/f2bec046-60bb-4346-b36b-2a24cccdde00)
