### PR TITLE
docs: fix internal markdown file links

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -27,7 +27,7 @@ Please go over the checklist and make sure all conditions are met.
 
 #### Tests
 
-- [ ] Tests are compliant with [TESTING_README.md](TESTING_README.md) instructions.
+- [ ] Tests are compliant with [TESTING_README.md](/packages/core/TESTING_README.md) instructions.
 
 #### Accessibility
 

--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@
 [monday.com](https://www.monday.com) React components library - [Storybook](https://style.monday.com)
 
 | [<img src="https://raw.githubusercontent.com/alrra/browser-logos/master/src/firefox/firefox_48x48.png" alt="Firefox" width="24px" height="24px" />](http://godban.github.io/browsers-support-badges/)</br>Firefox | [<img src="https://raw.githubusercontent.com/alrra/browser-logos/master/src/chrome/chrome_48x48.png" alt="Chrome" width="24px" height="24px" />](http://godban.github.io/browsers-support-badges/)</br>Chrome | [<img src="https://raw.githubusercontent.com/alrra/browser-logos/master/src/safari/safari_48x48.png" alt="Safari" width="24px" height="24px" />](http://godban.github.io/browsers-support-badges/)</br>Safari | [<img src="https://raw.githubusercontent.com/alrra/browser-logos/master/src/safari-ios/safari-ios_48x48.png" alt="iOS Safari" width="24px" height="24px" />](http://godban.github.io/browsers-support-badges/)</br>iOS Safari | [<img src="https://raw.githubusercontent.com/alrra/browser-logos/master/src/samsung-internet/samsung-internet_48x48.png" alt="Samsung" width="24px" height="24px" />](http://godban.github.io/browsers-support-badges/)</br>Samsung | [<img src="https://raw.githubusercontent.com/alrra/browser-logos/master/src/opera/opera_48x48.png" alt="Opera" width="24px" height="24px" />](http://godban.github.io/browsers-support-badges/)</br>Opera |
-| --------- | --------- | --------- | --------- | --------- | --------- |
-| last 4 versions| last 4 versions| 14+| last 2 versions| last 2 versions| last 2 versions |
+| ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| last 4 versions                                                                                                                                                                                                   | last 4 versions                                                                                                                                                                                               | 14+                                                                                                                                                                                                           | last 2 versions                                                                                                                                                                                                               | last 2 versions                                                                                                                                                                                                                     | last 2 versions                                                                                                                                                                                           |
 
 ## Installation
 
@@ -32,7 +32,7 @@ In order to load all the relevant CSS tokens, you should import the `tokens` fil
 import "monday-ui-react-core/tokens";
 ```
 
-_If your project (or it's Storybook) is importing files differently - read more [here](DEPRECATED_IMPORTS.md)._
+_If your project (or it's Storybook) is importing files differently - read more [here](packages/core/DEPRECATED_IMPORTS.md)._
 
 ### Font installation
 
@@ -83,7 +83,7 @@ npm start
 
 ## Contributing
 
-We welcome every contributor, please read the [contribution guidelines](CONTRIBUTING.md) before submitting a PR
+We welcome every contributor, please read the [contribution guidelines](packages/core/CONTRIBUTING.md) before submitting a PR
 
 ## Themes
 

--- a/packages/core/CONTRIBUTING.md
+++ b/packages/core/CONTRIBUTING.md
@@ -1,4 +1,5 @@
 # Contribution guidelines
+
 This is an **official library** of shared UI components for Monday builders. It is used both for internal and external Monday apps development.
 
 This library is open-sourced, and we encourage everyone to use and contribute into it.
@@ -15,15 +16,17 @@ This library is open-sourced, and we encourage everyone to use and contribute in
 8. Commit to your local fork using [Semantic Commit Messages](https://seesparkbox.com/foundry/semantic_commit_messages)
 9. Create a PR with title based using [Semantic Commit Messages](https://seesparkbox.com/foundry/semantic_commit_messages)
    For example: `feat: add new TextArea component`
-10. Go over the [checklist](PULL_REQUEST_TEMPLATE.md) in the PR and make sure that all checks are passed
+10. Go over the [checklist](/.github/PULL_REQUEST_TEMPLATE.md) in the PR and make sure that all checks are passed
 11. Wait for the Design and Code review
 12. Enjoy your change after merge!
 
 ## Information about the project
 
 ### Creating new files in the library
+
 Our code generator, Plop, is designed to simplify the creation of frequently used boilerplate code. To utilize it, execute the command `npm run plop`. If you want to learn more about Plop, you can find additional information [here](https://plopjs.com/).
 Currently, our Plop code generator supports the creation of the following:
+
 1. Tests
 2. Component story documentation pages
 3. Hook story documentation pages
@@ -32,26 +35,33 @@ Currently, our Plop code generator supports the creation of the following:
 We strongly recommend utilizing our Plop code generator within this repository for generating any of the mentioned items. Doing so ensures that your code will be created with the latest recommended structure, providing a solid foundation for your development tasks.
 
 ### API
+
 If you add new features or abilities to an existing component, please ensure your props' naming follows our conventions and best practices. Read more about it [here](./API_GUIDELINES.MD).
 
 ### Storybook
+
 As the main development environment and documentation playground, we are using [Storybook](https://storybook.js.org/).
 Each component should be developed in isolation in the Storybook environment.
 You can read more about our docs implementation best practices [here](COMPONENTS_DOCUMENTATION_GUIDELINES.md).
 
 ### Theming
+
 Every component should support theming, you can find more information about it [here](THEME_README.md).
 
 ### Tests and coverage
+
 All the guidelines about testing your new component or changes to the existing one you can find [here](TESTING_README.md).
 
 ### Linting
+
 We use [Prettier](https://prettier.io/) with the default community guidelines. Please, make sure that you are formatting your code with prettier.
 
 ### Commits
+
 We are using [Semantic commits](https://gist.github.com/joshbuchea/6f47e86d2510bce28f8e7f42ae84c716) convention for creating Pull Requests and commits messages inside of the Pull Request.
 
 ### Releasing
+
 To release a new version, you can run the ["Release new version" workflow](https://github.com/mondaycom/monday-ui-react-core/actions/workflows/release.yml).
 
 If you want to run it locally, you can do so with [Github's CLI](https://cli.github.com/):


### PR DESCRIPTION
There are some broken markdown links in the codebase. This PR fixes them so that users aren't redirected to 404 pages. 