### PR TITLE
ci: use wildcard in `build-and-upload` to support future additional packages, add cache to `setup` for yarn dependencies

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -13,8 +13,9 @@ runs:
       with:
         node-version-file: ".nvmrc"
         registry-url: https://registry.npmjs.org/
+        cache: "yarn"
     - name: Install
       run: yarn
       shell: bash
       env:
-        NODE_AUTH_TOKEN: ${{inputs.npm_token}}
+        NODE_AUTH_TOKEN: ${{ inputs.npm_token }}

--- a/.github/workflows/build-and-upload.yml
+++ b/.github/workflows/build-and-upload.yml
@@ -41,7 +41,5 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: ci-builds-${{ github.run_id }}-${{ github.run_attempt }}
-          path: |
-            packages/core/dist/
-            packages/style/dist/
+          path: "./packages/*/dist/"
           if-no-files-found: ignore


### PR DESCRIPTION
https://monday.monday.com/boards/3532714909/pulses/6244728962
https://monday.monday.com/boards/3532714909/pulses/6244733896