### PR TITLE
fix: add href support to actions in the Toast component

### DIFF
--- a/packages/core/src/components/Button/__tests__/__snapshots__/button-snapshot-tests.jest.js.snap
+++ b/packages/core/src/components/Button/__tests__/__snapshots__/button-snapshot-tests.jest.js.snap
@@ -78,6 +78,23 @@ exports[`Button renders correctly renders Button color- fixed-light 1`] = `
 </button>
 `;
 
+exports[`Button renders correctly renders Button color- inverted 1`] = `
+<button
+  aria-busy={false}
+  aria-disabled={false}
+  className="button sizeMedium kindPrimary colorInverted"
+  data-testid="button"
+  onBlur={[Function]}
+  onClick={[Function]}
+  onFocus={[Function]}
+  onMouseDown={[Function]}
+  onMouseUp={[Function]}
+  type="button"
+>
+  Button
+</button>
+`;
+
 exports[`Button renders correctly renders Button color- negative 1`] = `
 <button
   aria-busy={false}

--- a/packages/core/src/components/Toast/Toast.tsx
+++ b/packages/core/src/components/Toast/Toast.tsx
@@ -73,11 +73,19 @@ const Toast: FC<ToastProps> & { types?: typeof ToastType; actionTypes?: typeof T
     return actions
       ? actions
           .filter(action => action.type === ToastActionType.BUTTON)
-          .map(({ type: _type, content, ...otherProps }, index) => (
-            <ToastButton key={`alert-button-${index}`} className={styles.actionButton} {...otherProps}>
-              {content}
-            </ToastButton>
-          ))
+          .map(({ type: _type, content, ...otherProps }, index) => {
+            return otherProps.href ? (
+              <a target="_blank" href={otherProps.href} rel="noreferrer">
+                <ToastButton key={`alert-button-${index}`} className={styles.actionButton} {...otherProps}>
+                  {content}
+                </ToastButton>
+              </a>
+            ) : (
+              <ToastButton key={`alert-button-${index}`} className={styles.actionButton} {...otherProps}>
+                {content}
+              </ToastButton>
+            );
+          })
       : null;
   }, [actions]);
 


### PR DESCRIPTION
When passing in actions to a Toast, the href property is not acted upon if the type of the action is ToastActionType.BUTTON. With this fix, the url supplied to href is opened in a new tab when the button is clicked on. 