### PR TITLE
ci: always build before building storybook

### DIFF
--- a/.github/workflows/publish-storybook.yml
+++ b/.github/workflows/publish-storybook.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Build & deploy Storybooks to GitHub Pages
         run: |
           yarn
-          yarn lerna run build --since=origin/master --include-dependencies
+          yarn lerna run build --scope monday-ui-style
           yarn lerna run --scope monday-ui-react-core build-storybook
           yarn lerna run --scope monday-ui-style build-storybook
           cd packages/core/static_storybook

--- a/.github/workflows/publish-storybook.yml
+++ b/.github/workflows/publish-storybook.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Build & deploy Storybooks to GitHub Pages
         run: |
           yarn
-          yarn lerna run build --scope monday-ui-style
+          yarn lerna run build --since --include-dependencies
           yarn lerna run --scope monday-ui-react-core build-storybook
           yarn lerna run --scope monday-ui-style build-storybook
           cd packages/core/static_storybook


### PR DESCRIPTION
We need to always build it as it's a dependency of storybook as well, no need to build core though