### PR TITLE
ci(chromatic): allow to run on both master and other branches

### DIFF
--- a/.github/actions/check-changed-packages/action.yml
+++ b/.github/actions/check-changed-packages/action.yml
@@ -2,10 +2,10 @@ name: Check Changed Packages
 description: Check if there are any changed packages in the monorepo
 
 inputs:
-  exit_code_on_no_changes:
-    description: Exit code to use if no changes are detected. Do not supply value in case you want to continue without exiting even if no changes found.
+  exit_on_no_changes:
+    description: Whether to exit with a non-zero code if there are no changes.
     required: false
-    default: ""
+    default: "false"
 outputs:
   has_changes:
     description: Whether there are any changes in the monorepo.
@@ -26,10 +26,10 @@ runs:
         if [[ $changed_packages = "[]" ]]; then
           echo "has_changes=false" >> $GITHUB_OUTPUT
           echo "No packages to process as Lerna didn't detect any changes."
-          if [[ -n "${{ inputs.exit_code_on_no_changes }}" ]]; then
-            exit ${{ inputs.exit_code_on_no_changes }}
+          if [[ "${{ inputs.exit_on_no_changes }}" == "true" ]]; then
+            exit 1
           else
-            echo "Continuing because exit_code_on_no_changes is not used."
+            echo "Continuing because exit_on_no_changes is not used."
           fi
         else
           echo "has_changes=true" >> $GITHUB_OUTPUT

--- a/.github/actions/check-changed-packages/action.yml
+++ b/.github/actions/check-changed-packages/action.yml
@@ -1,0 +1,38 @@
+name: Check Changed Packages
+description: Check if there are any changed packages in the monorepo
+
+inputs:
+  exit_code_on_no_changes:
+    description: Exit code to use if no changes are detected. Do not supply value in case you want to continue without exiting even if no changes found.
+    required: false
+    default: ""
+outputs:
+  has_changes:
+    description: Whether there are any changes in the monorepo.
+    value: ${{ steps.check-changed-packages.outputs.has_changes }}
+
+runs:
+  using: "composite"
+  steps:
+    - id: determine-since-flag
+      uses: ./.github/actions/determine-lerna-since-flag
+    - id: check-changed-packages
+      shell: bash
+      env:
+        SINCE_FLAG: ${{ steps.determine-since-flag.outputs.since_flag }}
+      run: |
+        changed_packages=$(yarn -s lerna ls $SINCE_FLAG --json --loglevel=error)
+
+        if [[ $changed_packages = "[]" ]]; then
+          echo "has_changes=false" >> $GITHUB_OUTPUT
+          echo "No packages to process as Lerna didn't detect any changes."
+          if [[ -n "${{ inputs.exit_code_on_no_changes }}" ]]; then
+            exit ${{ inputs.exit_code_on_no_changes }}
+          else
+            echo "Continuing because exit_code_on_no_changes is not used."
+          fi
+        else
+          echo "has_changes=true" >> $GITHUB_OUTPUT
+          echo "Change detected:"
+          echo "$changed_packages"
+        fi

--- a/.github/actions/determine-lerna-since-flag/action.yml
+++ b/.github/actions/determine-lerna-since-flag/action.yml
@@ -13,7 +13,7 @@ runs:
       shell: bash
       run: |
         if [[ "$GITHUB_REF" == "refs/heads/master" ]]; then
-          since_flag=""
+          since_flag="--since"
           echo "Running on master branch, checking for all changes."
         else
           since_flag="--since=origin/master"

--- a/.github/actions/determine-lerna-since-flag/action.yml
+++ b/.github/actions/determine-lerna-since-flag/action.yml
@@ -1,0 +1,23 @@
+name: Determine Lerna since flag
+description: Determine the --since flag value for Lerna commands based on the branch. Should be used for workflows/actions that can be used on both default branch and other branches.
+
+outputs:
+  since_flag:
+    description: The --since flag value to use with Lerna commands.
+    value: ${{ steps.get-since-flag.outputs.since_flag }}
+
+runs:
+  using: "composite"
+  steps:
+    - id: get-since-flag
+      shell: bash
+      run: |
+        if [[ "$GITHUB_REF" == "refs/heads/master" ]]; then
+          since_flag=""
+          echo "Running on master branch, checking for all changes."
+        else
+          since_flag="--since=origin/master"
+          echo "Not running on master branch, checking for changes since origin/master."
+        fi
+
+        echo "since_flag=$since_flag" >> $GITHUB_OUTPUT

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -15,19 +15,18 @@ jobs:
           npm_token: ${{ secrets.npm_token }}
       - id: check-changed-packages
         uses: ./.github/actions/check-changed-packages
-        with:
-          exit_code_on_no_changes: 0
       - id: determine-since-flag
         uses: ./.github/actions/determine-lerna-since-flag
       - name: Run Build
+        if: ${{ steps.check-changed-packages.outputs.has_changes == 'true' }}
         shell: bash
         env:
           SINCE_FLAG: ${{ steps.determine-since-flag.outputs.since_flag }}
         run: yarn lerna run build $SINCE_FLAG --include-filtered-dependencies
       - name: Publish to Chromatic
+        if: ${{ steps.check-changed-packages.outputs.has_changes == 'true' }}
         uses: chromaui/action@v11
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          # 👇 Chromatic projectToken, if you are project maintainer refer to the manage page to obtain it.
           projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
           workingDir: packages/core

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -6,19 +6,22 @@ jobs:
   chromatic-deployment:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
-      - name: Install dependencies
-        run: yarn
-      - name: Check if there are changed packages
-        id: changed-packages
-        continue-on-error: true
-        run: |
-          changed_packages=$(yarn -s lerna ls --since=origin/master --json --loglevel=error)
-          [[ $changed_packages = "[]" ]] && echo "HAS_CHANGES=false" >> $GITHUB_ENV || echo "HAS_CHANGES=true" >> $GITHUB_ENV
+      - uses: actions/checkout@v4
+      - name: Run Setup
+        uses: ./.github/actions/setup
+        with:
+          npm_token: ${{ secrets.npm_token }}
+      - id: check-changed-packages
+        uses: ./.github/actions/check-changed-packages
+        with:
+          exit_code_on_no_changes: 0
+      - id: determine-since-flag
+        uses: ./.github/actions/determine-lerna-since-flag
       - name: Run Build
-        if: ${{ env.HAS_CHANGES == 'true' }}
         shell: bash
-        run: yarn lerna run build --since=origin/master --include-filtered-dependencies
+        env:
+          SINCE_FLAG: ${{ steps.determine-since-flag.outputs.since_flag }}
+        run: yarn lerna run build $SINCE_FLAG --include-filtered-dependencies
       - name: Publish to Chromatic
         uses: chromaui/action@v1
         if: ${{ env.HAS_CHANGES == 'true' }}

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -7,6 +7,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Run Setup
         uses: ./.github/actions/setup
         with:

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -23,8 +23,7 @@ jobs:
           SINCE_FLAG: ${{ steps.determine-since-flag.outputs.since_flag }}
         run: yarn lerna run build $SINCE_FLAG --include-filtered-dependencies
       - name: Publish to Chromatic
-        uses: chromaui/action@v1
-        if: ${{ env.HAS_CHANGES == 'true' }}
+        uses: chromaui/action@v11
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           # 👇 Chromatic projectToken, if you are project maintainer refer to the manage page to obtain it.


### PR DESCRIPTION
https://monday.monday.com/boards/3532714909/pulses/6231010883

This PR also adds:
- reusable action that outputs the `since` flag value according to context of branch running the action
- reusable action that outputs whether there are changes to the monorepo's packages