### PR TITLE
chore: migrate `<Canvas><Story of />` syntax to <Canvas of` syntax

### DIFF
--- a/packages/core/src/components/Accordion/Accordion/__stories__/accordion.mdx
+++ b/packages/core/src/components/Accordion/Accordion/__stories__/accordion.mdx
@@ -1,6 +1,6 @@
 import Accordion from "../Accordion";
 import AccordionItem from "../../AccordionItem/AccordionItem";
-import { Canvas, Meta, Story } from "@storybook/blocks";
+import { Canvas, Meta } from "@storybook/blocks";
 import {
   BREADCRUBMS,
   EXPAND_COLLAPSE,
@@ -26,9 +26,7 @@ import * as AccordionStories from "./accordion.stories";
 
 Accordion is a vertically stacked list of items. Each item can be "expanded" or "collapsed" to reveal the content within with that item.
 
-<Canvas>
-  <Story of={AccordionStories.Overview} />
-</Canvas>
+<Canvas of={AccordionStories.Overview} />
 
 ## Props
 
@@ -51,17 +49,13 @@ Accordion is a vertically stacked list of items. Each item can be "expanded" or 
 
 Each section can be expanded without closing the others
 
-<Canvas>
-  <Story of={AccordionStories.MultiActive} />
-</Canvas>
+<Canvas of={AccordionStories.MultiActive} />
 
 ### Single active
 
 Only one section can be open at the time
 
-<Canvas>
-  <Story of={AccordionStories.SingleActive} />
-</Canvas>
+<Canvas of={AccordionStories.SingleActive} />
 
 ## Do’s and Don’ts
 
@@ -98,9 +92,7 @@ Only one section can be open at the time
 
 ### Preferences Accordion
 
-<Canvas>
-  <Story of={AccordionStories.PreferencesAccordion} />
-</Canvas>
+<Canvas of={AccordionStories.PreferencesAccordion} />
 
 ## Related components
 

--- a/packages/core/src/components/AlertBanner/__stories__/alertBanner.mdx
+++ b/packages/core/src/components/AlertBanner/__stories__/alertBanner.mdx
@@ -1,4 +1,4 @@
-import { Canvas, Meta, Story } from "@storybook/blocks";
+import { Canvas, Meta } from "@storybook/blocks";
 import { ComponentRules, Link, UsageGuidelines } from "vibe-storybook-components";
 import AlertBanner from "../AlertBanner";
 import AlertBannerText from "../AlertBannerText/AlertBannerText";
@@ -29,9 +29,7 @@ import * as AlertBannerStories from "./alertBanner.stories";
 
 Alert banners show pressing and high-signal messages, such as system alerts. They are meant to be noticed and prompt users to take action.
 
-<Canvas>
-  <Story of={AlertBannerStories.Overview} />
-</Canvas>
+<Canvas of={AlertBannerStories.Overview} />
 
 ## Props
 
@@ -55,21 +53,15 @@ Alert banners show pressing and high-signal messages, such as system alerts. The
 
 There are five types of alert banners: primary, positive, negative, warning and inverted.
 
-<Canvas>
-  <Story of={AlertBannerStories.Types} />
-</Canvas>
+<Canvas of={AlertBannerStories.Types} />
 
 ### Alert Banner with button
 
-<Canvas>
-  <Story of={AlertBannerStories.AlertBannerWithButton} />
-</Canvas>
+<Canvas of={AlertBannerStories.AlertBannerWithButton} />
 
 ### Alert Banner with link
 
-<Canvas>
-  <Story of={AlertBannerStories.AlertBannerWithLink} />
-</Canvas>
+<Canvas of={AlertBannerStories.AlertBannerWithLink} />
 
 ## Do’s and Don’ts
 
@@ -169,25 +161,19 @@ There are five types of alert banners: primary, positive, negative, warning and 
 
 Use when you’d like to notify about an event or cross-company announcment.
 
-<Canvas>
-  <Story of={AlertBannerStories.AlertBannerAsAnAnnouncement} />
-</Canvas>
+<Canvas of={AlertBannerStories.AlertBannerAsAnAnnouncement} />
 
 ### Alert banner as an opportunity to upgrade
 
 Use to show a trial user the number of remaining free days to use the platform.
 
-<Canvas>
-  <Story of={AlertBannerStories.AlertBannerAsAnOpportunityToUpgrade} />
-</Canvas>
+<Canvas of={AlertBannerStories.AlertBannerAsAnOpportunityToUpgrade} />
 
 ### Overflow text
 
 In case that there’s not enough space for the conent, use an ellipses (...).
 
-<Canvas>
-  <Story of={AlertBannerStories.OverflowText} />
-</Canvas>
+<Canvas of={AlertBannerStories.OverflowText} />
 
 ## Related components
 

--- a/packages/core/src/components/AttentionBox/__stories__/attentionBox.mdx
+++ b/packages/core/src/components/AttentionBox/__stories__/attentionBox.mdx
@@ -1,4 +1,4 @@
-import { Canvas, Meta, Story } from "@storybook/blocks";
+import { Canvas, Meta } from "@storybook/blocks";
 import AttentionBox from "../AttentionBox";
 import { Link } from "vibe-storybook-components";
 import { Info } from "../../Icon/Icons";
@@ -29,9 +29,7 @@ import * as AttentionBoxStories from "./attentionBox.stories";
 
 Attention box lets users know important information within content areas, as close as possible to the content it’s about.
 
-<Canvas>
-  <Story of={AttentionBoxStories.Overview} />
-</Canvas>
+<Canvas of={AttentionBoxStories.Overview} />
 
 ## Props
 
@@ -55,21 +53,15 @@ Attention box lets users know important information within content areas, as clo
 
 There are five types of attention boxes: Primary, success, danger, warning and dark (natural).
 
-<Canvas>
-  <Story of={AttentionBoxStories.States} />
-</Canvas>
+<Canvas of={AttentionBoxStories.States} />
 
 ### Attention box with link
 
-<Canvas>
-  <Story of={AttentionBoxStories.AttentionBoxWithLink} />
-</Canvas>
+<Canvas of={AttentionBoxStories.AttentionBoxWithLink} />
 
 ### Dismissable
 
-<Canvas>
-  <Story of={AttentionBoxStories.Dismissable} />
-</Canvas>
+<Canvas of={AttentionBoxStories.Dismissable} />
 
 ## Do’s and Don’ts
 
@@ -137,17 +129,13 @@ There are five types of attention boxes: Primary, success, danger, warning and d
 
 Provides additional information about an action or section.
 
-<Canvas>
-  <Story of={AttentionBoxStories.NaturalAttentionBox} />
-</Canvas>
+<Canvas of={AttentionBoxStories.NaturalAttentionBox} />
 
 ### Attention box inside a dialog/combobox
 
 Provides cotextual and related information.
 
-<Canvas>
-  <Story of={AttentionBoxStories.AttentionBoxInsideADialogCombobox} />
-</Canvas>
+<Canvas of={AttentionBoxStories.AttentionBoxInsideADialogCombobox} />
 
 ## Related components
 

--- a/packages/core/src/components/Avatar/__stories__/avatar.mdx
+++ b/packages/core/src/components/Avatar/__stories__/avatar.mdx
@@ -1,5 +1,5 @@
 import Avatar from "../Avatar";
-import { Canvas, Meta, Story } from "@storybook/blocks";
+import { Canvas, Meta } from "@storybook/blocks";
 import {
   AVATAR_GROUP,
   BADGE,
@@ -29,9 +29,7 @@ export const avatarTemplate = createComponentTemplate(Avatar);
 
 Avatar is a graphical representation of a person through a profile picture, image, icon, or set of initials.
 
-<Canvas>
-  <Story of={AvatarStories.Overview} />
-</Canvas>
+<Canvas of={AvatarStories.Overview} />
 
 ## Props
 
@@ -57,33 +55,25 @@ Avatar is a graphical representation of a person through a profile picture, imag
 
 Avatars appear in 3 sizes: Small, Medium, and Large.
 
-<Canvas>
-  <Story of={AvatarStories.Size} />
-</Canvas>
+<Canvas of={AvatarStories.Size} />
 
 ### Disabled
 
 Use when a user is inactive in the system.
 
-<Canvas>
-  <Story of={AvatarStories.Disable} />
-</Canvas>
+<Canvas of={AvatarStories.Disable} />
 
 ### Avatar with text
 
 Use when a user’s image is not available, use their initials.
 
-<Canvas>
-  <Story of={AvatarStories.AvatarWithText} />
-</Canvas>
+<Canvas of={AvatarStories.AvatarWithText} />
 
 ### Square avatar with icon or text
 
 Use for non-person avatars, such as a workspace or team.
 
-<Canvas>
-  <Story of={AvatarStories.SquareAvatar} />
-</Canvas>
+<Canvas of={AvatarStories.SquareAvatar} />
 
 ## Do’s and Don’ts
 
@@ -145,41 +135,31 @@ Use for non-person avatars, such as a workspace or team.
 
 Use to indicate the user’s permissions such as: Guest, owner.
 
-<Canvas>
-  <Story of={AvatarStories.AvatarWithRightBadge} />
-</Canvas>
+<Canvas of={AvatarStories.AvatarWithRightBadge} />
 
 ### Avatar with left badge
 
 Use to indicate the status of a user such as: Working from home, out of office etc.
 
-<Canvas>
-  <Story of={AvatarStories.AvatarWithLeftBadge} />
-</Canvas>
+<Canvas of={AvatarStories.AvatarWithLeftBadge} />
 
 ### Avatar with tooltip
 
 Use to display tooltip on onHover Avatar event.
 
-<Canvas>
-  <Story of={AvatarStories.AvatarWithTooltip} />
-</Canvas>
+<Canvas of={AvatarStories.AvatarWithTooltip} />
 
 ### Clickable avatar
 
 Use to fire actions on avatar click event.
 
-<Canvas>
-  <Story of={AvatarStories.ClickableAvatar} />
-</Canvas>
+<Canvas of={AvatarStories.ClickableAvatar} />
 
 ### Multiple avatars
 
 To group multiple Avatars together, use the <StorybookLink page="Media/Avatar/AvatarGroup">AvatarGroup</StorybookLink> component.
 
-<Canvas>
-  <Story of={AvatarStories.MultipleAvatars} />
-</Canvas>
+<Canvas of={AvatarStories.MultipleAvatars} />
 
 ## Related components
 

--- a/packages/core/src/components/AvatarGroup/__stories__/AvatarGroup.mdx
+++ b/packages/core/src/components/AvatarGroup/__stories__/AvatarGroup.mdx
@@ -1,4 +1,4 @@
-import { Canvas, Meta, Story } from "@storybook/blocks";
+import { Canvas, Meta } from "@storybook/blocks";
 import { UsageGuidelines } from "vibe-storybook-components";
 import { AVATAR, COUNTER, BADGE } from "../../../storybook/components/related-components/component-description-map";
 import * as AvatarGroupStories from "./AvatarGroup.stories";
@@ -18,9 +18,7 @@ import * as AvatarGroupStories from "./AvatarGroup.stories";
 
 Use this component if you need to stack avatars as a group.
 
-<Canvas>
-  <Story of={AvatarGroupStories.Overview} />
-</Canvas>
+<Canvas of={AvatarGroupStories.Overview} />
 
 ## Props
 
@@ -47,80 +45,60 @@ Use this component if you need to stack avatars as a group.
 
 As an avatar, avatar groups appear in 3 sizes: Small, Medium, and Large.
 
-<Canvas>
-  <Story of={AvatarGroupStories.Size} />
-</Canvas>
+<Canvas of={AvatarGroupStories.Size} />
 
 ### Color variants
 
 You can use Light or Dark counter color to maintain visual hierarchy.
 
-<Canvas>
-  <Story of={AvatarGroupStories.ColorVariants} />
-</Canvas>
+<Canvas of={AvatarGroupStories.ColorVariants} />
 
 ### Custom counter
 
 You can pass `counterProps` to specify counter params.
 
-<Canvas>
-  <Story of={AvatarGroupStories.CustomCounter} />
-</Canvas>
+<Canvas of={AvatarGroupStories.CustomCounter} />
 
 ### Grid tooltip
 
 When tooltip text for additional avatars is not passed, extra avatars will be displayed in a grid mode.
 
-<Canvas>
-  <Story of={AvatarGroupStories.GridTooltip} />
-</Canvas>
+<Canvas of={AvatarGroupStories.GridTooltip} />
 
 ### Max amount to display
 
 Choose the maximum amount of avatars you want to display.
 
-<Canvas>
-  <Story of={AvatarGroupStories.MaxAmountToDisplay} />
-</Canvas>
+<Canvas of={AvatarGroupStories.MaxAmountToDisplay} />
 
 ### Hover vs Clickable
 
 If avatars are clickable, they will be displayed via <StorybookLink page="Navigation/Menu/Menu">Menu</StorybookLink> and user will be able to navigate each additional item.
 Otherwise, avatars will be displayed in a Tooltip with no item's navigation.
 
-<Canvas>
-  <Story of={AvatarGroupStories.HoverVsClickable} />
-</Canvas>
+<Canvas of={AvatarGroupStories.HoverVsClickable} />
 
 ### Virtualized list
 
 Should be used only to display large amount of avatars in default counter tooltip
 
-<Canvas>
-  <Story of={AvatarGroupStories.VirtualizedList} />
-</Canvas>
+<Canvas of={AvatarGroupStories.VirtualizedList} />
 
 ### Counter custom tooltip content
 
 Counter tooltip props can be specified in order to render tooltip with custom content.
 
-<Canvas>
-  <Story of={AvatarGroupStories.CounterCustomTooltipContent} />
-</Canvas>
+<Canvas of={AvatarGroupStories.CounterCustomTooltipContent} />
 
 ## Use cases and examples
 
 ### Last seen users
 
-<Canvas>
-  <Story of={AvatarGroupStories.LastSeenUsers} />
-</Canvas>
+<Canvas of={AvatarGroupStories.LastSeenUsers} />
 
 ### Displaying teams
 
-<Canvas>
-  <Story of={AvatarGroupStories.DisplayingTeams} />
-</Canvas>
+<Canvas of={AvatarGroupStories.DisplayingTeams} />
 
 ## Related components
 

--- a/packages/core/src/components/Badge/__stories__/Badge.mdx
+++ b/packages/core/src/components/Badge/__stories__/Badge.mdx
@@ -1,5 +1,5 @@
 import Badge from "../Badge";
-import { Canvas, Meta, Story } from "@storybook/blocks";
+import { Canvas, Meta } from "@storybook/blocks";
 import person from "./assets/person.png";
 import { WhatsNew } from "../../Icon/Icons";
 import Link from "../../Link/Link";
@@ -25,9 +25,7 @@ import * as BadgeStories from "./Badge.stories";
 
 Badge component is responsible for layout an indicator/counter on a child component
 
-<Canvas>
-  <Story of={BadgeStories.Overview} />
-</Canvas>
+<Canvas of={BadgeStories.Overview} />
 
 ## Props
 
@@ -39,33 +37,25 @@ Badge component is responsible for layout an indicator/counter on a child compon
 
 Badge can be of type Indicator or type Counter
 
-<Canvas>
-  <Story of={BadgeStories.States} />
-</Canvas>
+<Canvas of={BadgeStories.States} />
 
 ### Button
 
 When using Badge on a Button element, use alignment of RECTANGULAR in order to attach it to the element
 
-<Canvas>
-  <Story of={BadgeStories.ButtonStory} />
-</Canvas>
+<Canvas of={BadgeStories.ButtonStory} />
 
 ### Avatar
 
 When using Badge on an Avatar element, use alignment of CIRCULAR in order to attach it to the element
 
-<Canvas>
-  <Story of={BadgeStories.AvatarStory} />
-</Canvas>
+<Canvas of={BadgeStories.AvatarStory} />
 
 ### Inline elements
 
 When using Badge on an inline element, use alignment of OUTSIDE in order to attach it to the element
 
-<Canvas>
-  <Story of={BadgeStories.InlineElements} />
-</Canvas>
+<Canvas of={BadgeStories.InlineElements} />
 
 ## Do’s and Don’ts
 

--- a/packages/core/src/components/Box/__stories__/Box.mdx
+++ b/packages/core/src/components/Box/__stories__/Box.mdx
@@ -1,4 +1,4 @@
-import { Canvas, Meta, Story } from "@storybook/blocks";
+import { Canvas, Meta } from "@storybook/blocks";
 import { UsageGuidelines } from "vibe-storybook-components";
 import {
   DIALOG_CONTENT_CONTAINER,
@@ -28,9 +28,7 @@ Box component is used as a wrapper component.
 Its purpose is to help scaffold compositions while using Vibe's prop keys without writing new CSS. <br />It can be used as a container for
 atom based compositions, it can accept all Vibe style related props and have a semantic html tag.
 
-<Canvas>
-  <Story of={BoxStories.Overview} />
-</Canvas>
+<Canvas of={BoxStories.Overview} />
 
 ## Props
 
@@ -52,49 +50,35 @@ atom based compositions, it can accept all Vibe style related props and have a s
 
 ### BACKGROUNDS COLORS
 
-<Canvas>
-  <Story of={BoxStories.BackgroundColors} />
-</Canvas>
+<Canvas of={BoxStories.BackgroundColors} />
 
 ### TEXT COLORS
 
-<Canvas>
-  <Story of={BoxStories.TextColors} />
-</Canvas>
+<Canvas of={BoxStories.TextColors} />
 
 ### BORDER
 
-<Canvas>
-  <Story of={BoxStories.Border} />
-</Canvas>
+<Canvas of={BoxStories.Border} />
 
 ### BORDER COLOR
 
-<Canvas>
-  <Story of={BoxStories.BorderColor} />
-</Canvas>
+<Canvas of={BoxStories.BorderColor} />
 
 ### ROUNDED CORNERS
 
 #### Size props
 
-<Canvas>
-  <Story of={BoxStories.RoundCorners} />
-</Canvas>
+<Canvas of={BoxStories.RoundCorners} />
 
 ### SHADOW
 
-<Canvas>
-  <Story of={BoxStories.Shadow} />
-</Canvas>
+<Canvas of={BoxStories.Shadow} />
 
 ### MARGIN
 
 #### Size props
 
-<Canvas>
-  <Story of={BoxStories.Margin} />
-</Canvas>
+<Canvas of={BoxStories.Margin} />
 
 #### Property variations per each size:
 
@@ -121,9 +105,7 @@ NONE
 
 #### Size props
 
-<Canvas>
-  <Story of={BoxStories.Padding} />
-</Canvas>
+<Canvas of={BoxStories.Padding} />
 
 #### Property variations per each size:
 
@@ -139,9 +121,7 @@ paddingStart
 
 ### Component Disabled
 
-<Canvas>
-  <Story of={BoxStories.Disabled} />
-</Canvas>
+<Canvas of={BoxStories.Disabled} />
 
 ## Related components
 

--- a/packages/core/src/components/BreadcrumbsBar/BreadcrumbItem/__stories__/breadcrumbItem.mdx
+++ b/packages/core/src/components/BreadcrumbsBar/BreadcrumbItem/__stories__/breadcrumbItem.mdx
@@ -1,4 +1,4 @@
-import { Canvas, Meta, Story } from "@storybook/blocks";
+import { Canvas, Meta } from "@storybook/blocks";
 import * as BreadcrumbItemStories from "./breadcrumbItem.stories";
 
 <Meta of={BreadcrumbItemStories} />
@@ -12,9 +12,7 @@ import * as BreadcrumbItemStories from "./breadcrumbItem.stories";
 
 ## Overview
 
-<Canvas>
-  <Story of={BreadcrumbItemStories.Overview} />
-</Canvas>
+<Canvas of={BreadcrumbItemStories.Overview} />
 
 ## Props
 
@@ -24,12 +22,8 @@ import * as BreadcrumbItemStories from "./breadcrumbItem.stories";
 
 ### States
 
-<Canvas>
-  <Story of={BreadcrumbItemStories.States} />
-</Canvas>
+<Canvas of={BreadcrumbItemStories.States} />
 
 ### With icon
 
-<Canvas>
-  <Story of={BreadcrumbItemStories.WithIcon} />
-</Canvas>
+<Canvas of={BreadcrumbItemStories.WithIcon} />

--- a/packages/core/src/components/BreadcrumbsBar/__stories__/breadcrumbsBar.mdx
+++ b/packages/core/src/components/BreadcrumbsBar/__stories__/breadcrumbsBar.mdx
@@ -1,4 +1,4 @@
-import { Canvas, Meta, Story } from "@storybook/blocks";
+import { Canvas, Meta } from "@storybook/blocks";
 import BreadcrumbsBar from "../BreadcrumbsBar";
 import BreadcrumbItem from "../BreadcrumbItem/BreadcrumbItem.tsx";
 import Avatar from "../../Avatar/Avatar";
@@ -30,9 +30,7 @@ import * as BreadcrumbsBarStories from "./breadcrumbsBar.stories";
 
 Breadcrumbs allow users to keep track and maintain awareness of their location as they navigate through pages, folders, files, etc.
 
-<Canvas>
-  <Story of={BreadcrumbsBarStories.Overview} />
-</Canvas>
+<Canvas of={BreadcrumbsBarStories.Overview} />
 
 ## Props
 
@@ -56,15 +54,11 @@ Breadcrumbs allow users to keep track and maintain awareness of their location a
 
 ### Text only
 
-<Canvas>
-  <Story of={BreadcrumbsBarStories.TextOnly} />
-</Canvas>
+<Canvas of={BreadcrumbsBarStories.TextOnly} />
 
 ### With icons
 
-<Canvas>
-  <Story of={BreadcrumbsBarStories.WithIcons} />
-</Canvas>
+<Canvas of={BreadcrumbsBarStories.WithIcons} />
 
 ## Do’s and Don’ts
 
@@ -134,9 +128,7 @@ Breadcrumbs allow users to keep track and maintain awareness of their location a
 
 Use when breadcrumbs are clickable and are used for information and navigation
 
-<Canvas>
-  <Story of={BreadcrumbsBarStories.NavigatableBreadcrumbs} />
-</Canvas>
+<Canvas of={BreadcrumbsBarStories.NavigatableBreadcrumbs} />
 
 ## Related components
 

--- a/packages/core/src/components/Button/__stories__/button.mdx
+++ b/packages/core/src/components/Button/__stories__/button.mdx
@@ -1,5 +1,5 @@
 import Button from "../Button";
-import { Canvas, Meta, Story } from "@storybook/blocks";
+import { Canvas, Meta } from "@storybook/blocks";
 import {
   BUTTON_GROUP,
   BADGE,
@@ -27,9 +27,7 @@ Buttons allow users to trigger an action or event with a single click.
 For example, you can use a button for allowing the functionality of submitting a form, opening a dialog, canceling an action,
 or performing a delete operation.
 
-<Canvas>
-  <Story of={ButtonStories.Overview} />
-</Canvas>
+<Canvas of={ButtonStories.Overview} />
 
 ## Props
 
@@ -55,41 +53,29 @@ or performing a delete operation.
 
 There can be more than one button in a screen, but to create the hierarchy of actions we need to use button kinds.
 
-<Canvas>
-  <Story of={ButtonStories.ButtonKinds} />
-</Canvas>
+<Canvas of={ButtonStories.ButtonKinds} />
 
 ### Sizes
 
-<Canvas>
-  <Story of={ButtonStories.Sizes} />
-</Canvas>
+<Canvas of={ButtonStories.Sizes} />
 
 ### Disabled
 
 Set disable button for something that isn’t usable. Use a tooltip on hover in order to indicate the reason of the disabled action.
 
-<Canvas>
-  <Story of={ButtonStories.Disabled} />
-</Canvas>
+<Canvas of={ButtonStories.Disabled} />
 
 ### States
 
-<Canvas>
-  <Story of={ButtonStories.States} />
-</Canvas>
+<Canvas of={ButtonStories.States} />
 
 ### Positive and Negative
 
-<Canvas>
-  <Story of={ButtonStories.PositiveAndNegative} />
-</Canvas>
+<Canvas of={ButtonStories.PositiveAndNegative} />
 
 ### Icons
 
-<Canvas>
-  <Story of={ButtonStories.Icons} />
-</Canvas>
+<Canvas of={ButtonStories.Icons} />
 
 ## Do’s and Don’ts
 
@@ -142,27 +128,19 @@ Set disable button for something that isn’t usable. Use a tooltip on hover in 
 
 ### Loading state
 
-<Canvas>
-  <Story of={ButtonStories.LoadingState} />
-</Canvas>
+<Canvas of={ButtonStories.LoadingState} />
 
 ### Success state
 
-<Canvas>
-  <Story of={ButtonStories.SuccessState} />
-</Canvas>
+<Canvas of={ButtonStories.SuccessState} />
 
 ### On color state
 
-<Canvas>
-  <Story of={ButtonStories.OnColorStates} />
-</Canvas>
+<Canvas of={ButtonStories.OnColorStates} />
 
 ### Adjacent buttons
 
-<Canvas>
-  <Story of={ButtonStories.AdjacentButtons} />
-</Canvas>
+<Canvas of={ButtonStories.AdjacentButtons} />
 
 ## Related components
 

--- a/packages/core/src/components/ButtonGroup/__stories__/buttonGroup.mdx
+++ b/packages/core/src/components/ButtonGroup/__stories__/buttonGroup.mdx
@@ -1,4 +1,4 @@
-import { Canvas, Meta, Story } from "@storybook/blocks";
+import { Canvas, Meta } from "@storybook/blocks";
 import { Link } from "vibe-storybook-components";
 import ButtonGroup from "../ButtonGroup";
 import { Mobile } from "../../Icon/Icons";
@@ -24,9 +24,7 @@ import * as ButtonGroupStories from "./buttonGroup.stories";
 
 ButtonGroup can be used to group related options. To emphasize groups of related toggle buttons, a group should share a common container.
 
-<Canvas>
-  <Story of={ButtonGroupStories.Overview} />
-</Canvas>
+<Canvas of={ButtonGroupStories.Overview} />
 
 ## Props
 
@@ -57,33 +55,23 @@ ButtonGroup can be used to group related options. To emphasize groups of related
 
 ### Default
 
-<Canvas>
-  <Story of={ButtonGroupStories.Default} />
-</Canvas>
+<Canvas of={ButtonGroupStories.Default} />
 
 ### Tertiary
 
-<Canvas>
-  <Story of={ButtonGroupStories.Tertiary} />
-</Canvas>
+<Canvas of={ButtonGroupStories.Tertiary} />
 
 ### Disabled - all buttons
 
-<Canvas>
-  <Story of={ButtonGroupStories.Disabled} />
-</Canvas>
+<Canvas of={ButtonGroupStories.Disabled} />
 
 ### Disabled - single button
 
-<Canvas>
-  <Story of={ButtonGroupStories.DisabledSingeButton} />
-</Canvas>
+<Canvas of={ButtonGroupStories.DisabledSingeButton} />
 
 ### Size
 
-<Canvas>
-  <Story of={ButtonGroupStories.Size} />
-</Canvas>
+<Canvas of={ButtonGroupStories.Size} />
 
 ## Do’s and Don’ts
 
@@ -213,18 +201,14 @@ ButtonGroup can be used to group related options. To emphasize groups of related
 
 For example: on the views settings you can choose only one option.
 
-<Canvas>
-  <Story of={ButtonGroupStories.ButtonGroupInSettings} />
-</Canvas>
+<Canvas of={ButtonGroupStories.ButtonGroupInSettings} />
 
 ### Button group as toggle
 
 Use button group as toggle for change the view between two states.
 For on and off actions, use the <StorybookLink page="Inputs/Toggle">Toggle</StorybookLink> component.
 
-<Canvas>
-  <Story of={ButtonGroupStories.ButtonGroupAsToggle} />
-</Canvas>
+<Canvas of={ButtonGroupStories.ButtonGroupAsToggle} />
 
 ## Related components
 

--- a/packages/core/src/components/Checkbox/__stories__/checkbox.mdx
+++ b/packages/core/src/components/Checkbox/__stories__/checkbox.mdx
@@ -1,4 +1,4 @@
-import { Canvas, Meta, Story } from "@storybook/blocks";
+import { Canvas, Meta } from "@storybook/blocks";
 import Checkbox from "../Checkbox";
 import { createComponentTemplate, Link } from "vibe-storybook-components";
 import { createStoryMetaSettingsDecorator } from "../../../storybook";
@@ -33,9 +33,7 @@ export const checkboxTemplate = createComponentTemplate(Checkbox);
 
 Checkboxes allow users to select one or more items from a set of options.
 
-<Canvas>
-  <Story of={CheckboxStories.Overview} />
-</Canvas>
+<Canvas of={CheckboxStories.Overview} />
 
 ## Props
 
@@ -67,9 +65,7 @@ Checkboxes allow users to select one or more items from a set of options.
 
 Has 4 states: regular, hover, selected, and disabled.
 
-<Canvas>
-  <Story of={CheckboxStories.States} />
-</Canvas>
+<Canvas of={CheckboxStories.States} />
 
 ## Do’s and Don’ts
 
@@ -179,9 +175,7 @@ Has 4 states: regular, hover, selected, and disabled.
 
 Allows the user to choose a single option. For example: accept terms of use.
 
-<Canvas>
-  <Story of={CheckboxStories.SingleCheckbox} />
-</Canvas>
+<Canvas of={CheckboxStories.SingleCheckbox} />
 
 ## Related components
 

--- a/packages/core/src/components/Chips/__stories__/chips.mdx
+++ b/packages/core/src/components/Chips/__stories__/chips.mdx
@@ -1,4 +1,4 @@
-import { Canvas, Meta, Story } from "@storybook/blocks";
+import { Canvas, Meta } from "@storybook/blocks";
 import Chips from "../Chips";
 import { COUNTER, LABEL, TOOLTIP } from "../../../storybook/components/related-components/component-description-map";
 import { TipLabel } from "./chips.stories.helpers";
@@ -21,9 +21,7 @@ import * as ChipsStories from "./chips.stories";
 
 Chips are compact elements that represent an input, attribute, or action. They may display text, icons, or both.
 
-<Canvas>
-  <Story of={ChipsStories.Overview} />
-</Canvas>
+<Canvas of={ChipsStories.Overview} />
 
 ## Props
 
@@ -45,33 +43,23 @@ Chips are compact elements that represent an input, attribute, or action. They m
 
 ### With read only state
 
-<Canvas>
-  <Story of={ChipsStories.ChipsWithReadOnlyState} />
-</Canvas>
+<Canvas of={ChipsStories.ChipsWithReadOnlyState} />
 
 ### With icons
 
-<Canvas>
-  <Story of={ChipsStories.ChipsWithIcons} />
-</Canvas>
+<Canvas of={ChipsStories.ChipsWithIcons} />
 
 ### With avatars
 
-<Canvas>
-  <Story of={ChipsStories.ChipsWithAvatars} />
-</Canvas>
+<Canvas of={ChipsStories.ChipsWithAvatars} />
 
 ### Themes
 
-<Canvas>
-  <Story of={ChipsStories.Themes} />
-</Canvas>
+<Canvas of={ChipsStories.Themes} />
 
 ### Clickable chips
 
-<Canvas>
-  <Story of={ChipsStories.Clickable} />
-</Canvas>
+<Canvas of={ChipsStories.Clickable} />
 
 ### Color coded chips
 
@@ -82,17 +70,13 @@ e.g.
 <Chips label="GRASS_GREEN" color={Chips.colors.GRASS_GREEN} />
 ```
 
-<Canvas>
-  <Story of={ChipsStories.ChipsPalette} />
-</Canvas>
+<Canvas of={ChipsStories.ChipsPalette} />
 
 ### Chips on colored backgrounds
 
 When a chip appears on a background color identical to its color, use `showBorder` prop in order to add a distinctive white border.
 
-<Canvas>
-  <Story of={ChipsStories.OnColor} />
-</Canvas>
+<Canvas of={ChipsStories.OnColor} />
 
 ## Do’s and Don’ts
 
@@ -117,17 +101,13 @@ When a chip appears on a background color identical to its color, use `showBorde
 
 Sometimes when needed, chips can change fill color.
 
-<Canvas>
-  <Story of={ChipsStories.ColorfulChipsForDifferentContent} />
-</Canvas>
+<Canvas of={ChipsStories.ColorfulChipsForDifferentContent} />
 
 ### Chips in a person picker combo box
 
 Chips can be removable, and can be used in a multiple options selection use cases.
 
-<Canvas>
-  <Story of={ChipsStories.ChipsInAPersonPickerComboBox} />
-</Canvas>
+<Canvas of={ChipsStories.ChipsInAPersonPickerComboBox} />
 
 ## Related components
 

--- a/packages/core/src/components/Clickable/__stories__/Clickable.mdx
+++ b/packages/core/src/components/Clickable/__stories__/Clickable.mdx
@@ -1,4 +1,4 @@
-import { Canvas, Meta, Story } from "@storybook/blocks";
+import { Canvas, Meta } from "@storybook/blocks";
 import {
   BUTTON,
   HIDDEN_TEXT,
@@ -20,9 +20,7 @@ import { TipHookSolution } from "./Clickable.stories.helpers";
 
 An accessibility helper component, this component simulates a button on non button elements
 
-<Canvas>
-  <Story of={ClickableStories.Overview} />
-</Canvas>
+<Canvas of={ClickableStories.Overview} />
 
 ## Props
 
@@ -36,9 +34,7 @@ Clickable component supports two different states: regular state and disabled st
 The state only affects the component functionality (a user cannot interact with a disabled clickable component) and not the component appearance.
 You can use the component className and style props to change the component appearance.
 
-<Canvas>
-  <Story of={ClickableStories.States} />
-</Canvas>
+<Canvas of={ClickableStories.States} />
 
 <TipHookSolution />
 

--- a/packages/core/src/components/ColorPicker/__stories__/ColorPicker.mdx
+++ b/packages/core/src/components/ColorPicker/__stories__/ColorPicker.mdx
@@ -1,4 +1,4 @@
-import { Canvas, Meta, Story } from "@storybook/blocks";
+import { Canvas, Meta } from "@storybook/blocks";
 import * as ColorPickerStories from "./ColorPicker.stories";
 
 <Meta of={ColorPickerStories} />
@@ -14,9 +14,7 @@ import * as ColorPickerStories from "./ColorPicker.stories";
 
 ColorPicker is our component for selecting our content colors
 
-<Canvas>
-  <Story of={ColorPickerStories.Overview} />
-</Canvas>
+<Canvas of={ColorPickerStories.Overview} />
 
 ## Props
 
@@ -26,42 +24,30 @@ ColorPicker is our component for selecting our content colors
 
 ### With Indicator
 
-<Canvas>
-  <Story of={ColorPickerStories.WithIndicator} />
-</Canvas>
+<Canvas of={ColorPickerStories.WithIndicator} />
 
 ### Text Indication
 
-<Canvas>
-  <Story of={ColorPickerStories.TextIndication} />
-</Canvas>
+<Canvas of={ColorPickerStories.TextIndication} />
 
 ### Selected
 
-<Canvas>
-  <Story of={ColorPickerStories.Selected} />
-</Canvas>
+<Canvas of={ColorPickerStories.Selected} />
 
 ### No color
 
 Ability to revert to initial color
 
-<Canvas>
-  <Story of={ColorPickerStories.NoColor} />
-</Canvas>
+<Canvas of={ColorPickerStories.NoColor} />
 
 ### Selected icon
 
 Selected colors indication, when using multi-selection
 
-<Canvas>
-  <Story of={ColorPickerStories.SelectedIcon} />
-</Canvas>
+<Canvas of={ColorPickerStories.SelectedIcon} />
 
 ### Shapes
 
 The `ColorPicker` supports multiple shapes
 
-<Canvas>
-  <Story of={ColorPickerStories.Shapes} />
-</Canvas>
+<Canvas of={ColorPickerStories.Shapes} />

--- a/packages/core/src/components/Combobox/__stories__/combobox.mdx
+++ b/packages/core/src/components/Combobox/__stories__/combobox.mdx
@@ -1,4 +1,4 @@
-import { Canvas, Meta, Story } from "@storybook/blocks";
+import { Canvas, Meta } from "@storybook/blocks";
 import { Link } from "vibe-storybook-components";
 import Combobox from "../Combobox";
 import DialogContentContainer from "../../DialogContentContainer/DialogContentContainer";
@@ -23,9 +23,7 @@ import * as ComboboxStories from "./combobox.stories";
 
 Combobox allowing users to filter longer lists to only the selections matching a query.
 
-<Canvas>
-  <Story of={ComboboxStories.Overview} />
-</Canvas>
+<Canvas of={ComboboxStories.Overview} />
 
 ## Props
 
@@ -51,76 +49,56 @@ Combobox allowing users to filter longer lists to only the selections matching a
 
 Default Combobox can be used without dialog or as part of the layout.
 
-<Canvas>
-  <Story of={ComboboxStories.Default} />
-</Canvas>
+<Canvas of={ComboboxStories.Default} />
 
 ### Combobox inside a dialog
 
 Use this for Combobox that triggered by button.
 
-<Canvas>
-  <Story of={ComboboxStories.ComboboxInsideADialog} />
-</Canvas>
+<Canvas of={ComboboxStories.ComboboxInsideADialog} />
 
 ### Sizes
 
 We have three pre-defined sizes for Combobox width size: Small 200px, Medium 240px, Large 260px.
 
-<Canvas>
-  <Story of={ComboboxStories.Sizes} />
-</Canvas>
+<Canvas of={ComboboxStories.Sizes} />
 
 ### With categories
 
 When having a lot of options, you may use headings to categorize them.
 
-<Canvas>
-  <Story of={ComboboxStories.WithCategories} />
-</Canvas>
+<Canvas of={ComboboxStories.WithCategories} />
 
 ### With icons
 
-<Canvas>
-  <Story of={ComboboxStories.WithIcons} />
-</Canvas>
+<Canvas of={ComboboxStories.WithIcons} />
 
 ### With optionRenderer
 
-<Canvas>
-  <Story of={ComboboxStories.WithOptionRenderer} />
-</Canvas>
+<Canvas of={ComboboxStories.WithOptionRenderer} />
 
 ### With Button
 
 If Combobox requires action, use button component at the end of the list.
 
-<Canvas>
-  <Story of={ComboboxStories.WithButton} />
-</Canvas>
+<Canvas of={ComboboxStories.WithButton} />
 
 ### With creation when no items are available
 
-<Canvas>
-  <Story of={ComboboxStories.WithCreation} />
-</Canvas>
+<Canvas of={ComboboxStories.WithCreation} />
 
 ### With virtualization optimization
 
 When you display a large number of options, you may want to render only the options shown at a given moment to allow better performance and a
 better user experience.
 
-<Canvas>
-  <Story of={ComboboxStories.WithVirtualizationOptimization} />
-</Canvas>
+<Canvas of={ComboboxStories.WithVirtualizationOptimization} />
 
 ### Loading state
 
 If importing the Combobox options may take time, you reflect this to the user by using our Combobox loading mode.
 
-<Canvas>
-  <Story of={ComboboxStories.LoadingState} />
-</Canvas>
+<Canvas of={ComboboxStories.LoadingState} />
 
 ## Do’s and Don’ts
 
@@ -213,9 +191,7 @@ If importing the Combobox options may take time, you reflect this to the user by
 
 We are using Combobox component for our board person picker.
 
-<Canvas>
-  <Story of={ComboboxStories.ComboboxAsPersonPicker} />
-</Canvas>
+<Canvas of={ComboboxStories.ComboboxAsPersonPicker} />
 
 ## Related components
 

--- a/packages/core/src/components/Counter/__stories__/counter.mdx
+++ b/packages/core/src/components/Counter/__stories__/counter.mdx
@@ -1,4 +1,4 @@
-import { Canvas, Meta, Story } from "@storybook/blocks";
+import { Canvas, Meta } from "@storybook/blocks";
 import { Link } from "vibe-storybook-components";
 import Counter from "../Counter";
 import { CHIP, LABEL, TOOLTIP } from "../../../storybook/components/related-components/component-description-map";
@@ -22,9 +22,7 @@ import * as CounterStories from "./counter.stories";
 
 Counters show the count of some adjacent data.
 
-<Canvas>
-  <Story of={CounterStories.Overview} />
-</Canvas>
+<Canvas of={CounterStories.Overview} />
 
 ## Props
 
@@ -42,27 +40,19 @@ Counters show the count of some adjacent data.
 
 There are two sizes of counters
 
-<Canvas>
-  <Story of={CounterStories.Sizes} />
-</Canvas>
+<Canvas of={CounterStories.Sizes} />
 
 ### Colors
 
-<Canvas>
-  <Story of={CounterStories.Colors} />
-</Canvas>
+<Canvas of={CounterStories.Colors} />
 
 ### Outline
 
-<Canvas>
-  <Story of={CounterStories.Outline} />
-</Canvas>
+<Canvas of={CounterStories.Outline} />
 
 ### Limits
 
-<Canvas>
-  <Story of={CounterStories.Limits} />
-</Canvas>
+<Canvas of={CounterStories.Limits} />
 
 ## Do’s and Don’ts
 
@@ -102,25 +92,19 @@ There are two sizes of counters
 
 Used on the notification icon to indicate the number of new notifications.
 
-<Canvas>
-  <Story of={CounterStories.NotificationCounter} />
-</Canvas>
+<Canvas of={CounterStories.NotificationCounter} />
 
 ### Counter on inbox filters
 
 The counter represents the number of items on each topic.
 
-<Canvas>
-  <Story of={CounterStories.CounterOnInboxFilters} />
-</Canvas>
+<Canvas of={CounterStories.CounterOnInboxFilters} />
 
 ### Count the number of updates
 
 The counter represents the number of items on each topic.
 
-<Canvas>
-  <Story of={CounterStories.CountTheNumberOfUpdates} />
-</Canvas>
+<Canvas of={CounterStories.CountTheNumberOfUpdates} />
 
 ## Related components
 

--- a/packages/core/src/components/DatePicker/__stories__/datepicker.mdx
+++ b/packages/core/src/components/DatePicker/__stories__/datepicker.mdx
@@ -1,4 +1,4 @@
-import { Canvas, Meta, Story } from "@storybook/blocks";
+import { Canvas, Meta } from "@storybook/blocks";
 import {
   DIALOG_CONTENT_CONTAINER,
   DROPDOWN,
@@ -19,9 +19,7 @@ import * as DatepickerStories from "./datepicker.stories";
 
 A simple and reusable Datepicker component
 
-<Canvas>
-  <Story of={DatepickerStories.Overview} />
-</Canvas>
+<Canvas of={DatepickerStories.Overview} />
 
 ## Props
 
@@ -33,23 +31,17 @@ A simple and reusable Datepicker component
 
 Allows users to select a single date
 
-<Canvas>
-  <Story of={DatepickerStories.SingleDay} />
-</Canvas>
+<Canvas of={DatepickerStories.SingleDay} />
 
 ### Date range
 
 Allows users to select a date range
 
-<Canvas>
-  <Story of={DatepickerStories.DateRange} />
-</Canvas>
+<Canvas of={DatepickerStories.DateRange} />
 
 ### Number of months
 
-<Canvas>
-  <Story of={DatepickerStories.NumberOfMonths} />
-</Canvas>
+<Canvas of={DatepickerStories.NumberOfMonths} />
 
 ## Related components
 

--- a/packages/core/src/components/Dialog/__stories__/Dialog.mdx
+++ b/packages/core/src/components/Dialog/__stories__/Dialog.mdx
@@ -1,4 +1,4 @@
-import { Canvas, Meta, Story } from "@storybook/blocks";
+import { Canvas, Meta } from "@storybook/blocks";
 import { Link } from "vibe-storybook-components";
 import { AttentionBox, AttentionBoxLink } from "../../../components";
 import {
@@ -30,9 +30,7 @@ import * as DialogStories from "./Dialog.stories";
 The dialog component's purpose is to position a popup component nearby another element, such as any kind of a button.
 Please be aware that the dialog component is not responsible for the appearance features of the popup, such as its background color or size.
 
-<Canvas>
-  <Story of={DialogStories.Overview} />
-</Canvas>
+<Canvas of={DialogStories.Overview} />
 
 <TipDialogContentContainer />
 
@@ -70,49 +68,37 @@ Please be aware that the dialog component is not responsible for the appearance 
 
 ### Positions
 
-<Canvas>
-  <Story of={DialogStories.Positions} />
-</Canvas>
+<Canvas of={DialogStories.Positions} />
 
 ### Dialog show triggers
 
 We can choose what will be the related element's trigger which will be responsible for the dialog appearance
 
-<Canvas>
-  <Story of={DialogStories.ShowTriggers} />
-</Canvas>
+<Canvas of={DialogStories.ShowTriggers} />
 
 ### Dialog hide triggers
 
 We can set the triggers which will be responsible for hide the dialog
 
-<Canvas>
-  <Story of={DialogStories.HideTriggers} />
-</Canvas>
+<Canvas of={DialogStories.HideTriggers} />
 
 ### Controlled Dialog
 
 Manage the open and close state of the dialog. Note that `isOpen` is used and `showTrigger` is set to `[]` to disable the default triggers.
 
-<Canvas>
-  <Story of={DialogStories.ControlledDialog} />
-</Canvas>
+<Canvas of={DialogStories.ControlledDialog} />
 
 ### Dialog with tooltip
 
 Dialog has a <code>tooltip</code> prop which adds an arrow pointing toward the center of the reference element.
 
-<Canvas>
-  <Story of={DialogStories.DialogWithTooltip} />
-</Canvas>
+<Canvas of={DialogStories.DialogWithTooltip} />
 
 ### Dialog prevent container scroll
 
 Prevent containerSelector scroll when dialog open
 
-<Canvas>
-  <Story of={DialogStories.DisableScrollWhenDialogOpen} />
-</Canvas>
+<Canvas of={DialogStories.DisableScrollWhenDialogOpen} />
 
 <TipDevTipTechnicalPattern />
 

--- a/packages/core/src/components/DialogContentContainer/__stories__/DialogContentContainer.mdx
+++ b/packages/core/src/components/DialogContentContainer/__stories__/DialogContentContainer.mdx
@@ -1,4 +1,4 @@
-import { Canvas, Meta, Story } from "@storybook/blocks";
+import { Canvas, Meta } from "@storybook/blocks";
 import * as DialogContentContainerStories from "./DialogContentContainer.stories";
 
 <Meta of={DialogContentContainerStories} />
@@ -15,9 +15,7 @@ import * as DialogContentContainerStories from "./DialogContentContainer.stories
 
 This component is a style component, it provide the look and feel of elevation.
 
-<Canvas>
-  <Story of={DialogContentContainerStories.Overview} />
-</Canvas>
+<Canvas of={DialogContentContainerStories.Overview} />
 
 ## Props
 
@@ -31,12 +29,8 @@ This component is a style component, it provide the look and feel of elevation.
 
 ### Popover
 
-<Canvas>
-  <Story of={DialogContentContainerStories.Popover} />
-</Canvas>
+<Canvas of={DialogContentContainerStories.Popover} />
 
 ### Modal
 
-<Canvas>
-  <Story of={DialogContentContainerStories.Modal} />
-</Canvas>
+<Canvas of={DialogContentContainerStories.Modal} />

--- a/packages/core/src/components/Divider/__stories__/Divider.mdx
+++ b/packages/core/src/components/Divider/__stories__/Divider.mdx
@@ -1,4 +1,4 @@
-import { Canvas, Meta, Story } from "@storybook/blocks";
+import { Canvas, Meta } from "@storybook/blocks";
 import { CHIP, ICONS, LABEL } from "../../../storybook/components/related-components/component-description-map";
 import * as DividerStories from "./Divider.stories";
 
@@ -15,9 +15,7 @@ import * as DividerStories from "./Divider.stories";
 
 Divider create separation between two UI elements
 
-<Canvas>
-  <Story of={DividerStories.Overview} />
-</Canvas>
+<Canvas of={DividerStories.Overview} />
 
 ## Props
 
@@ -27,9 +25,7 @@ Divider create separation between two UI elements
 
 ### Directions
 
-<Canvas>
-  <Story of={DividerStories.Directions} />
-</Canvas>
+<Canvas of={DividerStories.Directions} />
 
 ## Related components
 

--- a/packages/core/src/components/Dropdown/__stories__/dropdown.mdx
+++ b/packages/core/src/components/Dropdown/__stories__/dropdown.mdx
@@ -1,4 +1,4 @@
-import { Canvas, Meta, Story } from "@storybook/blocks";
+import { Canvas, Meta } from "@storybook/blocks";
 import { Link } from "vibe-storybook-components";
 import {
   COMBOBOX,
@@ -26,9 +26,7 @@ import { TipDevTipPopover } from "./dropdown.stories.helpers";
 
 Dropdown present a list of options from which a user can select one or several.
 
-<Canvas>
-  <Story of={DropdownStories.Overview} />
-</Canvas>
+<Canvas of={DropdownStories.Overview} />
 
 ## Props
 
@@ -52,59 +50,41 @@ Dropdown present a list of options from which a user can select one or several.
 
 There are three sizes available: Small, Medium, and Large
 
-<Canvas>
-  <Story of={DropdownStories.Sizes} />
-</Canvas>
+<Canvas of={DropdownStories.Sizes} />
 
 ### Disabled
 
-<Canvas>
-  <Story of={DropdownStories.Disabled} />
-</Canvas>
+<Canvas of={DropdownStories.Disabled} />
 
 ### Readonly
 
-<Canvas>
-  <Story of={DropdownStories.Readonly} />
-</Canvas>
+<Canvas of={DropdownStories.Readonly} />
 
 ### RTL
 
-<Canvas>
-  <Story of={DropdownStories.Rtl} />
-</Canvas>
+<Canvas of={DropdownStories.Rtl} />
 
 ### Multi line states
 
 The Dropdown component supports multiple options selection in two different state - single line and multiple lines.
 
-<Canvas>
-  <Story of={DropdownStories.MultiChoiceWithDifferentStates} />
-</Canvas>
+<Canvas of={DropdownStories.MultiChoiceWithDifferentStates} />
 
 ### Dropdown with avatar
 
-<Canvas>
-  <Story of={DropdownStories.DropdownWithAvatar} />
-</Canvas>
+<Canvas of={DropdownStories.DropdownWithAvatar} />
 
 ### Dropdown with icon
 
-<Canvas>
-  <Story of={DropdownStories.DropdownWithIcon} />
-</Canvas>
+<Canvas of={DropdownStories.DropdownWithIcon} />
 
 ### Dropdown with chip colors
 
-<Canvas>
-  <Story of={DropdownStories.DropdownWithChipColors} />
-</Canvas>
+<Canvas of={DropdownStories.DropdownWithChipColors} />
 
 ### Dropdown with tooltips on items
 
-<Canvas>
-  <Story of={DropdownStories.DropdownWithTooltipsOnItems} />
-</Canvas>
+<Canvas of={DropdownStories.DropdownWithTooltipsOnItems} />
 
 ## Do’s and Don’ts
 
@@ -156,39 +136,29 @@ The Dropdown component supports multiple options selection in two different stat
 
 Inside the advanced filters, a user can select multiple people from the dropdown menu, and they will be shown as Chips.
 
-<Canvas>
-  <Story of={DropdownStories.DropdownWithChips} />
-</Canvas>
+<Canvas of={DropdownStories.DropdownWithChips} />
 
 ### Searchable Dropdown
 
 In case of multiple options, you can use the `onInputChange` prop to allow filtering options.
 
-<Canvas>
-  <Story of={DropdownStories.SearchableDropdown} />
-</Canvas>
+<Canvas of={DropdownStories.SearchableDropdown} />
 
 ### Dropdown with labels
 
 A dropdown menu can include labels.
 
-<Canvas>
-  <Story of={DropdownStories.DropdownWithLabels} />
-</Canvas>
+<Canvas of={DropdownStories.DropdownWithLabels} />
 
 ### Dropdown inside a form
 
 A classic dropdown presents options a user needs to choose from.
 
-<Canvas>
-  <Story of={DropdownStories.DropdownInsideAForm} />
-</Canvas>
+<Canvas of={DropdownStories.DropdownInsideAForm} />
 
 ### Dropdown with groups
 
-<Canvas>
-  <Story of={DropdownStories.DropdownWithGroups} />
-</Canvas>
+<Canvas of={DropdownStories.DropdownWithGroups} />
 
 ### Dropdown inside popover
 
@@ -197,33 +167,25 @@ component) or container with overflow hidden content.
 
 <TipDevTipPopover />
 
-<Canvas>
-  <Story of={DropdownStories.DropdownInsidePopover} />
-</Canvas>
+<Canvas of={DropdownStories.DropdownInsidePopover} />
 
 ### Dropdown with loading
 
 If importing the dropdown options may take time, you can reflect this to the user using Dropdown isLoading flag with optional custom message.
 
-<Canvas>
-  <Story of={DropdownStories.DropdownWithLoading} />
-</Canvas>
+<Canvas of={DropdownStories.DropdownWithLoading} />
 
 ### Dropdown with ref
 
 If you need to programmatically control Dropdown state, use `ref` prop. Pay attention that type of returned ref will be `StateManager` from <Link withoutSpacing href="https://react-select.com/home">`react-select`</Link> library.
 
-<Canvas>
-  <Story of={DropdownStories.DropdownWithRef} />
-</Canvas>
+<Canvas of={DropdownStories.DropdownWithRef} />
 
 ### Dropdown value selection
 
 Control the value selection mechanism with the <code>tabSelectsValue</code> (default: true) prop.
 
-<Canvas>
-  <Story of={DropdownStories.DropdownValueSelection} />
-</Canvas>
+<Canvas of={DropdownStories.DropdownValueSelection} />
 
 ## Related components
 

--- a/packages/core/src/components/EditableHeading/__stories__/EditableHeading.mdx
+++ b/packages/core/src/components/EditableHeading/__stories__/EditableHeading.mdx
@@ -1,5 +1,5 @@
 import EditableHeading from "../EditableHeading";
-import { Canvas, Meta, Story } from "@storybook/blocks";
+import { Canvas, Meta } from "@storybook/blocks";
 import { createComponentTemplate } from "vibe-storybook-components";
 import {
   EDITABLE_TEXT,
@@ -26,9 +26,7 @@ export const editableHeadingTemplate = createComponentTemplate(EditableHeading);
 
 Editable Heading allows users to seamlessly and dynamically edit in-line content. Its default state is a read-view, based on the <StorybookLink page="Text/Heading">Heading</StorybookLink> component, and it becomes editable after clicking on it.
 
-<Canvas>
-  <Story of={EditableHeadingStories.Overview} />
-</Canvas>
+<Canvas of={EditableHeadingStories.Overview} />
 
 ## Props
 
@@ -51,9 +49,7 @@ Editable Heading allows users to seamlessly and dynamically edit in-line content
 
 Editable heading can be used with any of the <StorybookLink page="Text/Heading">Heading</StorybookLink> component sizes and weights.
 
-<Canvas>
-  <Story of={EditableHeadingStories.Types} />
-</Canvas>
+<Canvas of={EditableHeadingStories.Types} />
 
 ## Related components
 

--- a/packages/core/src/components/EditableText/__stories__/EditableText.mdx
+++ b/packages/core/src/components/EditableText/__stories__/EditableText.mdx
@@ -1,4 +1,4 @@
-import { Canvas, Meta, Story } from "@storybook/blocks";
+import { Canvas, Meta } from "@storybook/blocks";
 import {
   EDITABLE_HEADING,
   HEADING,
@@ -22,9 +22,7 @@ import * as EditableTextStories from "./EditableText.stories";
 
 Editable text allows users to seamlessly and dynamically edit in-line content. Its default state is a read-view, based on the <StorybookLink page="Text/Text">Text</StorybookLink> component, and it becomes editable after clicking on it.
 
-<Canvas>
-  <Story of={EditableTextStories.Overview} />
-</Canvas>
+<Canvas of={EditableTextStories.Overview} />
 
 ## Props
 
@@ -47,9 +45,7 @@ Editable text allows users to seamlessly and dynamically edit in-line content. I
 
 Editable text can be used with any of the <StorybookLink page="Text/Text">Text</StorybookLink> component sizes and weights.
 
-<Canvas>
-  <Story of={EditableTextStories.Types} />
-</Canvas>
+<Canvas of={EditableTextStories.Types} />
 
 ## Related components
 

--- a/packages/core/src/components/ExpandCollapse/__stories__/ExpandCollapse.mdx
+++ b/packages/core/src/components/ExpandCollapse/__stories__/ExpandCollapse.mdx
@@ -1,4 +1,4 @@
-import { Canvas, Meta, Story } from "@storybook/blocks";
+import { Canvas, Meta } from "@storybook/blocks";
 import { ACCORDION, DROPDOWN, TABLE } from "../../../storybook/components/related-components/component-description-map";
 import { TipCombineMultiple } from "./ExpandCollapse.stories.helpers";
 import * as ExpandCollapseStories from "./ExpandCollapse.stories";
@@ -17,9 +17,7 @@ import * as ExpandCollapseStories from "./ExpandCollapse.stories";
 
 ExpandCollapse is a component that allows you to hide and show content.
 
-<Canvas>
-  <Story of={ExpandCollapseStories.Overview} />
-</Canvas>
+<Canvas of={ExpandCollapseStories.Overview} />
 
 <TipCombineMultiple />
 
@@ -31,29 +29,21 @@ ExpandCollapse is a component that allows you to hide and show content.
 
 ### Open by default
 
-<Canvas>
-  <Story of={ExpandCollapseStories.OpenByDefault} />
-</Canvas>
+<Canvas of={ExpandCollapseStories.OpenByDefault} />
 
 ### Controlled open state
 
 You can control the open state of the ExpandCollapse component by passing the <code>open</code> prop.
 
-<Canvas>
-  <Story of={ExpandCollapseStories.ControlledOpenState} />
-</Canvas>
+<Canvas of={ExpandCollapseStories.ControlledOpenState} />
 
 ### Custom header renderer
 
-<Canvas>
-  <Story of={ExpandCollapseStories.CustomHeaderRenderer} />
-</Canvas>
+<Canvas of={ExpandCollapseStories.CustomHeaderRenderer} />
 
 ### Without borders
 
-<Canvas>
-  <Story of={ExpandCollapseStories.WithoutBorders} />
-</Canvas>
+<Canvas of={ExpandCollapseStories.WithoutBorders} />
 
 ## Related components
 

--- a/packages/core/src/components/Flex/__stories__/Flex.mdx
+++ b/packages/core/src/components/Flex/__stories__/Flex.mdx
@@ -1,4 +1,4 @@
-import { Canvas, Meta, Story } from "@storybook/blocks";
+import { Canvas, Meta } from "@storybook/blocks";
 import { LIST, MENU, TABS } from "../../../storybook/components/related-components/component-description-map";
 import * as FlexStories from "./Flex.stories";
 
@@ -19,9 +19,7 @@ import * as FlexStories from "./Flex.stories";
 
 Use Flex component to position group of sub-elements in one dimension, horizontal or vertical, without being dependent on a custom CSS file for positioning the sub-elements.
 
-<Canvas>
-  <Story of={FlexStories.Overview} />
-</Canvas>
+<Canvas of={FlexStories.Overview} />
 
 ## Props
 
@@ -41,42 +39,30 @@ Use Flex component to position group of sub-elements in one dimension, horizonta
 
 ### Directions
 
-<Canvas>
-  <Story of={FlexStories.Directions} />
-</Canvas>
+<Canvas of={FlexStories.Directions} />
 
 ### Horizontal spacing between items
 
-<Canvas>
-  <Story of={FlexStories.HorizontalSpacingBetweenItems} />
-</Canvas>
+<Canvas of={FlexStories.HorizontalSpacingBetweenItems} />
 
 ### Vertical spacing between items
 
-<Canvas>
-  <Story of={FlexStories.VerticalSpacingBetweenItems} />
-</Canvas>
+<Canvas of={FlexStories.VerticalSpacingBetweenItems} />
 
 ### Horizontal positions
 
-<Canvas>
-  <Story of={FlexStories.HorizontalPositions} />
-</Canvas>
+<Canvas of={FlexStories.HorizontalPositions} />
 
 ### Vertical positions
 
-<Canvas>
-  <Story of={FlexStories.VerticalPositions} />
-</Canvas>
+<Canvas of={FlexStories.VerticalPositions} />
 
 ### Support multi lines layout
 
 You can display a layout that includes multiple lines using the flex component wrap mode.
 This mode allows the layout to break into multiple lines if all the component children cannot fit into one only.
 
-<Canvas>
-  <Story of={FlexStories.SupportMultiLinesLayout} />
-</Canvas>
+<Canvas of={FlexStories.SupportMultiLinesLayout} />
 
 ## Use cases and examples
 
@@ -84,9 +70,7 @@ This mode allows the layout to break into multiple lines if all the component ch
 
 You can use flex component for create responsive toolbars
 
-<Canvas>
-  <Story of={FlexStories.FlexAsToolbarContainer} />
-</Canvas>
+<Canvas of={FlexStories.FlexAsToolbarContainer} />
 
 ## Related components
 

--- a/packages/core/src/components/GridKeyboardNavigationContext/__stories__/useGridKeyboardNavigationContext.mdx
+++ b/packages/core/src/components/GridKeyboardNavigationContext/__stories__/useGridKeyboardNavigationContext.mdx
@@ -1,4 +1,4 @@
-import { Canvas, Meta, Story } from "@storybook/blocks";
+import { Canvas, Meta } from "@storybook/blocks";
 import * as UseGridKeyboardNavigationContextStories from "./useGridKeyboardNavigationContext.stories";
 
 <Meta of={UseGridKeyboardNavigationContextStories} />
@@ -15,9 +15,7 @@ import * as UseGridKeyboardNavigationContextStories from "./useGridKeyboardNavig
 
 A hook used to specify a connection between multiple navigable components, which are navigable between each other.
 
-<Canvas>
-  <Story of={UseGridKeyboardNavigationContextStories.Overview} />
-</Canvas>
+<Canvas of={UseGridKeyboardNavigationContextStories.Overview} />
 
 ## Usage
 
@@ -72,14 +70,10 @@ A hook used to specify a connection between multiple navigable components, which
 
 Disabled components can be skipped by adding a `disabled` (or `data-disabled`) to the referenced element.
 
-<Canvas>
-  <Story of={UseGridKeyboardNavigationContextStories.DisabledElements} />
-</Canvas>
+<Canvas of={UseGridKeyboardNavigationContextStories.DisabledElements} />
 
 ### Multiple Depths
 
 The hook can be used inside multiple depths, in more complex layout requirements.
 
-<Canvas>
-  <Story of={UseGridKeyboardNavigationContextStories.MultipleDepths} />
-</Canvas>
+<Canvas of={UseGridKeyboardNavigationContextStories.MultipleDepths} />

--- a/packages/core/src/components/Heading/__stories__/Heading.mdx
+++ b/packages/core/src/components/Heading/__stories__/Heading.mdx
@@ -1,4 +1,4 @@
-import { Canvas, Meta, Story } from "@storybook/blocks";
+import { Canvas, Meta } from "@storybook/blocks";
 import Heading from "../Heading";
 import {
   EDITABLE_HEADING,
@@ -26,9 +26,7 @@ import { TipEditableHeading } from "./Heading.stories.helpers";
 
 Heading components are used for titles at the top of pages and sub-sections.
 
-<Canvas>
-  <Story of={HeadingStories.Overview} />
-</Canvas>
+<Canvas of={HeadingStories.Overview} />
 
 ## Import
 
@@ -59,17 +57,13 @@ just like any other component.
 
 Heading component comes in three types: H1 (32px), H2 (24px), H3 (18px) and three weights: bold (700), normal (500), light (300)
 
-<Canvas>
-  <Story of={HeadingStories.TypesAndWeights} />
-</Canvas>
+<Canvas of={HeadingStories.TypesAndWeights} />
 
 ### Colors
 
 Heading component comes in four colors: primary, secondary, on primary, on inverted
 
-<Canvas>
-  <Story of={HeadingStories.Colors} />
-</Canvas>
+<Canvas of={HeadingStories.Colors} />
 
 ### Overflow
 
@@ -78,9 +72,7 @@ When the text is longer than its container and the ellipsis flag is on, the end 
 
 We support two kinds of ellipsis: single-line ellipsis with a tooltip displayed in hover or ellipsis after multiple lines. You can see examples for both use cases below.
 
-<Canvas>
-  <Story of={HeadingStories.Overflow} />
-</Canvas>
+<Canvas of={HeadingStories.Overflow} />
 
 ## Do’s and Don’ts
 
@@ -103,15 +95,11 @@ We support two kinds of ellipsis: single-line ellipsis with a tooltip displayed 
 
 ### Built-in page header (not editable)
 
-<Canvas>
-  <Story of={HeadingStories.BuiltInPageHeaderNotEditable} />
-</Canvas>
+<Canvas of={HeadingStories.BuiltInPageHeaderNotEditable} />
 
 ### Empty state heading
 
-<Canvas>
-  <Story of={HeadingStories.EmptyStateHeading} />
-</Canvas>
+<Canvas of={HeadingStories.EmptyStateHeading} />
 
 ## Related components
 

--- a/packages/core/src/components/HiddenText/__stories__/HiddenText.mdx
+++ b/packages/core/src/components/HiddenText/__stories__/HiddenText.mdx
@@ -1,4 +1,4 @@
-import { Canvas, Meta, Story } from "@storybook/blocks";
+import { Canvas, Meta } from "@storybook/blocks";
 import { Tip } from "vibe-storybook-components";
 import {
   CLICKABLE,
@@ -21,9 +21,7 @@ import * as HiddenTextStories from "./HiddenText.stories";
 
 Hidden text helps us to create a text which is accessible to screen reader users but not to users who see the screen.
 
-<Canvas>
-  <Story of={HiddenTextStories.Overview} />
-</Canvas>
+<Canvas of={HiddenTextStories.Overview} />
 
 ## Props
 

--- a/packages/core/src/components/Icon/__stories__/Icon.mdx
+++ b/packages/core/src/components/Icon/__stories__/Icon.mdx
@@ -1,4 +1,4 @@
-import { Canvas, Meta, Story } from "@storybook/blocks";
+import { Canvas, Meta } from "@storybook/blocks";
 import "./Icon.stories.module.scss";
 import * as IconStories from "./Icon.stories";
 
@@ -18,9 +18,7 @@ import * as IconStories from "./Icon.stories";
 
 Icon component is our component to unify the supported icon types (Vibe Icons, FontIcon and Custom SVG Icons)
 
-<Canvas>
-  <Story of={IconStories.Overview} />
-</Canvas>
+<Canvas of={IconStories.Overview} />
 
 ## Props
 
@@ -39,21 +37,15 @@ Icon component is our component to unify the supported icon types (Vibe Icons, F
 
 ### Vibe Icon
 
-<Canvas>
-  <Story of={IconStories.VibeIcon} />
-</Canvas>
+<Canvas of={IconStories.VibeIcon} />
 
 ### FontIcon
 
-<Canvas>
-  <Story of={IconStories.FontIcon} />
-</Canvas>
+<Canvas of={IconStories.FontIcon} />
 
 ### Custom SVG
 
-<Canvas>
-  <Story of={IconStories.CustomSvg} />
-</Canvas>
+<Canvas of={IconStories.CustomSvg} />
 
 ## States
 
@@ -61,9 +53,7 @@ Icon component is our component to unify the supported icon types (Vibe Icons, F
 
 As a default the icon will inherit the color of it's parent container
 
-<Canvas>
-  <Story of={IconStories.Color} />
-</Canvas>
+<Canvas of={IconStories.Color} />
 
 ## Icons List
 
@@ -73,6 +63,4 @@ Icons are exported by name from `monday-ui-react-core/icons`:
 import { DoubleCheck } from "monday-ui-react-core/icons";
 ```
 
-<Canvas>
-  <Story of={IconStories.IconsListStory} />
-</Canvas>
+<Canvas of={IconStories.IconsListStory} />

--- a/packages/core/src/components/IconButton/__stories__/IconButton.mdx
+++ b/packages/core/src/components/IconButton/__stories__/IconButton.mdx
@@ -1,4 +1,4 @@
-import { Canvas, Meta, Story } from "@storybook/blocks";
+import { Canvas, Meta } from "@storybook/blocks";
 import { Link } from "vibe-storybook-components";
 import IconButton from "../IconButton";
 import DialogContentContainer from "../../DialogContentContainer/DialogContentContainer";
@@ -24,9 +24,7 @@ import * as IconButtonStories from "./IconButton.stories";
 
 Icon button is a square button contains only icon with no visible text labels used mostly in control bars.
 
-<Canvas>
-  <Story of={IconButtonStories.Overview} />
-</Canvas>
+<Canvas of={IconButtonStories.Overview} />
 
 ## Props
 
@@ -56,31 +54,23 @@ Icon button is a square button contains only icon with no visible text labels us
 
 There can be more than one button in a screen, but to create the hierarchy of actions we need to use button kinds.
 
-<Canvas>
-  <Story of={IconButtonStories.Kinds} />
-</Canvas>
+<Canvas of={IconButtonStories.Kinds} />
 
 <TipMenuButton />
 
 ### Sizes
 
-<Canvas>
-  <Story of={IconButtonStories.Sizes} />
-</Canvas>
+<Canvas of={IconButtonStories.Sizes} />
 
 ### Active
 
-<Canvas>
-  <Story of={IconButtonStories.Active} />
-</Canvas>
+<Canvas of={IconButtonStories.Active} />
 
 ### Disabled
 
 Set disable button for something that isn’t usable. Use a tooltip on hover in order to indicate the reason of the disabled action.
 
-<Canvas>
-  <Story of={IconButtonStories.Disabled} />
-</Canvas>
+<Canvas of={IconButtonStories.Disabled} />
 
 ## Do’s and Don’ts
 
@@ -126,15 +116,11 @@ Set disable button for something that isn’t usable. Use a tooltip on hover in 
 
 ### Icon button as toolbar button
 
-<Canvas>
-  <Story of={IconButtonStories.IconButtonAsToolbarButton} />
-</Canvas>
+<Canvas of={IconButtonStories.IconButtonAsToolbarButton} />
 
 ### Icon button as close button
 
-<Canvas>
-  <Story of={IconButtonStories.IconButtonAsCloseButton} />
-</Canvas>
+<Canvas of={IconButtonStories.IconButtonAsCloseButton} />
 
 ## Related components
 

--- a/packages/core/src/components/Label/__stories__/label.mdx
+++ b/packages/core/src/components/Label/__stories__/label.mdx
@@ -1,4 +1,4 @@
-import { Canvas, Meta, Story } from "@storybook/blocks";
+import { Canvas, Meta } from "@storybook/blocks";
 import { Link } from "vibe-storybook-components";
 import Label from "../Label";
 import { CHIP, COUNTER, TOOLTIP } from "../../../storybook/components/related-components/component-description-map";
@@ -22,9 +22,7 @@ import { TipCheckYourself } from "./label.stories.helpers";
 
 A label indicates the status of an item.
 
-<Canvas>
-  <Story of={LabelStories.Overview} />
-</Canvas>
+<Canvas of={LabelStories.Overview} />
 
 ## Props
 
@@ -46,21 +44,15 @@ A label indicates the status of an item.
 
 ### Kinds
 
-<Canvas>
-  <Story of={LabelStories.Kinds} />
-</Canvas>
+<Canvas of={LabelStories.Kinds} />
 
 ### Colors
 
-<Canvas>
-  <Story of={LabelStories.Colors} />
-</Canvas>
+<Canvas of={LabelStories.Colors} />
 
 ### Clickable
 
-<Canvas>
-  <Story of={LabelStories.Clickable} />
-</Canvas>
+<Canvas of={LabelStories.Clickable} />
 
 ## Do’s and Don’ts
 
@@ -140,9 +132,7 @@ A label indicates the status of an item.
 
 In case of visual overload, use the secondary label in order to create hirarchy.
 
-<Canvas>
-  <Story of={LabelStories.SecondaryLabel} />
-</Canvas>
+<Canvas of={LabelStories.SecondaryLabel} />
 
 ## Related components
 

--- a/packages/core/src/components/LegacyEditableHeading/__stories__/LegacyEditableHeading.mdx
+++ b/packages/core/src/components/LegacyEditableHeading/__stories__/LegacyEditableHeading.mdx
@@ -1,5 +1,5 @@
 import { DeprecatedWarning, Link } from "vibe-storybook-components";
-import { Canvas, Meta, Story } from "@storybook/blocks";
+import { Canvas, Meta } from "@storybook/blocks";
 import * as LegacyEditableHeadingStories from "./LegacyEditableHeading.stories";
 
 <Meta of={LegacyEditableHeadingStories} />
@@ -30,9 +30,7 @@ import * as LegacyEditableHeadingStories from "./LegacyEditableHeading.stories";
 
 An extension of Heading component, it allows built in editing capabilities
 
-<Canvas>
-  <Story of={LegacyEditableHeadingStories.Overview} />
-</Canvas>
+<Canvas of={LegacyEditableHeadingStories.Overview} />
 
 ## Props
 
@@ -52,24 +50,16 @@ An extension of Heading component, it allows built in editing capabilities
 
 ### Heading types
 
-<Canvas>
-  <Story of={LegacyEditableHeadingStories.Types} />
-</Canvas>
+<Canvas of={LegacyEditableHeadingStories.Types} />
 
 ### Placeholder
 
-<Canvas>
-  <Story of={LegacyEditableHeadingStories.Placeholder} />
-</Canvas>
+<Canvas of={LegacyEditableHeadingStories.Placeholder} />
 
 ### With text highlight
 
-<Canvas>
-  <Story of={LegacyEditableHeadingStories.TextHighlight} />
-</Canvas>
+<Canvas of={LegacyEditableHeadingStories.TextHighlight} />
 
 ### With text colors
 
-<Canvas>
-  <Story of={LegacyEditableHeadingStories.Colors} />
-</Canvas>
+<Canvas of={LegacyEditableHeadingStories.Colors} />

--- a/packages/core/src/components/LegacyHeading/__stories__/LegacyHeading.mdx
+++ b/packages/core/src/components/LegacyHeading/__stories__/LegacyHeading.mdx
@@ -1,5 +1,5 @@
 import Heading from "../LegacyHeading";
-import { Canvas, Meta, Story } from "@storybook/blocks";
+import { Canvas, Meta } from "@storybook/blocks";
 import { DeprecatedWarning, Link } from "vibe-storybook-components";
 import {
   EDITABLE_HEADING,
@@ -40,9 +40,7 @@ import * as LegacyHeadingStories from "./LegacyHeading.stories";
 
 Heading components are used to title any page sections or sub-sections in top-level page sections.
 
-<Canvas>
-  <Story of={LegacyHeadingStories.Overview} />
-</Canvas>
+<Canvas of={LegacyHeadingStories.Overview} />
 
 ## Props
 
@@ -63,26 +61,20 @@ Heading components are used to title any page sections or sub-sections in top-le
 
 ### Sizes
 
-<Canvas>
-  <Story of={LegacyHeadingStories.Sizes} />
-</Canvas>
+<Canvas of={LegacyHeadingStories.Sizes} />
 
 ### Overflow
 
 Our heading component support overflow state.
 When the heading text is too long and the component includes an ellipsis flag, we will cut the end of the heading and display instead of it "...".
 
-<Canvas>
-  <Story of={LegacyHeadingStories.Overflow} />
-</Canvas>
+<Canvas of={LegacyHeadingStories.Overflow} />
 
 ### With text highlight
 
 Our heading component support text highlight.
 
-<Canvas>
-  <Story of={LegacyHeadingStories.TextHighlight} />
-</Canvas>
+<Canvas of={LegacyHeadingStories.TextHighlight} />
 
 ## Do’s and Don’ts
 
@@ -105,15 +97,11 @@ Our heading component support text highlight.
 
 ### Not editable header of a page
 
-<Canvas>
-  <Story of={LegacyHeadingStories.NotEditableHeaderOfAPage} />
-</Canvas>
+<Canvas of={LegacyHeadingStories.NotEditableHeaderOfAPage} />
 
 ### Empty state title
 
-<Canvas>
-  <Story of={LegacyHeadingStories.EmptyStateTitle} />
-</Canvas>
+<Canvas of={LegacyHeadingStories.EmptyStateTitle} />
 
 ## Related components
 

--- a/packages/core/src/components/Link/__stories__/Link.mdx
+++ b/packages/core/src/components/Link/__stories__/Link.mdx
@@ -1,4 +1,4 @@
-import { Canvas, Meta, Story } from "@storybook/blocks";
+import { Canvas, Meta } from "@storybook/blocks";
 import Link from "../Link.tsx";
 import { ExternalPage, Gallery } from "../../Icon/Icons";
 import { BREADCRUBMS, BUTTON, BADGE } from "../../../storybook/components/related-components/component-description-map";
@@ -22,9 +22,7 @@ import * as LinkStories from "./Link.stories";
 
 Link is an actionable text component with connection to another web pages.
 
-<Canvas>
-  <Story of={LinkStories.Overview} />
-</Canvas>
+<Canvas of={LinkStories.Overview} />
 
 ## Props
 
@@ -46,21 +44,15 @@ Link is an actionable text component with connection to another web pages.
 
 ### States
 
-<Canvas>
-  <Story of={LinkStories.States} />
-</Canvas>
+<Canvas of={LinkStories.States} />
 
 ### Right to left
 
-<Canvas>
-  <Story of={LinkStories.RightToLeft} />
-</Canvas>
+<Canvas of={LinkStories.RightToLeft} />
 
 ### With icons
 
-<Canvas>
-  <Story of={LinkStories.WithIcons} />
-</Canvas>
+<Canvas of={LinkStories.WithIcons} />
 
 ## Do’s and Don’ts
 
@@ -120,17 +112,13 @@ Link is an actionable text component with connection to another web pages.
 
 Use this menu to allow a user to either select one or more items from the list.
 
-<Canvas>
-  <Story of={LinkStories.ReferenceLink} />
-</Canvas>
+<Canvas of={LinkStories.ReferenceLink} />
 
 ### Shortening texts
 
 Use read more to shorten long paragraphs of text
 
-<Canvas>
-  <Story of={LinkStories.ShorteningTexts} />
-</Canvas>
+<Canvas of={LinkStories.ShorteningTexts} />
 
 ## Related components
 

--- a/packages/core/src/components/List/__stories__/List.mdx
+++ b/packages/core/src/components/List/__stories__/List.mdx
@@ -1,5 +1,5 @@
 import List from "../List";
-import { Canvas, Meta, Story } from "@storybook/blocks";
+import { Canvas, Meta } from "@storybook/blocks";
 import Board from "../../Icon/Icons/components/Board";
 import ListItem from "../../ListItem/ListItem";
 import ListItemIcon from "../../ListItemIcon/ListItemIcon";
@@ -34,9 +34,7 @@ import * as ListStories from "./List.stories";
 
 Lists is a group of actionable items containing primary and supplemental actions, which are represented by icons and text.
 
-<Canvas>
-  <Story of={ListStories.Overview} />
-</Canvas>
+<Canvas of={ListStories.Overview} />
 
 ## Props
 
@@ -58,30 +56,22 @@ Lists is a group of actionable items containing primary and supplemental actions
 
 ### List with categories
 
-<Canvas>
-  <Story of={ListStories.ListWithCategories} />
-</Canvas>
+<Canvas of={ListStories.ListWithCategories} />
 
 ### List with icons
 
-<Canvas>
-  <Story of={ListStories.ListWithIcons} />
-</Canvas>
+<Canvas of={ListStories.ListWithIcons} />
 
 ### List with avatars
 
-<Canvas>
-  <Story of={ListStories.ListWithAvatars} />
-</Canvas>
+<Canvas of={ListStories.ListWithAvatars} />
 
 ### List with virtualization optimization
 
 When you display a large number of items, you may want to render only the options shown at a given moment to allow better performance and a
 better user experience.
 
-<Canvas>
-  <Story of={ListStories.ListWithVirtualizationOptimization} />
-</Canvas>
+<Canvas of={ListStories.ListWithVirtualizationOptimization} />
 
 <Tip>
   While using virtualization optimization on your list component, please be aware your list needs to contain a constant
@@ -162,9 +152,7 @@ better user experience.
 
 ### List as leftpane
 
-<Canvas>
-  <Story of={ListStories.ListAsLeftpane} />
-</Canvas>
+<Canvas of={ListStories.ListAsLeftpane} />
 
 ## Related components
 

--- a/packages/core/src/components/ListItem/__stories__/ListItem.mdx
+++ b/packages/core/src/components/ListItem/__stories__/ListItem.mdx
@@ -1,4 +1,4 @@
-import { Canvas, Meta, Story } from "@storybook/blocks";
+import { Canvas, Meta } from "@storybook/blocks";
 import * as ListItemStories from "./ListItem.stories";
 
 <Meta of={ListItemStories} />
@@ -15,9 +15,7 @@ import * as ListItemStories from "./ListItem.stories";
 
 An item of a List component
 
-<Canvas>
-  <Story of={ListItemStories.Overview} />
-</Canvas>
+<Canvas of={ListItemStories.Overview} />
 
 ## Props
 
@@ -36,24 +34,16 @@ An item of a List component
 
 ### States
 
-<Canvas>
-  <Story of={ListItemStories.States} />
-</Canvas>
+<Canvas of={ListItemStories.States} />
 
 ### Sizes
 
-<Canvas>
-  <Story of={ListItemStories.Sizes} />
-</Canvas>
+<Canvas of={ListItemStories.Sizes} />
 
 ### List item with an icon
 
-<Canvas>
-  <Story of={ListItemStories.WithIcon} />
-</Canvas>
+<Canvas of={ListItemStories.WithIcon} />
 
 ### List item with an avatar
 
-<Canvas>
-  <Story of={ListItemStories.WithAvatar} />
-</Canvas>
+<Canvas of={ListItemStories.WithAvatar} />

--- a/packages/core/src/components/Loader/__stories__/Loader.mdx
+++ b/packages/core/src/components/Loader/__stories__/Loader.mdx
@@ -1,5 +1,5 @@
 import Loader from "../Loader";
-import { Canvas, Meta, Story } from "@storybook/blocks";
+import { Canvas, Meta } from "@storybook/blocks";
 import { ComponentRules, UsageGuidelines } from "vibe-storybook-components";
 import { Flex } from "../..";
 import {
@@ -28,9 +28,7 @@ import "./Loader.stories.scss";
 
 Circular loader indicates to user waiting state.
 
-<Canvas>
-  <Story of={LoaderStories.Overview} />
-</Canvas>
+<Canvas of={LoaderStories.Overview} />
 
 ## Props
 
@@ -52,29 +50,21 @@ Circular loader indicates to user waiting state.
 
 ### Size variants
 
-<Canvas>
-  <Story of={LoaderStories.SizeVariants} />
-</Canvas>
+<Canvas of={LoaderStories.SizeVariants} />
 
 ### Color variants
 
-<Canvas>
-  <Story of={LoaderStories.ColorVariants} />
-</Canvas>
+<Canvas of={LoaderStories.ColorVariants} />
 
 ### Custom colors
 
 If there is a need for color customization, css `color` attribute of a parent component can be used.
 
-<Canvas>
-  <Story of={LoaderStories.CustomColors} />
-</Canvas>
+<Canvas of={LoaderStories.CustomColors} />
 
 ### Visual variants
 
-<Canvas>
-  <Story of={LoaderStories.VisualVariants} />
-</Canvas>
+<Canvas of={LoaderStories.VisualVariants} />
 
 ## Do’s and Don’ts
 
@@ -109,17 +99,13 @@ If there is a need for color customization, css `color` attribute of a parent co
 
 Use loader in search field while filtering results.
 
-<Canvas>
-  <Story of={LoaderStories.LoaderInTextField} />
-</Canvas>
+<Canvas of={LoaderStories.LoaderInTextField} />
 
 ### Loader in button
 
 Indicate the loading status in button if content or an action is loading.
 
-<Canvas>
-  <Story of={LoaderStories.LoaderInButton} />
-</Canvas>
+<Canvas of={LoaderStories.LoaderInButton} />
 
 ## Related components
 

--- a/packages/core/src/components/Menu/Menu/__stories__/Menu.mdx
+++ b/packages/core/src/components/Menu/Menu/__stories__/Menu.mdx
@@ -1,4 +1,4 @@
-import { Canvas, Meta, Story } from "@storybook/blocks";
+import { Canvas, Meta } from "@storybook/blocks";
 import {
   COMBOBOX,
   DROPDOWN,
@@ -31,9 +31,7 @@ import * as MenuStories from "./Menu.stories";
 
 A menu is a navigable contextual list of items that can be selected.
 
-<Canvas>
-  <Story of={MenuStories.Overview} />
-</Canvas>
+<Canvas of={MenuStories.Overview} />
 
 ## Props
 
@@ -58,15 +56,11 @@ A menu is a navigable contextual list of items that can be selected.
 
 ### Sizes
 
-<Canvas>
-  <Story of={MenuStories.Sizes} />
-</Canvas>
+<Canvas of={MenuStories.Sizes} />
 
 ### Menu with icons
 
-<Canvas>
-  <Story of={MenuStories.MenuWithIcons} />
-</Canvas>
+<Canvas of={MenuStories.MenuWithIcons} />
 
 ## Do’s and Don’ts
 
@@ -104,23 +98,17 @@ A menu is a navigable contextual list of items that can be selected.
 
 ### Menu with sub menu
 
-<Canvas>
-  <Story of={MenuStories.MenuWithSubMenu} />
-</Canvas>
+<Canvas of={MenuStories.MenuWithSubMenu} />
 
 ### Menu with 2-depth sub menu
 
-<Canvas>
-  <Story of={MenuStories.MenuWith2DepthSubMenu} />
-</Canvas>
+<Canvas of={MenuStories.MenuWith2DepthSubMenu} />
 
 ### Menu with grid items and sub menu
 
 Grid menu items are navigable with a keyboard as well
 
-<Canvas>
-  <Story of={MenuStories.MenuWithGridItemsAndSubMenu} />
-</Canvas>
+<Canvas of={MenuStories.MenuWithGridItemsAndSubMenu} />
 
 ## Related components
 

--- a/packages/core/src/components/Menu/MenuDivider/__stories__/MenuDivider.mdx
+++ b/packages/core/src/components/Menu/MenuDivider/__stories__/MenuDivider.mdx
@@ -1,4 +1,4 @@
-import { Canvas, Meta, Story } from "@storybook/blocks";
+import { Canvas, Meta } from "@storybook/blocks";
 import * as MenuDividerStories from "./MenuDivider.stories";
 
 <Meta of={MenuDividerStories} />
@@ -15,9 +15,7 @@ import * as MenuDividerStories from "./MenuDivider.stories";
 
 Use menu divider for create separation between to menu items inside a menu
 
-<Canvas>
-  <Story of={MenuDividerStories.Overview} />
-</Canvas>
+<Canvas of={MenuDividerStories.Overview} />
 
 ## Props
 
@@ -27,12 +25,8 @@ Use menu divider for create separation between to menu items inside a menu
 
 ### Menu with divider
 
-<Canvas>
-  <Story of={MenuDividerStories.MenuWithDivider} />
-</Canvas>
+<Canvas of={MenuDividerStories.MenuWithDivider} />
 
 ### Sub menu with divider
 
-<Canvas>
-  <Story of={MenuDividerStories.SubMenuWithDivider} />
-</Canvas>
+<Canvas of={MenuDividerStories.SubMenuWithDivider} />

--- a/packages/core/src/components/Menu/MenuGridItem/__stories__/MenuGridItem.mdx
+++ b/packages/core/src/components/Menu/MenuGridItem/__stories__/MenuGridItem.mdx
@@ -1,4 +1,4 @@
-import { Canvas, Meta, Story } from "@storybook/blocks";
+import { Canvas, Meta } from "@storybook/blocks";
 import { MENU, MENU_BUTTON } from "../../../../storybook/components/related-components/component-description-map";
 import { TipOtherMenuItemComponents } from "./MenuGridItem.stories.helpers";
 import * as MenuGridItemStories from "./MenuGridItem.stories";
@@ -19,9 +19,7 @@ import * as MenuGridItemStories from "./MenuGridItem.stories";
 <code>MenuGridItem</code> can be used to place a grid-like, keyboard navigable container, inside a Menu. The user will be
 able to interact and navigate into and from the grid in a natural way.
 
-<Canvas>
-  <Story of={MenuGridItemStories.Overview} />
-</Canvas>
+<Canvas of={MenuGridItemStories.Overview} />
 
 ## Props
 
@@ -62,17 +60,13 @@ Since <code>MenuGridItem</code> should be used only inside a <code>Menu</code>, 
 
 Disabled items will be "skipped" when using keyboard navigation. Try it for yourself!
 
-<Canvas>
-  <Story of={MenuGridItemStories.WithDisabledStates} />
-</Canvas>
+<Canvas of={MenuGridItemStories.WithDisabledStates} />
 
 ### Inside sub-menus
 
 Keyboard navigation is also supported in sub-menus
 
-<Canvas>
-  <Story of={MenuGridItemStories.InsideSubMenus} />
-</Canvas>
+<Canvas of={MenuGridItemStories.InsideSubMenus} />
 
 ## Related components
 

--- a/packages/core/src/components/Menu/MenuItem/__stories__/MenuItem.mdx
+++ b/packages/core/src/components/Menu/MenuItem/__stories__/MenuItem.mdx
@@ -1,4 +1,4 @@
-import { Canvas, Meta, Story } from "@storybook/blocks";
+import { Canvas, Meta } from "@storybook/blocks";
 import { ComponentRuleWithLabelDo, ComponentRuleWithLabelDont } from "./MenuItem.stories.helpers";
 import * as MenuItemStories from "./MenuItem.stories";
 
@@ -16,9 +16,7 @@ import * as MenuItemStories from "./MenuItem.stories";
 
 Use menu item for drawing one options that displayed inside a menu.
 
-<Canvas>
-  <Story of={MenuItemStories.Overview} />
-</Canvas>
+<Canvas of={MenuItemStories.Overview} />
 
 ## Props
 
@@ -28,39 +26,27 @@ Use menu item for drawing one options that displayed inside a menu.
 
 ### States
 
-<Canvas>
-  <Story of={MenuItemStories.States} />
-</Canvas>
+<Canvas of={MenuItemStories.States} />
 
 ### Icons
 
-<Canvas>
-  <Story of={MenuItemStories.Icons} />
-</Canvas>
+<Canvas of={MenuItemStories.Icons} />
 
 ### Label
 
-<Canvas>
-  <Story of={MenuItemStories.Label} />
-</Canvas>
+<Canvas of={MenuItemStories.Label} />
 
 ### SubMenu
 
-<Canvas>
-  <Story of={MenuItemStories.SubMenu} />
-</Canvas>
+<Canvas of={MenuItemStories.SubMenu} />
 
 ### Overflow
 
-<Canvas>
-  <Story of={MenuItemStories.Overflow} />
-</Canvas>
+<Canvas of={MenuItemStories.Overflow} />
 
 ### Tooltips
 
-<Canvas>
-  <Story of={MenuItemStories.TooltipStory} />
-</Canvas>
+<Canvas of={MenuItemStories.TooltipStory} />
 
 ## Do's and Don’ts
 

--- a/packages/core/src/components/Menu/MenuItemButton/__stories__/MenuItemButton.mdx
+++ b/packages/core/src/components/Menu/MenuItemButton/__stories__/MenuItemButton.mdx
@@ -1,4 +1,4 @@
-import { Canvas, Meta, Story } from "@storybook/blocks";
+import { Canvas, Meta } from "@storybook/blocks";
 import { TipMenuGridItem } from "./MenuItemButton.stories.helpers";
 import * as MenuItemButtonStories from "./MenuItemButton.stories";
 
@@ -13,9 +13,7 @@ import * as MenuItemButtonStories from "./MenuItemButton.stories";
 
 ## Overview
 
-<Canvas>
-  <Story of={MenuItemButtonStories.Overview} />
-</Canvas>
+<Canvas of={MenuItemButtonStories.Overview} />
 
 ## Props
 
@@ -27,18 +25,12 @@ import * as MenuItemButtonStories from "./MenuItemButton.stories";
 
 ### States
 
-<Canvas>
-  <Story of={MenuItemButtonStories.States} />
-</Canvas>
+<Canvas of={MenuItemButtonStories.States} />
 
 ### Disabled
 
-<Canvas>
-  <Story of={MenuItemButtonStories.Disabled} />
-</Canvas>
+<Canvas of={MenuItemButtonStories.Disabled} />
 
 ### Icons
 
-<Canvas>
-  <Story of={MenuItemButtonStories.Icons} />
-</Canvas>
+<Canvas of={MenuItemButtonStories.Icons} />

--- a/packages/core/src/components/Menu/MenuTitle/__stories__/MenuTitle.mdx
+++ b/packages/core/src/components/Menu/MenuTitle/__stories__/MenuTitle.mdx
@@ -1,4 +1,4 @@
-import { Canvas, Meta, Story } from "@storybook/blocks";
+import { Canvas, Meta } from "@storybook/blocks";
 import * as MenuTitleStories from "./MenuTitle.stories";
 
 <Meta of={MenuTitleStories} />
@@ -12,9 +12,7 @@ import * as MenuTitleStories from "./MenuTitle.stories";
 
 ## Overview
 
-<Canvas>
-  <Story of={MenuTitleStories.Overview} />
-</Canvas>
+<Canvas of={MenuTitleStories.Overview} />
 
 ## Props
 
@@ -24,6 +22,4 @@ import * as MenuTitleStories from "./MenuTitle.stories";
 
 ### Caption positions
 
-<Canvas>
-  <Story of={MenuTitleStories.CaptionPlacements} />
-</Canvas>
+<Canvas of={MenuTitleStories.CaptionPlacements} />

--- a/packages/core/src/components/MenuButton/__stories__/MenuButton.mdx
+++ b/packages/core/src/components/MenuButton/__stories__/MenuButton.mdx
@@ -1,4 +1,4 @@
-import { Canvas, Meta, Story } from "@storybook/blocks";
+import { Canvas, Meta } from "@storybook/blocks";
 import {
   BUTTON,
   ICON_BUTTON,
@@ -21,9 +21,7 @@ import * as MenuButtonStories from "./MenuButton.stories";
 
 MenuButton is a component that opens a Dialog next to a button, the content of the dialog could be anything you want.
 
-<Canvas>
-  <Story of={MenuButtonStories.Overview} />
-</Canvas>
+<Canvas of={MenuButtonStories.Overview} />
 
 ## Props
 
@@ -42,33 +40,23 @@ MenuButton is a component that opens a Dialog next to a button, the content of t
 
 ### Sizes
 
-<Canvas>
-  <Story of={MenuButtonStories.Sizes} />
-</Canvas>
+<Canvas of={MenuButtonStories.Sizes} />
 
 ### Different Icon
 
-<Canvas>
-  <Story of={MenuButtonStories.DifferentIcon} />
-</Canvas>
+<Canvas of={MenuButtonStories.DifferentIcon} />
 
 ### With Text
 
-<Canvas>
-  <Story of={MenuButtonStories.WithText} />
-</Canvas>
+<Canvas of={MenuButtonStories.WithText} />
 
 ### With Text and Icon at the end
 
-<Canvas>
-  <Story of={MenuButtonStories.WithTextAndIconAtTheEnd} />
-</Canvas>
+<Canvas of={MenuButtonStories.WithTextAndIconAtTheEnd} />
 
 ### Disabled
 
-<Canvas>
-  <Story of={MenuButtonStories.Disabled} />
-</Canvas>
+<Canvas of={MenuButtonStories.Disabled} />
 
 ### Custom trigger element
 

--- a/packages/core/src/components/Modal/__stories__/modal.mdx
+++ b/packages/core/src/components/Modal/__stories__/modal.mdx
@@ -1,5 +1,5 @@
 import { ComponentRules, UsageGuidelines } from "vibe-storybook-components";
-import { Canvas, Meta, Story } from "@storybook/blocks";
+import { Canvas, Meta } from "@storybook/blocks";
 import { DIALOG, TIPSEEN, TOOLTIP } from "../../../storybook/components/related-components/component-description-map";
 import {
   DialogAsModalBadExample,
@@ -28,9 +28,7 @@ import * as ModalStories from "./modal.stories";
 Modal allows the user to focus on one task or a piece of information, by popping-up and blocking the page content until the modal task is completed, or until the user dismisses the action.
 Use modal for short and non-frequent tasks. For common tasks consider using the main flow.
 
-<Canvas>
-  <Story of={ModalStories.Overview} />
-</Canvas>
+<Canvas of={ModalStories.Overview} />
 
 ## Props
 
@@ -65,18 +63,14 @@ Use modal for short and non-frequent tasks. For common tasks consider using the 
 
 Use the ModalHeader component to display a Header with an icon
 
-<Canvas>
-  <Story of={ModalStories.ModalWithIcon} />
-</Canvas>
+<Canvas of={ModalStories.ModalWithIcon} />
 
 ### Alert Modal
 
 Use the <code>alertDialog</code> boolean prop in order to allow closing the modal only by the close buttons and not by ESC or by
 clicking outside. Use this variant in case of sensitive or important messages, and in modals that requires data from the user, such as forms.
 
-<Canvas>
-  <Story of={ModalStories.AlertModal} />
-</Canvas>
+<Canvas of={ModalStories.AlertModal} />
 
 ## Do’s and Don’ts
 
@@ -105,9 +99,7 @@ clicking outside. Use this variant in case of sensitive or important messages, a
 
 ### Modal with editable title
 
-<Canvas>
-  <Story of={ModalStories.ModalWithEditableTitle} />
-</Canvas>
+<Canvas of={ModalStories.ModalWithEditableTitle} />
 
 ## Related components
 

--- a/packages/core/src/components/MultiStepIndicator/__stories__/multiStepIndicator.mdx
+++ b/packages/core/src/components/MultiStepIndicator/__stories__/multiStepIndicator.mdx
@@ -1,5 +1,5 @@
 import MultiStepIndicator from "../MultiStepIndicator";
-import { Canvas, Meta, Story } from "@storybook/blocks";
+import { Canvas, Meta } from "@storybook/blocks";
 import { BREADCRUBMS, STEPS, TABS } from "../../../storybook/components/related-components/component-description-map";
 import { firstSteps, secondSteps, thirdSteps, TipNotWhatYouAreLookingFor } from "./multiStepIndicator.stories.helpers";
 import * as MultiStepIndicatorStories from "./multiStepIndicator.stories";
@@ -21,9 +21,7 @@ import * as MultiStepIndicatorStories from "./multiStepIndicator.stories";
 
 Tabular navigation component that helps users visualize and interact with a multi-step process.
 
-<Canvas>
-  <Story of={MultiStepIndicatorStories.Overview} />
-</Canvas>
+<Canvas of={MultiStepIndicatorStories.Overview} />
 
 ## Props
 
@@ -47,39 +45,29 @@ Tabular navigation component that helps users visualize and interact with a mult
 
 Placements
 
-<Canvas>
-  <Story of={MultiStepIndicatorStories.Placements} />
-</Canvas>
+<Canvas of={MultiStepIndicatorStories.Placements} />
 
 ### Types
 
 There are 4 types: Primary, success, danger, dark.
 
-<Canvas>
-  <Story of={MultiStepIndicatorStories.Types} />
-</Canvas>
+<Canvas of={MultiStepIndicatorStories.Types} />
 
 ### Sizes
 
 Compact is a smaller version of the Regular Wizard Stepper, and is suitable for smaller containers. In case you need to display more content, use the Regular size. As of now, vertical placement is not supported.
 
-<Canvas>
-  <Story of={MultiStepIndicatorStories.Sizes} />
-</Canvas>
+<Canvas of={MultiStepIndicatorStories.Sizes} />
 
 ### Fulfilled Icons
 
-<Canvas>
-  <Story of={MultiStepIndicatorStories.FulfilledIcons} />
-</Canvas>
+<Canvas of={MultiStepIndicatorStories.FulfilledIcons} />
 
 ### Transition Animation
 
 State transition automatic example
 
-<Canvas>
-  <Story of={MultiStepIndicatorStories.TransitionAnimation} />
-</Canvas>
+<Canvas of={MultiStepIndicatorStories.TransitionAnimation} />
 
 ## Do’s and Don’ts
 
@@ -146,9 +134,7 @@ State transition automatic example
 
 ### Multi step wizard
 
-<Canvas>
-  <Story of={MultiStepIndicatorStories.MultiStepWizard} />
-</Canvas>
+<Canvas of={MultiStepIndicatorStories.MultiStepWizard} />
 
 ## Related components
 

--- a/packages/core/src/components/ProgressBars/LinearProgressBar/__stories__/linearProgressBar.mdx
+++ b/packages/core/src/components/ProgressBars/LinearProgressBar/__stories__/linearProgressBar.mdx
@@ -1,4 +1,4 @@
-import { Canvas, Meta, Story } from "@storybook/blocks";
+import { Canvas, Meta } from "@storybook/blocks";
 import {
   SKELETON,
   SPINNER,
@@ -28,9 +28,7 @@ import * as LinearProgressBarStories from "./linearProgressBar.stories";
 
 Progress bars show continuous progress through a process, such as a percentage value. They show how much progress is complete and how much remains.
 
-<Canvas>
-  <Story of={LinearProgressBarStories.Overview} />
-</Canvas>
+<Canvas of={LinearProgressBarStories.Overview} />
 
 ## Props
 
@@ -48,21 +46,15 @@ Progress bars show continuous progress through a process, such as a percentage v
 
 ### Regular
 
-<Canvas>
-  <Story of={LinearProgressBarStories.Regular} />
-</Canvas>
+<Canvas of={LinearProgressBarStories.Regular} />
 
 ### With secondary value
 
-<Canvas>
-  <Story of={LinearProgressBarStories.WithSecondaryValue} />
-</Canvas>
+<Canvas of={LinearProgressBarStories.WithSecondaryValue} />
 
 ### Multi progress bar
 
-<Canvas>
-  <Story of={LinearProgressBarStories.MultiProgressBar} />
-</Canvas>
+<Canvas of={LinearProgressBarStories.MultiProgressBar} />
 
 ## Do’s and Don’ts
 
@@ -87,15 +79,11 @@ Progress bars show continuous progress through a process, such as a percentage v
 
 The user can see in a clear way the number of items used in the account.
 
-<Canvas>
-  <Story of={LinearProgressBarStories.ProgressBarAsACounter} />
-</Canvas>
+<Canvas of={LinearProgressBarStories.ProgressBarAsACounter} />
 
 ### Progress bar as loading indicator
 
-<Canvas>
-  <Story of={LinearProgressBarStories.ProgressBarAsLoadingIndicator} />
-</Canvas>
+<Canvas of={LinearProgressBarStories.ProgressBarAsLoadingIndicator} />
 
 ## Related components
 

--- a/packages/core/src/components/RadioButton/__stories__/radioButton.mdx
+++ b/packages/core/src/components/RadioButton/__stories__/radioButton.mdx
@@ -1,4 +1,4 @@
-import { Canvas, Meta, Story } from "@storybook/blocks";
+import { Canvas, Meta } from "@storybook/blocks";
 import { Link } from "vibe-storybook-components";
 import RadioButton from "../RadioButton";
 import { CHECKBOX, DROPDOWN, TOGGLE } from "../../../storybook/components/related-components/component-description-map";
@@ -23,9 +23,7 @@ import * as RadioButtonStories from "./radioButton.stories";
 
 A radio represents an item in a single selection list.
 
-<Canvas>
-  <Story of={RadioButtonStories.Overview} />
-</Canvas>
+<Canvas of={RadioButtonStories.Overview} />
 
 ## Props
 
@@ -50,9 +48,7 @@ A radio represents an item in a single selection list.
 
 Radio buttons have 3 states: regular, selected, and disabled.
 
-<Canvas>
-  <Story of={RadioButtonStories.States} />
-</Canvas>
+<Canvas of={RadioButtonStories.States} />
 
 ## Do’s and Don’ts
 
@@ -119,15 +115,11 @@ Radio buttons have 3 states: regular, selected, and disabled.
 
 The user needs to select only one option.
 
-<Canvas>
-  <Story of={RadioButtonStories.RadioButtonInItemsList} />
-</Canvas>
+<Canvas of={RadioButtonStories.RadioButtonInItemsList} />
 
 Controlled externally.
 
-<Canvas>
-  <Story of={RadioButtonStories.ControlledRadioButtons} />
-</Canvas>
+<Canvas of={RadioButtonStories.ControlledRadioButtons} />
 
 ## Related components
 

--- a/packages/core/src/components/ResponsiveList/__stories__/ResponsiveList.mdx
+++ b/packages/core/src/components/ResponsiveList/__stories__/ResponsiveList.mdx
@@ -1,4 +1,4 @@
-import { Canvas, Meta, Story } from "@storybook/blocks";
+import { Canvas, Meta } from "@storybook/blocks";
 import * as ResponsiveListStories from "./ResponsiveList.stories";
 
 <Meta of={ResponsiveListStories} />
@@ -15,9 +15,7 @@ import * as ResponsiveListStories from "./ResponsiveList.stories";
 ResponsiveList is a helper component, it is in charge of "moving" elements when there container is overflowing. It moves them to a list at the end of the container.
 (the blue handle is a resize handler - not part of the component)
 
-<Canvas>
-  <Story of={ResponsiveListStories.Overview} />
-</Canvas>
+<Canvas of={ResponsiveListStories.Overview} />
 
 ## Props
 

--- a/packages/core/src/components/Search/__stories__/Search.mdx
+++ b/packages/core/src/components/Search/__stories__/Search.mdx
@@ -1,4 +1,4 @@
-import { Canvas, Meta, Story } from "@storybook/blocks";
+import { Canvas, Meta } from "@storybook/blocks";
 import { UsageGuidelines } from "vibe-storybook-components";
 import {
   COMBOBOX,
@@ -25,9 +25,7 @@ import * as SearchStories from "./Search.stories";
 
 Search lets users quickly find relevant content. A search field allows a user to type a word or phrase to filter through a large amount of data without navigation.
 
-<Canvas>
-  <Story of={SearchStories.Overview} />
-</Canvas>
+<Canvas of={SearchStories.Overview} />
 
 ## Props
 
@@ -53,17 +51,13 @@ Search lets users quickly find relevant content. A search field allows a user to
 
 There are three sizes available: Small (32px), Medium (40px), and Large (48px).
 
-<Canvas>
-  <Story of={SearchStories.Sizes} />
-</Canvas>
+<Canvas of={SearchStories.Sizes} />
 
 ## Use cases and examples
 
 ### Filter in combobox
 
-<Canvas>
-  <Story of={SearchStories.FilterInCombobox} />
-</Canvas>
+<Canvas of={SearchStories.FilterInCombobox} />
 
 ## Related components
 

--- a/packages/core/src/components/Skeleton/__stories__/skeleton.mdx
+++ b/packages/core/src/components/Skeleton/__stories__/skeleton.mdx
@@ -1,5 +1,5 @@
 import Skeleton from "../Skeleton";
-import { Canvas, Meta, Story } from "@storybook/blocks";
+import { Canvas, Meta } from "@storybook/blocks";
 import {
   COUNTER,
   LINEAR_PROGRESS_BAR,
@@ -26,9 +26,7 @@ import "./skeleton.stories.scss";
 
 Skeleton loading componet used to indicate content and ui loading that will appear after its loaded. It helps to decrease perceived duration time
 
-<Canvas>
-  <Story of={SkeletonStories.Overview} />
-</Canvas>
+<Canvas of={SkeletonStories.Overview} />
 
 ## Props
 
@@ -51,17 +49,13 @@ Skeleton loading componet used to indicate content and ui loading that will appe
 
 Use shaes to mimic Avatars, images, buttons etc...
 
-<Canvas>
-  <Story of={SkeletonStories.Shapes} />
-</Canvas>
+<Canvas of={SkeletonStories.Shapes} />
 
 ### Text
 
 Presents a classic menu or equivalent picker
 
-<Canvas>
-  <Story of={SkeletonStories.Text} />
-</Canvas>
+<Canvas of={SkeletonStories.Text} />
 
 ## Do’s and Don’ts
 
@@ -125,9 +119,7 @@ Presents a classic menu or equivalent picker
 
 Use this menu to allow a user to either select one or more items from the list.
 
-<Canvas>
-  <Story of={SkeletonStories.UpdateInTheSystem} />
-</Canvas>
+<Canvas of={SkeletonStories.UpdateInTheSystem} />
 
 ## Related components
 

--- a/packages/core/src/components/Slider/__stories__/Slider.mdx
+++ b/packages/core/src/components/Slider/__stories__/Slider.mdx
@@ -1,4 +1,4 @@
-import { Canvas, Meta, Story } from "@storybook/blocks";
+import { Canvas, Meta } from "@storybook/blocks";
 import { UsageGuidelines } from "vibe-storybook-components";
 import {
   LINEAR_PROGRESS_BAR,
@@ -23,9 +23,7 @@ import * as SliderStories from "./Slider.stories";
 
 Slider is a visual input component that reflects current state status in its appearance.
 
-<Canvas>
-  <Story of={SliderStories.Overview} />
-</Canvas>
+<Canvas of={SliderStories.Overview} />
 
 ## Props
 
@@ -50,57 +48,43 @@ Slider is a visual input component that reflects current state status in its app
 
 Sizes small/medium/large are available.
 
-<Canvas>
-  <Story of={SliderStories.Sizes} />
-</Canvas>
+<Canvas of={SliderStories.Sizes} />
 
 ### Ranged Slider
 
 Slider can define range instead of single value
 
-<Canvas>
-  <Story of={SliderStories.Ranged} />
-</Canvas>
+<Canvas of={SliderStories.Ranged} />
 
 ### Colors
 
 Color Modes primary/positive/negative are available.
 
-<Canvas>
-  <Story of={SliderStories.Colors} />
-</Canvas>
+<Canvas of={SliderStories.Colors} />
 
 ### Disabled
 
 Slider can be disabled.
 
-<Canvas>
-  <Story of={SliderStories.Disabled} />
-</Canvas>
+<Canvas of={SliderStories.Disabled} />
 
 ### With labels
 
 Indicate selection at Label, Add Prefix and/or Postfix Icons or Labels
 
-<Canvas>
-  <Story of={SliderStories.WithLabels} />
-</Canvas>
+<Canvas of={SliderStories.WithLabels} />
 
 ### Always show Slider's value
 
 Always show value of slider (instead of Tooltip).
 
-<Canvas>
-  <Story of={SliderStories.ShowValue} />
-</Canvas>
+<Canvas of={SliderStories.ShowValue} />
 
 ### Limit and Step
 
 Limit and Step can be customized.
 
-<Canvas>
-  <Story of={SliderStories.LimitsSteps} />
-</Canvas>
+<Canvas of={SliderStories.LimitsSteps} />
 
 ### Customisation
 
@@ -108,9 +92,7 @@ Custom ID, custom `data-testid` and Custom Class. Add Custom Items as Prefix and
 
 **Important!** Please use customisation very careful, only if you really need it. Check twice with your Product/Designer.
 
-<Canvas>
-  <Story of={SliderStories.Customisation} />
-</Canvas>
+<Canvas of={SliderStories.Customisation} />
 
 ## Related components
 

--- a/packages/core/src/components/SplitButton/__stories__/splitButton.mdx
+++ b/packages/core/src/components/SplitButton/__stories__/splitButton.mdx
@@ -1,4 +1,4 @@
-import { Canvas, Meta, Story } from "@storybook/blocks";
+import { Canvas, Meta } from "@storybook/blocks";
 import { Link, UsageGuidelines } from "vibe-storybook-components";
 import SplitButton from "../SplitButton";
 import Button from "../../Button/Button";
@@ -24,9 +24,7 @@ import * as SplitButtonStories from "./splitButton.stories";
 
 A split button is a dual-function menu button that offers a default action as well as the possibility of choosing a secondary action, by selecting from a set of alternatives.
 
-<Canvas>
-  <Story of={SplitButtonStories.Overview} />
-</Canvas>
+<Canvas of={SplitButtonStories.Overview} />
 
 ## Props
 
@@ -51,23 +49,17 @@ A split button is a dual-function menu button that offers a default action as we
 
 The split button has three variants: primary, secondary, and tertiary.
 
-<Canvas>
-  <Story of={SplitButtonStories.Types} />
-</Canvas>
+<Canvas of={SplitButtonStories.Types} />
 
 ### Sizes
 
 The split button has supports multiple sizes: small, medium and large.
 
-<Canvas>
-  <Story of={SplitButtonStories.Sizes} />
-</Canvas>
+<Canvas of={SplitButtonStories.Sizes} />
 
 ### Icon usage
 
-<Canvas>
-  <Story of={SplitButtonStories.SplitButtonWithIcons} />
-</Canvas>
+<Canvas of={SplitButtonStories.SplitButtonWithIcons} />
 
 ## Do’s and Don’ts
 
@@ -170,17 +162,13 @@ The split button has supports multiple sizes: small, medium and large.
 
 Use template is the main action.
 
-<Canvas>
-  <Story of={SplitButtonStories.SplitButtonAsThePrimaryAction} />
-</Canvas>
+<Canvas of={SplitButtonStories.SplitButtonAsThePrimaryAction} />
 
 ### Secondary split button
 
 When there’s already a primary button in the view, use a secondary split button.
 
-<Canvas>
-  <Story of={SplitButtonStories.SecondarySplitButton} />
-</Canvas>
+<Canvas of={SplitButtonStories.SecondarySplitButton} />
 
 ### Custom menu
 
@@ -188,9 +176,7 @@ The split button can accept a custom Menu in case there's a need to override the
 
 Notice to always include `focusItemIndexOnMount` prop for accessibility reasons when using custom menus.
 
-<Canvas>
-  <Story of={SplitButtonStories.CustomMenu} />
-</Canvas>
+<Canvas of={SplitButtonStories.CustomMenu} />
 
 ## Related components
 

--- a/packages/core/src/components/Steps/__stories__/steps.mdx
+++ b/packages/core/src/components/Steps/__stories__/steps.mdx
@@ -1,4 +1,4 @@
-import { Canvas, Meta, Story } from "@storybook/blocks";
+import { Canvas, Meta } from "@storybook/blocks";
 import { StepsGalleryDontTemplate, StepsNumbersDoTemplate } from "./steps.stories.helpers";
 import {
   BREADCRUBMS,
@@ -25,9 +25,7 @@ import * as StepsStories from "./steps.stories";
 
 Steps display progress through a sequence of logical and numbered steps. They may also be used for navigation.
 
-<Canvas>
-  <Story of={StepsStories.Overview} />
-</Canvas>
+<Canvas of={StepsStories.Overview} />
 
 ## Props
 
@@ -49,15 +47,11 @@ Steps display progress through a sequence of logical and numbered steps. They ma
 
 Steps with a number view or gallery view.
 
-<Canvas>
-  <Story of={StepsStories.Types} />
-</Canvas>
+<Canvas of={StepsStories.Types} />
 
 ### On primary
 
-<Canvas>
-  <Story of={StepsStories.OnPrimary} />
-</Canvas>
+<Canvas of={StepsStories.OnPrimary} />
 
 ## Do’s and Don’ts
 
@@ -82,17 +76,13 @@ Steps with a number view or gallery view.
 
 Navigable steps with proper code example.
 
-<Canvas>
-  <Story of={StepsStories.NavigableSteps} />
-</Canvas>
+<Canvas of={StepsStories.NavigableSteps} />
 
 ### Steps inside a tipseen
 
 Our Tipseen component includes support for steps as content.
 
-<Canvas>
-  <Story of={StepsStories.StepsInsideATipseen} />
-</Canvas>
+<Canvas of={StepsStories.StepsInsideATipseen} />
 
 ## Related components
 

--- a/packages/core/src/components/Table/Table/__stories__/table.mdx
+++ b/packages/core/src/components/Table/Table/__stories__/table.mdx
@@ -1,4 +1,4 @@
-import { Canvas, Meta, Story } from "@storybook/blocks";
+import { Canvas, Meta } from "@storybook/blocks";
 import Table from "../Table";
 import TableHeader from "../../TableHeader/TableHeader";
 import TableHeaderCell from "../../TableHeaderCell/TableHeaderCell";
@@ -40,9 +40,7 @@ import styles from "./table.stories.module.scss";
 
 Tables are used to organize data, making it easier to understand.
 
-<Canvas>
-  <Story of={TableStories.Overview} />
-</Canvas>
+<Canvas of={TableStories.Overview} />
 
 ## Props
 
@@ -66,42 +64,32 @@ The table is available with or without an outer border. When using a table insid
 
 Sorting, Icons and Information added to selected columns
 
-<Canvas>
-  <Story of={TableStories.TableHeaderFunctionality} />
-</Canvas>
+<Canvas of={TableStories.TableHeaderFunctionality} />
 
 ## Loading
 
 Using skeleton
 
-<Canvas>
-  <Story of={TableStories.Loading} />
-</Canvas>
+<Canvas of={TableStories.Loading} />
 
 ## Scroll
 
 Table with both vertical and horizontal scroll
 
-<Canvas>
-  <Story of={TableStories.Scroll} />
-</Canvas>
+<Canvas of={TableStories.Scroll} />
 
 ## Virtualized Scroll
 
 This is an example of a table with 5000 rows
 
-<Canvas>
-  <Story of={TableStories.VirtualizedScroll} />
-</Canvas>
+<Canvas of={TableStories.VirtualizedScroll} />
 
 ## Highlighted row
 
 Use a highlighted row to mark a single row of the table.
 A highlighted row allows adding additional information for the entire row, using a system trigger such as a side-panel or model.
 
-<Canvas>
-  <Story of={TableStories.HighlightedRow} />
-</Canvas>
+<Canvas of={TableStories.HighlightedRow} />
 
 ## Do’s and Don’ts
 

--- a/packages/core/src/components/Tabs/Tab/__stories__/tab.mdx
+++ b/packages/core/src/components/Tabs/Tab/__stories__/tab.mdx
@@ -13,9 +13,7 @@ import { Controls } from "@storybook/blocks";
 
 ## Overview
 
-<Canvas>
-  <Story of={TabStories.Overview} />
-</Canvas>
+<Canvas of={TabStories.Overview} />
 
 ## Props
 
@@ -25,12 +23,8 @@ import { Controls } from "@storybook/blocks";
 
 ### States
 
-<Canvas>
-  <Story of={TabStories.States} />
-</Canvas>
+<Canvas of={TabStories.States} />
 
 ### Icons
 
-<Canvas>
-  <Story of={TabStories.Icons} />
-</Canvas>
+<Canvas of={TabStories.Icons} />

--- a/packages/core/src/components/Tabs/TabList/__stories__/tab-list.mdx
+++ b/packages/core/src/components/Tabs/TabList/__stories__/tab-list.mdx
@@ -1,4 +1,4 @@
-import { Canvas, Meta, Story } from "@storybook/blocks";
+import { Canvas, Meta } from "@storybook/blocks";
 import * as TabListStories from "./tab-list.stories";
 
 <Meta of={TabListStories} />
@@ -14,9 +14,7 @@ import * as TabListStories from "./tab-list.stories";
 
 TabList is a container of all the tabs headers inside the tabs component
 
-<Canvas>
-  <Story of={TabListStories.Overview} />
-</Canvas>
+<Canvas of={TabListStories.Overview} />
 
 ## Props
 
@@ -26,20 +24,14 @@ TabList is a container of all the tabs headers inside the tabs component
 
 ### Default - compact tabs
 
-<Canvas>
-  <Story of={TabListStories.Default} />
-</Canvas>
+<Canvas of={TabListStories.Default} />
 
 ### Stretched
 
 The width of the list is responsive to the screen's width.
 
-<Canvas>
-  <Story of={TabListStories.Stretched} />
-</Canvas>
+<Canvas of={TabListStories.Stretched} />
 
 ### Sizes
 
-<Canvas>
-  <Story of={TabListStories.Sizes} />
-</Canvas>
+<Canvas of={TabListStories.Sizes} />

--- a/packages/core/src/components/Tabs/TabPanel/__stories__/tab-panel.mdx
+++ b/packages/core/src/components/Tabs/TabPanel/__stories__/tab-panel.mdx
@@ -1,4 +1,4 @@
-import { Canvas, Meta, Story } from "@storybook/blocks";
+import { Canvas, Meta } from "@storybook/blocks";
 import * as TabPanelStories from "./tab-panel.stories";
 
 <Meta of={TabPanelStories} />
@@ -14,9 +14,7 @@ import * as TabPanelStories from "./tab-panel.stories";
 
 Tab panel contains the content of one tab in a Tabs component.
 
-<Canvas>
-  <Story of={TabPanelStories.Overview} />
-</Canvas>
+<Canvas of={TabPanelStories.Overview} />
 
 ## Props
 

--- a/packages/core/src/components/Tabs/TabPanels/__stories__/tab-panels.mdx
+++ b/packages/core/src/components/Tabs/TabPanels/__stories__/tab-panels.mdx
@@ -1,4 +1,4 @@
-import { Canvas, Meta, Story } from "@storybook/blocks";
+import { Canvas, Meta } from "@storybook/blocks";
 import * as TabPanelsStories from "./tab-panels.stories";
 
 <Meta of={TabPanelsStories} />
@@ -14,9 +14,7 @@ import * as TabPanelsStories from "./tab-panels.stories";
 
 The Tab Panels component contains all the content of all the Tabs component's tabs.
 
-<Canvas>
-  <Story of={TabPanelsStories.Overview} />
-</Canvas>
+<Canvas of={TabPanelsStories.Overview} />
 
 ## Props
 

--- a/packages/core/src/components/Tabs/__stories__/tabs.mdx
+++ b/packages/core/src/components/Tabs/__stories__/tabs.mdx
@@ -1,6 +1,6 @@
 import Tab from "../Tab/Tab";
 import TabList from "../TabList/TabList";
-import { Canvas, Meta, Story } from "@storybook/blocks";
+import { Canvas, Meta } from "@storybook/blocks";
 import { Calendar, Chart, Gantt, NavigationChevronDown, NewTab, Table } from "../../Icon/Icons";
 import DialogContentContainer from "../../DialogContentContainer/DialogContentContainer";
 import { UsageGuidelines } from "vibe-storybook-components";
@@ -29,9 +29,7 @@ import { TipButtonGroup } from "./tabs.stories.helpers";
 
 Tabs allow users to navigate between related views of content while remaining in the context of the page.
 
-<Canvas>
-  <Story of={TabsStories.Overview} />
-</Canvas>
+<Canvas of={TabsStories.Overview} />
 
 ## Props
 
@@ -54,25 +52,19 @@ Tabs allow users to navigate between related views of content while remaining in
 
 ### Default - compact tabs
 
-<Canvas>
-  <Story of={TabsStories.Default} />
-</Canvas>
+<Canvas of={TabsStories.Default} />
 
 ### Stretched
 
 The width of the list is responsive to the screen's width.
 
-<Canvas>
-  <Story of={TabsStories.Stretched} />
-</Canvas>
+<Canvas of={TabsStories.Stretched} />
 
 ### Motion
 
 Tabs animation direction
 
-<Canvas>
-  <Story of={TabsStories.Motion} />
-</Canvas>
+<Canvas of={TabsStories.Motion} />
 
 ## Do’s and Don’ts
 
@@ -141,17 +133,13 @@ Tabs animation direction
 
 The tabs are presenting the same content, in a different view.
 
-<Canvas>
-  <Story of={TabsStories.BoardViewsTabs} />
-</Canvas>
+<Canvas of={TabsStories.BoardViewsTabs} />
 
 ### Admin section tabs
 
 In the admin section tabs used to navigate between the different preferences
 
-<Canvas>
-  <Story of={TabsStories.AdminSectionTabs} />
-</Canvas>
+<Canvas of={TabsStories.AdminSectionTabs} />
 
 ## Related components
 

--- a/packages/core/src/components/Text/__stories__/Text.mdx
+++ b/packages/core/src/components/Text/__stories__/Text.mdx
@@ -1,4 +1,4 @@
-import { Canvas, Meta, Story } from "@storybook/blocks";
+import { Canvas, Meta } from "@storybook/blocks";
 import { Tip } from "vibe-storybook-components";
 import Text from "../Text";
 import Flex from "../../Flex/Flex";
@@ -27,9 +27,7 @@ import * as TextStories from "./Text.stories";
 
 The text component serves as a wrapper for applying typography styles to the text it contains.
 
-<Canvas>
-  <Story of={TextStories.Overview} />
-</Canvas>
+<Canvas of={TextStories.Overview} />
 
 <TipHeading />
 
@@ -47,17 +45,13 @@ The text component serves as a wrapper for applying typography styles to the tex
 
 Text component comes in two sizes: text1 (16px) and text2 (14px), and in three weights: bold (700), medium (600) and normal (400)
 
-<Canvas>
-  <Story of={TextStories.SizesAndWeights} />
-</Canvas>
+<Canvas of={TextStories.SizesAndWeights} />
 
 ### Colors
 
 Text component comes in four colors: primary, secondary, on-primary and on-inverted
 
-<Canvas>
-  <Story of={TextStories.Colors} />
-</Canvas>
+<Canvas of={TextStories.Colors} />
 
 ### Overflow
 
@@ -66,9 +60,7 @@ When the text is longer than its container and the ellipsis flag is on, the end 
 
 We support two kinds of ellipsis: single-line ellipsis with a tooltip displayed in hover or ellipsis after multiple lines. You can see examples for both use cases below.
 
-<Canvas>
-  <Story of={TextStories.Overflow} />
-</Canvas>
+<Canvas of={TextStories.Overflow} />
 
 <Tip>Ellipsis prop is true by default. If you wish to turn off ellipsis you can change the prop to false.</Tip>
 
@@ -79,17 +71,13 @@ This changes the text wrapper element to `p`, enabling the creation of paragraph
 The paragraph will receive default top and bottom margins based on browser settings for `p` elements.
 Customize ellipsis behavior using the "ellipsis" prop or override default margins with a custom class name.
 
-<Canvas>
-  <Story of={TextStories.Paragraph} />
-</Canvas>
+<Canvas of={TextStories.Paragraph} />
 
 ### Links
 
 A Text component with a link skin can be used to create a link within running text that redirects to an external webpage, as demonstrated in the following example.
 
-<Canvas>
-  <Story of={TextStories.LinksInsideRunningText} />
-</Canvas>
+<Canvas of={TextStories.LinksInsideRunningText} />
 
 <TipLink />
 

--- a/packages/core/src/components/TextField/__stories__/TextField.mdx
+++ b/packages/core/src/components/TextField/__stories__/TextField.mdx
@@ -1,4 +1,4 @@
-import { Canvas, Meta, Story } from "@storybook/blocks";
+import { Canvas, Meta } from "@storybook/blocks";
 import TextField from "../TextField";
 import { ComponentRules, UsageGuidelines } from "vibe-storybook-components";
 import { COMBOBOX, DROPDOWN, SEARCH } from "../../../storybook/components/related-components/component-description-map";
@@ -21,9 +21,7 @@ import * as TextFieldStories from "./TextField.stories";
 
 An input field includes a label and a text field users can type text into. They typically appear in forms and dialogs.
 
-<Canvas>
-  <Story of={TextFieldStories.Overview} />
-</Canvas>
+<Canvas of={TextFieldStories.Overview} />
 
 ## Props
 
@@ -45,15 +43,11 @@ An input field includes a label and a text field users can type text into. They 
 
 There are three sizes available: Small (32px), Medium (40px) and Large (48px).
 
-<Canvas>
-  <Story of={TextFieldStories.Sizes} />
-</Canvas>
+<Canvas of={TextFieldStories.Sizes} />
 
 ### States
 
-<Canvas>
-  <Story of={TextFieldStories.States} />
-</Canvas>
+<Canvas of={TextFieldStories.States} />
 
 ### Validation
 
@@ -61,9 +55,7 @@ Use validation to give feedback to the user for a case where he has provided an 
 
 <code>The validation object has two status states - error, success</code>
 
-<Canvas>
-  <Story of={TextFieldStories.Validation} />
-</Canvas>
+<Canvas of={TextFieldStories.Validation} />
 
 ## Do’s and Don’ts
 
@@ -123,35 +115,25 @@ Use validation to give feedback to the user for a case where he has provided an 
 
 Users can insert text.
 
-<Canvas>
-  <Story of={TextFieldStories.TextFieldInAForm} />
-</Canvas>
+<Canvas of={TextFieldStories.TextFieldInAForm} />
 
 ### Input field with placeholder text
 
-<Canvas>
-  <Story of={TextFieldStories.InputFieldWithPlaceholderText} />
-</Canvas>
+<Canvas of={TextFieldStories.InputFieldWithPlaceholderText} />
 
 ### Required input field
 
 Use the <code>requiredAsterisk</code> prop to indicate that a field is required. When set to <code>true</code>, an asterisk (\*) will appear next to the label.
 
-<Canvas>
-  <Story of={TextFieldStories.RequiredInputField} />
-</Canvas>
+<Canvas of={TextFieldStories.RequiredInputField} />
 
 ### Input field with date
 
-<Canvas>
-  <Story of={TextFieldStories.InputFieldWithDate} />
-</Canvas>
+<Canvas of={TextFieldStories.InputFieldWithDate} />
 
 ### Input field with datetime
 
-<Canvas>
-  <Story of={TextFieldStories.InputFieldWithDateAndTime} />
-</Canvas>
+<Canvas of={TextFieldStories.InputFieldWithDateAndTime} />
 
 ## Related components
 

--- a/packages/core/src/components/TextWithHighlight/__stories__/TextWithHighlight.mdx
+++ b/packages/core/src/components/TextWithHighlight/__stories__/TextWithHighlight.mdx
@@ -1,4 +1,4 @@
-import { Canvas, Meta, Story } from "@storybook/blocks";
+import { Canvas, Meta } from "@storybook/blocks";
 import {
   EDITABLE_HEADING,
   HEADING,
@@ -20,9 +20,7 @@ import * as TextWithHighlightStories from "./TextWithHighlight.stories";
 
 Component for displaying highlighted text
 
-<Canvas>
-  <Story of={TextWithHighlightStories.Overview} />
-</Canvas>
+<Canvas of={TextWithHighlightStories.Overview} />
 
 ## Props
 

--- a/packages/core/src/components/ThemeProvider/__stories__/ThemeProvider.mdx
+++ b/packages/core/src/components/ThemeProvider/__stories__/ThemeProvider.mdx
@@ -1,4 +1,4 @@
-import { Canvas, Meta, Story } from "@storybook/blocks";
+import { Canvas, Meta } from "@storybook/blocks";
 import {
   DescriptionWithLinkMondaySdkIntegration,
   ThemeProviderNegativeExampleTemplate,
@@ -30,9 +30,7 @@ There are 2 levels of theming: **system theme** and **product theme**.
 System theme is a one of a 3 predefined themes: <code>light</code>(<code>.light-app-theme</code>), <code>dark</code>(<code>.dark-app-theme</code>) and <code>black</code>(<code>.black-app-theme</code>).
 Product theme is a custom theme that can be provided by a user, there you can specify the values of specific color tokens for each of the system themes.
 
-<Canvas>
-  <Story of={ThemeProviderStories.Overview} />
-</Canvas>
+<Canvas of={ThemeProviderStories.Overview} />
 
 ## Props
 
@@ -60,33 +58,25 @@ There are 3 system themes <code>light</code>, <code>dark</code> and <code>black<
 
 Only components wrapped with ThemeProvider will be affected by the <code>themeConfig</code>.
 
-<Canvas>
-  <Story of={ThemeProviderStories.ThemingScope} />
-</Canvas>
+<Canvas of={ThemeProviderStories.ThemingScope} />
 
 ### Folded theming
 
 If component is wrapped with multiple ThemeProviders, the most nested one will override the values of the outer one, but if the nested ThemeProvider doesn't provide a value for a specific color token, the outer ThemeProvider will be used.
 
-<Canvas>
-  <Story of={ThemeProviderStories.FoldedTheming} />
-</Canvas>
+<Canvas of={ThemeProviderStories.FoldedTheming} />
 
 ### Product theming
 
 These are theme-definitions, which are used in monday.com products.
 
-<Canvas>
-  <Story of={ThemeProviderStories.ProductTheming} />
-</Canvas>
+<Canvas of={ThemeProviderStories.ProductTheming} />
 
 ### Custom class selector
 
 If you need to apply some of the tokens overrides only on elements under specific class you can declare theme like that:
 
-<Canvas>
-  <Story of={ThemeProviderStories.CustomClassSelector} />
-</Canvas>
+<Canvas of={ThemeProviderStories.CustomClassSelector} />
 
 ### With systemTheme
 

--- a/packages/core/src/components/Tipseen/__stories__/tipseen.mdx
+++ b/packages/core/src/components/Tipseen/__stories__/tipseen.mdx
@@ -1,4 +1,4 @@
-import { Canvas, Meta, Story } from "@storybook/blocks";
+import { Canvas, Meta } from "@storybook/blocks";
 import { Link } from "vibe-storybook-components";
 import Tipseen from "../Tipseen";
 import TipseenContent from "../TipseenContent";
@@ -31,9 +31,7 @@ import { tipseenTemplate } from "./tipseen.stories";
 
 Tipseen is a virtual unboxing experience that helps users get started with the system and discover new features.
 
-<Canvas>
-  <Story of={TipseenStories.Overview} />
-</Canvas>
+<Canvas of={TipseenStories.Overview} />
 
 ## Props
 
@@ -60,40 +58,30 @@ The inverted type is the default. \
 Use the inverted color for feature discovery, or to give the user general guidance. \
 Use the primary color to bring attention to updates about your product offering.
 
-<Canvas>
-  <Story of={TipseenStories.Colors} />
-</Canvas>
+<Canvas of={TipseenStories.Colors} />
 
 ### Tipseen with a wizard
 
 Use Tipseen with a wizard when you want to teach something in steps.
 
-<Canvas>
-  <Story of={TipseenStories.TipseenWithAWizard} />
-</Canvas>
+<Canvas of={TipseenStories.TipseenWithAWizard} />
 
 ### Tipseen with image
 
-<Canvas>
-  <Story of={TipseenStories.TipseenWithImage} />
-</Canvas>
+<Canvas of={TipseenStories.TipseenWithImage} />
 
 ### Tipseen with custom media
 
 Wrap your custom media with `TipseenMedia` component. This use case is good for when using Lottie animations or other media that is not necessarily an image.
 
-<Canvas>
-  <Story of={TipseenStories.TipseenWithCustomMedia} />
-</Canvas>
+<Canvas of={TipseenStories.TipseenWithCustomMedia} />
 
 ### Floating Tipseen
 
 Use Floating Tipseen in case where the guidance is not relevant to a specific UI element, but general.
 In this case, the Tipseen position will be the right corner of the screen and without an arrow tip.
 
-<Canvas>
-  <Story of={TipseenStories.FloatingTipseen} height={"500px"} />
-</Canvas>
+<Canvas of={TipseenStories.FloatingTipseen} height={"500px"} />
 
 ## Do’s and Don’ts
 

--- a/packages/core/src/components/Toast/__stories__/toast.mdx
+++ b/packages/core/src/components/Toast/__stories__/toast.mdx
@@ -1,4 +1,4 @@
-import { Canvas, Meta, Story } from "@storybook/blocks";
+import { Canvas, Meta } from "@storybook/blocks";
 import { UsageGuidelines } from "vibe-storybook-components";
 import Toast from "../Toast";
 import Flex from "../../Flex/Flex";
@@ -27,9 +27,7 @@ import { TipAlertBanner } from "./toast.stories.helpers";
 
 A toast notification is a message object that presents timely information, including confirmation of actions, alerts, and errors.
 
-<Canvas>
-  <Story of={ToastStories.Overview} />
-</Canvas>
+<Canvas of={ToastStories.Overview} />
 
 ## Props
 
@@ -53,49 +51,35 @@ A toast notification is a message object that presents timely information, inclu
 
 ### Default with button
 
-<Canvas>
-  <Story of={ToastStories.DefaultWithButton} />
-</Canvas>
+<Canvas of={ToastStories.DefaultWithButton} />
 
 ### Toast with link
 
-<Canvas>
-  <Story of={ToastStories.ToastWithLink} />
-</Canvas>
+<Canvas of={ToastStories.ToastWithLink} />
 
 ### Toast with loading
 
-<Canvas>
-  <Story of={ToastStories.ToastWithLoading} />
-</Canvas>
+<Canvas of={ToastStories.ToastWithLoading} />
 
 ### Success message
 
 Use to providing a feedback loop. For example: Item copied.
 
-<Canvas>
-  <Story of={ToastStories.SuccessMessage} />
-</Canvas>
+<Canvas of={ToastStories.SuccessMessage} />
 
 ### Error message
 
 Use when something was deleted, a problem has occurred, etc.
 
-<Canvas>
-  <Story of={ToastStories.ErrorMessage} />
-</Canvas>
+<Canvas of={ToastStories.ErrorMessage} />
 
 ### Warning message
 
-<Canvas>
-  <Story of={ToastStories.WarningMessage} />
-</Canvas>
+<Canvas of={ToastStories.WarningMessage} />
 
 ### Dark message
 
-<Canvas>
-  <Story of={ToastStories.DarkMessage} />
-</Canvas>
+<Canvas of={ToastStories.DarkMessage} />
 
 ## Do’s and Don’ts
 
@@ -168,9 +152,7 @@ Use when something was deleted, a problem has occurred, etc.
 
 After a user has done an action, provide feedback to close the loop. For example, when an item has been deleted, duplicated, etc.
 
-<Canvas>
-  <Story of={ToastStories.FeedbackLoop} />
-</Canvas>
+<Canvas of={ToastStories.FeedbackLoop} />
 
 ## Related components
 

--- a/packages/core/src/components/Toggle/__stories__/toggle.mdx
+++ b/packages/core/src/components/Toggle/__stories__/toggle.mdx
@@ -1,4 +1,4 @@
-import { Canvas, Meta, Story } from "@storybook/blocks";
+import { Canvas, Meta } from "@storybook/blocks";
 import Toggle from "../Toggle";
 import {
   BUTTON_GROUP,
@@ -27,9 +27,7 @@ import "./toggle.stories.scss";
 
 Allow users to turn an single option on or off. They are usually used to activate or deactivate a specific setting.
 
-<Canvas>
-  <Story of={ToggleStories.Overview} />
-</Canvas>
+<Canvas of={ToggleStories.Overview} />
 
 ## Props
 
@@ -55,15 +53,11 @@ Allow users to turn an single option on or off. They are usually used to activat
 
 ### States
 
-<Canvas>
-  <Story of={ToggleStories.States} />
-</Canvas>
+<Canvas of={ToggleStories.States} />
 
 ### Disabled
 
-<Canvas>
-  <Story of={ToggleStories.Disabled} />
-</Canvas>
+<Canvas of={ToggleStories.Disabled} />
 
 ## Do’s and Don’ts
 
@@ -117,9 +111,7 @@ Allow users to turn an single option on or off. They are usually used to activat
 
 In the automations center, a user can turn the automation on or off.
 
-<Canvas>
-  <Story of={ToggleStories.TurnOnOffAnAutomation} />
-</Canvas>
+<Canvas of={ToggleStories.TurnOnOffAnAutomation} />
 
 ## Related components
 

--- a/packages/core/src/components/Tooltip/__stories__/tooltip.mdx
+++ b/packages/core/src/components/Tooltip/__stories__/tooltip.mdx
@@ -1,5 +1,5 @@
 import Tooltip from "../Tooltip";
-import { Canvas, Meta, Story } from "@storybook/blocks";
+import { Canvas, Meta } from "@storybook/blocks";
 import { Bolt } from "../../Icon/Icons";
 import Icon from "../../Icon/Icon";
 import Button from "../../Button/Button";
@@ -26,9 +26,7 @@ import { TipOtherComponents } from "./tooltip.stories.helpers";
 
 Tooltips show contextual help or information about specific components when a user hovers on them.
 
-<Canvas>
-  <Story of={TooltipStories.Overview} />
-</Canvas>
+<Canvas of={TooltipStories.Overview} />
 
 ## Props
 
@@ -51,17 +49,13 @@ Tooltips show contextual help or information about specific components when a us
 
 Tooltip’s arrow can appear from top, bottom, left or right.
 
-<Canvas>
-  <Story of={TooltipStories.Positions} />
-</Canvas>
+<Canvas of={TooltipStories.Positions} />
 
 ### Themes
 
 Tooltip’s arrow can have various themes.
 
-<Canvas>
-  <Story of={TooltipStories.Themes} />
-</Canvas>
+<Canvas of={TooltipStories.Themes} />
 
 ## Do’s and Don’ts
 
@@ -96,25 +90,19 @@ Tooltip’s arrow can have various themes.
 
 An icon tooltip is used to clarify the action or name of an interactive icon button. Provide tooltips for all unlabelled icons.
 
-<Canvas>
-  <Story of={TooltipStories.IconTooltip} />
-</Canvas>
+<Canvas of={TooltipStories.IconTooltip} />
 
 ### Definition tooltip
 
 The definition tooltip provides additional help or defines an item or term. It may be used on the label of a UI element, or on a word embedded in a paragraph.
 
-<Canvas>
-  <Story of={TooltipStories.DefinitionTooltip} />
-</Canvas>
+<Canvas of={TooltipStories.DefinitionTooltip} />
 
 ### Immediate tooltips
 
 Immediately show when another is shown. The two left tooltips uses the immediate show prop, the right one ignores it and should always have show delay.
 
-<Canvas>
-  <Story of={TooltipStories.ImmediateTooltips} />
-</Canvas>
+<Canvas of={TooltipStories.ImmediateTooltips} />
 
 ## Related components
 

--- a/packages/core/src/components/VirtualizedGrid/__stories__/VirtualizedGrid.mdx
+++ b/packages/core/src/components/VirtualizedGrid/__stories__/VirtualizedGrid.mdx
@@ -1,4 +1,4 @@
-import { Canvas, Meta, Story } from "@storybook/blocks";
+import { Canvas, Meta } from "@storybook/blocks";
 import { UsageGuidelines } from "vibe-storybook-components";
 import * as VirtualizedGridStories from "./VirtualizedGrid.stories";
 
@@ -17,9 +17,7 @@ VirtualizedGrid is a component which only renders visible grid items, it is a lo
 
 Under the hood we are using - [react-window](https://github.com/bvaughn/react-window) and [react-virtualized-auto-sizer](https://github.com/bvaughn/react-virtualized-auto-sizer)
 
-<Canvas>
-  <Story of={VirtualizedGridStories.Overview} />
-</Canvas>
+<Canvas of={VirtualizedGridStories.Overview} />
 
 ## Props
 

--- a/packages/core/src/components/VirtualizedList/__stories__/VirtualizedList.mdx
+++ b/packages/core/src/components/VirtualizedList/__stories__/VirtualizedList.mdx
@@ -1,4 +1,4 @@
-import { Canvas, Meta, Story } from "@storybook/blocks";
+import { Canvas, Meta } from "@storybook/blocks";
 import { UsageGuidelines } from "vibe-storybook-components";
 import { TipItemRenderer } from "./virtualizedList.stories.helpers";
 import * as VirtualizedListStories from "./VirtualizedList.stories";
@@ -20,9 +20,7 @@ The VirtualizedList can be Vertical or Horizontal
 
 Under the hood we are using - [react-window](https://github.com/bvaughn/react-window) and [react-virtualized-auto-sizer](https://github.com/bvaughn/react-virtualized-auto-sizer)
 
-<Canvas>
-  <Story of={VirtualizedListStories.Overview} />
-</Canvas>
+<Canvas of={VirtualizedListStories.Overview} />
 
 ## Props
 

--- a/packages/core/src/hooks/useActiveDescendantListFocus/__stories__/useActiveDescendantListFocus.mdx
+++ b/packages/core/src/hooks/useActiveDescendantListFocus/__stories__/useActiveDescendantListFocus.mdx
@@ -1,4 +1,4 @@
-import { Canvas, Meta, Story } from "@storybook/blocks";
+import { Canvas, Meta } from "@storybook/blocks";
 import { FunctionArgument, FunctionArguments, UnstyledList, UnstyledListItem } from "vibe-storybook-components";
 import * as UseActiveDescendantListFocusStories from "./useActiveDescendantListFocus.stories";
 
@@ -34,9 +34,7 @@ import * as UseActiveDescendantListFocusStories from "./useActiveDescendantListF
   </UnstyledListItem>
 </UnstyledList>
 
-<Canvas>
-  <Story of={UseActiveDescendantListFocusStories.Overview} />
-</Canvas>
+<Canvas of={UseActiveDescendantListFocusStories.Overview} />
 
 ## Arguments
 

--- a/packages/core/src/hooks/useAfterFirstRender/__stories__/useAfterFirstRender.mdx
+++ b/packages/core/src/hooks/useAfterFirstRender/__stories__/useAfterFirstRender.mdx
@@ -1,4 +1,4 @@
-import { Canvas, Meta, Story } from "@storybook/blocks";
+import { Canvas, Meta } from "@storybook/blocks";
 import { FunctionArgument, FunctionArguments, UsageGuidelines } from "vibe-storybook-components";
 import * as UseAfterFirstRenderStories from "./useAfterFirstRender.stories";
 
@@ -15,9 +15,7 @@ import * as UseAfterFirstRenderStories from "./useAfterFirstRender.stories";
 
 Use this hook to track whether the page has been rendered at least once.
 
-<Canvas>
-  <Story of={UseAfterFirstRenderStories.Overview} />
-</Canvas>
+<Canvas of={UseAfterFirstRenderStories.Overview} />
 
 ## Returns
 

--- a/packages/core/src/hooks/useClickOutside/__stories__/useClickOutside.mdx
+++ b/packages/core/src/hooks/useClickOutside/__stories__/useClickOutside.mdx
@@ -1,4 +1,4 @@
-import { Canvas, Meta, Story } from "@storybook/blocks";
+import { Canvas, Meta } from "@storybook/blocks";
 import { FunctionArgument, FunctionArguments, Link, UsageGuidelines } from "vibe-storybook-components";
 import * as UseClickOutsideStories from "./useClickOutside.stories";
 
@@ -15,9 +15,7 @@ import * as UseClickOutsideStories from "./useClickOutside.stories";
 
 This hook is used when you want to capture click events outside your component.
 
-<Canvas>
-  <Story of={UseClickOutsideStories.Overview} />
-</Canvas>
+<Canvas of={UseClickOutsideStories.Overview} />
 
 ## Arguments
 

--- a/packages/core/src/hooks/useClickableProps/__stories__/useClickableProps.mdx
+++ b/packages/core/src/hooks/useClickableProps/__stories__/useClickableProps.mdx
@@ -1,4 +1,4 @@
-import { Canvas, Meta, Story } from "@storybook/blocks";
+import { Canvas, Meta } from "@storybook/blocks";
 import { Link } from "vibe-storybook-components";
 import { TipClickable } from "./useClickableProps.stories.helpers";
 import * as UseClickablePropsStories from "./useClickableProps.stories";
@@ -16,9 +16,7 @@ import * as UseClickablePropsStories from "./useClickableProps.stories";
 
 Return props for making an element or component clickable by mouse and keyboard with screen reader support.
 
-<Canvas>
-  <Story of={UseClickablePropsStories.Overview} />
-</Canvas>
+<Canvas of={UseClickablePropsStories.Overview} />
 
 <TipClickable />
 

--- a/packages/core/src/hooks/useDebounceEvent/__stories__/useDebounceEvent.mdx
+++ b/packages/core/src/hooks/useDebounceEvent/__stories__/useDebounceEvent.mdx
@@ -1,4 +1,4 @@
-import { Canvas, Meta, Story } from "@storybook/blocks";
+import { Canvas, Meta } from "@storybook/blocks";
 import { FunctionArgument, FunctionArguments } from "vibe-storybook-components";
 import * as UseDebounceEventStories from "./useDebounceEvent.stories";
 
@@ -17,9 +17,7 @@ import * as UseDebounceEventStories from "./useDebounceEvent.stories";
 
 This hook generates an easy to use debounced value updater.
 
-<Canvas>
-  <Story of={UseDebounceEventStories.Overview} />
-</Canvas>
+<Canvas of={UseDebounceEventStories.Overview} />
 
 ## Arguments
 
@@ -69,18 +67,12 @@ This hook generates an easy to use debounced value updater.
 
 ### Passing an initial value
 
-<Canvas>
-  <Story of={UseDebounceEventStories.PassingAnInitialValue} />
-</Canvas>
+<Canvas of={UseDebounceEventStories.PassingAnInitialValue} />
 
 ### Passing an `onChange` handler
 
-<Canvas>
-  <Story of={UseDebounceEventStories.PassingAnOnChangeHandler} />
-</Canvas>
+<Canvas of={UseDebounceEventStories.PassingAnOnChangeHandler} />
 
 ### Trimming the value
 
-<Canvas>
-  <Story of={UseDebounceEventStories.WithTrim} />
-</Canvas>
+<Canvas of={UseDebounceEventStories.WithTrim} />

--- a/packages/core/src/hooks/useDisableScroll/__stories__/useDisableScroll.mdx
+++ b/packages/core/src/hooks/useDisableScroll/__stories__/useDisableScroll.mdx
@@ -1,4 +1,4 @@
-import { Canvas, Meta, Story } from "@storybook/blocks";
+import { Canvas, Meta } from "@storybook/blocks";
 import { FunctionArgument, FunctionArguments, UsageGuidelines } from "vibe-storybook-components";
 import * as UseDisableScrollStories from "./useDisableScroll.stories";
 
@@ -15,9 +15,7 @@ import * as UseDisableScrollStories from "./useDisableScroll.stories";
 
 Use this hook to disable scroll for element.
 
-<Canvas>
-  <Story of={UseDisableScrollStories.Overview} />
-</Canvas>
+<Canvas of={UseDisableScrollStories.Overview} />
 
 ## Returns
 

--- a/packages/core/src/hooks/useEventListener/__stories__/useEventListener.mdx
+++ b/packages/core/src/hooks/useEventListener/__stories__/useEventListener.mdx
@@ -1,4 +1,4 @@
-import { Story, Canvas, Meta } from "@storybook/blocks";
+import { Canvas, Meta } from "@storybook/blocks";
 import * as UseEventListenerStories from "./useEventListener.stories";
 
 <Meta of={UseEventListenerStories} />
@@ -13,9 +13,7 @@ import * as UseEventListenerStories from "./useEventListener.stories";
 
 Attaches a listener to any DOM event on a specific element, firing a provided callback when the event is triggered.
 
-<Canvas>
-  <Story of={UseEventListenerStories.Overview} />
-</Canvas>
+<Canvas of={UseEventListenerStories.Overview} />
 
 ## Arguments
 

--- a/packages/core/src/hooks/useGridKeyboardNavigation/__stories__/useGridKeyboardNavigation.mdx
+++ b/packages/core/src/hooks/useGridKeyboardNavigation/__stories__/useGridKeyboardNavigation.mdx
@@ -1,4 +1,4 @@
-import { Canvas, Meta, Story } from "@storybook/blocks";
+import { Canvas, Meta } from "@storybook/blocks";
 import { action } from "@storybook/addon-actions";
 import "./useGridKeyboardNavigation.stories.scss";
 import * as UseGridKeyboardNavigationStories from "./useGridKeyboardNavigation.stories";
@@ -22,9 +22,7 @@ export const PADDING_PX = 24;
 
 export const ON_CLICK = action("item selected");
 
-<Canvas>
-  <Story of={UseGridKeyboardNavigationStories.Overview} />
-</Canvas>
+<Canvas of={UseGridKeyboardNavigationStories.Overview} />
 
 ## Usage
 

--- a/packages/core/src/hooks/useHover/__stories__/useHover.mdx
+++ b/packages/core/src/hooks/useHover/__stories__/useHover.mdx
@@ -1,4 +1,4 @@
-import { Canvas, Meta, Story } from "@storybook/blocks";
+import { Canvas, Meta } from "@storybook/blocks";
 import { Link, UsageGuidelines } from "vibe-storybook-components";
 import * as UseHoverStories from "./useHover.stories";
 
@@ -15,9 +15,7 @@ import * as UseHoverStories from "./useHover.stories";
 
 Detect whether the mouse is hovering an element by returning its <code>isHovered</code> state.
 
-<Canvas>
-  <Story of={UseHoverStories.Overview} />
-</Canvas>
+<Canvas of={UseHoverStories.Overview} />
 
 ## Usage
 

--- a/packages/core/src/hooks/useIsOverflowing/__stories__/useIsOverflowing.mdx
+++ b/packages/core/src/hooks/useIsOverflowing/__stories__/useIsOverflowing.mdx
@@ -1,4 +1,4 @@
-import { Canvas, Meta, Story } from "@storybook/blocks";
+import { Canvas, Meta } from "@storybook/blocks";
 import { FunctionArgument, FunctionArguments, Link } from "vibe-storybook-components";
 import { TipTooltip } from "./useIsOverflowing.stories.helpers";
 import * as UseIsOverflowingStories from "./useIsOverflowing.stories";
@@ -16,9 +16,7 @@ import * as UseIsOverflowingStories from "./useIsOverflowing.stories";
 
 Use this hook, when there is a chance that content won't fit into the container, to track if overflow occurs.
 
-<Canvas>
-  <Story of={UseIsOverflowingStories.Overview} />
-</Canvas>
+<Canvas of={UseIsOverflowingStories.Overview} />
 
 ## Usage
 

--- a/packages/core/src/hooks/useKeyEvent/__stories__/useKeyEvent.mdx
+++ b/packages/core/src/hooks/useKeyEvent/__stories__/useKeyEvent.mdx
@@ -1,4 +1,4 @@
-import { Canvas, Meta, Story } from "@storybook/blocks";
+import { Canvas, Meta } from "@storybook/blocks";
 import { FunctionArgument, FunctionArguments, UsageGuidelines } from "vibe-storybook-components";
 import * as UseKeyEventStories from "./useKeyEvent.stories";
 
@@ -16,9 +16,7 @@ import * as UseKeyEventStories from "./useKeyEvent.stories";
 
 Attaches a listener to keyboard DOM events on a specific element, firing a provided callback when the event is triggered.
 
-<Canvas>
-  <Story of={UseKeyEventStories.Overview} />
-</Canvas>
+<Canvas of={UseKeyEventStories.Overview} />
 
 ## Arguments
 

--- a/packages/core/src/hooks/useListenFocusTriggers/__stories__/useListenFocusTriggers.mdx
+++ b/packages/core/src/hooks/useListenFocusTriggers/__stories__/useListenFocusTriggers.mdx
@@ -1,4 +1,4 @@
-import { Canvas, Meta, Story } from "@storybook/blocks";
+import { Canvas, Meta } from "@storybook/blocks";
 import { FunctionArgument, FunctionArguments, Link, UsageGuidelines } from "vibe-storybook-components";
 import * as UseListenFocusTriggersStories from "./useListenFocusTriggers.stories";
 
@@ -16,9 +16,7 @@ import * as UseListenFocusTriggersStories from "./useListenFocusTriggers.stories
 
 Fire provided callbacks, when focus by mouse or by keyboard happens.
 
-<Canvas>
-  <Story of={UseListenFocusTriggersStories.Overview} />
-</Canvas>
+<Canvas of={UseListenFocusTriggersStories.Overview} />
 
 ## Arguments
 

--- a/packages/core/src/hooks/useMediaQuery/__stories__/useMediaQuery.mdx
+++ b/packages/core/src/hooks/useMediaQuery/__stories__/useMediaQuery.mdx
@@ -1,4 +1,4 @@
-import { Canvas, Meta, Story } from "@storybook/blocks";
+import { Canvas, Meta } from "@storybook/blocks";
 import * as UseMediaQueryStories from "./useMediaQuery.stories";
 
 <Meta of={UseMediaQueryStories} />
@@ -14,13 +14,9 @@ import * as UseMediaQueryStories from "./useMediaQuery.stories";
 
 This hook helps maps if a media query is matched or not
 
-<Canvas>
-  <Story of={UseMediaQueryStories.SingleRule} />
-</Canvas>
+<Canvas of={UseMediaQueryStories.SingleRule} />
 
-<Canvas>
-  <Story of={UseMediaQueryStories.MultipleRules} />
-</Canvas>
+<Canvas of={UseMediaQueryStories.MultipleRules} />
 
 ## Arguments
 

--- a/packages/core/src/hooks/usePrevious/__stories__/usePrevious.mdx
+++ b/packages/core/src/hooks/usePrevious/__stories__/usePrevious.mdx
@@ -1,4 +1,4 @@
-import { Canvas, Meta, Story } from "@storybook/blocks";
+import { Canvas, Meta } from "@storybook/blocks";
 import { FunctionArgument, FunctionArguments } from "vibe-storybook-components";
 import * as UsePreviousStories from "./usePrevious.stories";
 
@@ -15,9 +15,7 @@ import * as UsePreviousStories from "./usePrevious.stories";
 
 Hook for keeping previous state value.
 
-<Canvas>
-  <Story of={UsePreviousStories.Overview} />
-</Canvas>
+<Canvas of={UsePreviousStories.Overview} />
 
 ## Arguments
 

--- a/packages/core/src/hooks/useSetFocus/__stories__/useSetFocus.mdx
+++ b/packages/core/src/hooks/useSetFocus/__stories__/useSetFocus.mdx
@@ -1,4 +1,4 @@
-import { Canvas, Meta, Story } from "@storybook/blocks";
+import { Canvas, Meta } from "@storybook/blocks";
 import { FunctionArgument, FunctionArguments } from "vibe-storybook-components";
 import * as UseSetFocusStories from "./useSetFocus.stories";
 
@@ -15,9 +15,7 @@ import * as UseSetFocusStories from "./useSetFocus.stories";
 
 Hook for controlling focus on specific component e.g. Input.
 
-<Canvas>
-  <Story of={UseSetFocusStories.Overview} />
-</Canvas>
+<Canvas of={UseSetFocusStories.Overview} />
 
 ## Arguments
 

--- a/packages/core/src/hooks/useSwitch/__stories__/useSwitch.mdx
+++ b/packages/core/src/hooks/useSwitch/__stories__/useSwitch.mdx
@@ -1,4 +1,4 @@
-import { Canvas, Meta, Story } from "@storybook/blocks";
+import { Canvas, Meta } from "@storybook/blocks";
 import { FunctionArgument, FunctionArguments } from "vibe-storybook-components";
 import * as UseSwitchStories from "./useSwitch.stories";
 
@@ -16,9 +16,7 @@ import * as UseSwitchStories from "./useSwitch.stories";
 
 Hook for controlling boolean state on components, e.g. Toggle, by exposing state and a handler
 
-<Canvas>
-  <Story of={UseSwitchStories.Overview} />
-</Canvas>
+<Canvas of={UseSwitchStories.Overview} />
 
 ## Variants
 
@@ -26,17 +24,13 @@ Hook for controlling boolean state on components, e.g. Toggle, by exposing state
 
 Hook can have argument of `isDisabled` to not allow trigger `onChange` (or the custom passed `onChange`) and change returned `isChecked` value.
 
-<Canvas>
-  <Story of={UseSwitchStories.Disabled} />
-</Canvas>
+<Canvas of={UseSwitchStories.Disabled} />
 
 ### Default (initial) value
 
 Hook can have argument of `defaultChecked` to control the **_initial_** value returned from it.
 
-<Canvas>
-  <Story of={UseSwitchStories.Default} />
-</Canvas>
+<Canvas of={UseSwitchStories.Default} />
 
 ## Arguments
 

--- a/packages/core/src/hooks/useTimeout/__stories__/useTimeout.mdx
+++ b/packages/core/src/hooks/useTimeout/__stories__/useTimeout.mdx
@@ -1,4 +1,4 @@
-import { Canvas, Meta, Story } from "@storybook/blocks";
+import { Canvas, Meta } from "@storybook/blocks";
 import { FunctionArgument, FunctionArguments } from "vibe-storybook-components";
 import * as UseTimeoutStories from "./useTimeout.stories";
 
@@ -15,9 +15,7 @@ import * as UseTimeoutStories from "./useTimeout.stories";
 
 Use this hook when you need to perform an action with timeout, this hook will cancel the timeout when the component unmounts.
 
-<Canvas>
-  <Story of={UseTimeoutStories.Overview} />
-</Canvas>
+<Canvas of={UseTimeoutStories.Overview} />
 
 ## Arguments
 

--- a/packages/core/src/hooks/useVibeMediaQuery/__stories__/useVibeMediaQuery.mdx
+++ b/packages/core/src/hooks/useVibeMediaQuery/__stories__/useVibeMediaQuery.mdx
@@ -1,4 +1,4 @@
-import { Canvas, Meta, Story } from "@storybook/blocks";
+import { Canvas, Meta } from "@storybook/blocks";
 import { FunctionArgument, FunctionArguments } from "vibe-storybook-components";
 import { TableMediaQuery } from "./useVibeMediaQuery.stories.helpers";
 import * as UseVibeMediaQueryStories from "./useVibeMediaQuery.stories";
@@ -18,9 +18,7 @@ This hook will return the value of the current vibe break point
 
 <TableMediaQuery />
 
-<Canvas>
-  <Story of={UseVibeMediaQueryStories.Overview} />
-</Canvas>
+<Canvas of={UseVibeMediaQueryStories.Overview} />
 
 ## Arguments
 


### PR DESCRIPTION
Storybook deprecates the `<Story of` syntax
also, this PR is a prerequisite step to achieve the Edit mode inside our stories in the Docs page