### PR TITLE
fix: Button does not dispatch onClick event on edge click

### DIFF
--- a/packages/core/src/components/Button/Button.tsx
+++ b/packages/core/src/components/Button/Button.tsx
@@ -192,6 +192,7 @@ const Button: VibeComponent<ButtonProps, unknown> & {
 
         if (onMouseDown) {
           onMouseDown(event);
+          onClick(event);
         }
       },
       [onMouseDown, disabled, loading, success]


### PR DESCRIPTION
Hey @talkor ,

This PR is raised in regards to the issue pointed out in #1766  .

Based on our discussion, there is a very slight diffrence in the onClick and onMouseDown events . Hence, I have fired an onClick event whenever a mouseDownEvent occurs. It takes care of the button edge clicks as well as multiple clicks as everytime a mouseDown event is surely registered

Thanks,
Ritik
