### PR TITLE
chore(Tab): allow accepting children of a single ReactElement

### DIFF
--- a/packages/core/src/components/Tabs/Tab/Tab.tsx
+++ b/packages/core/src/components/Tabs/Tab/Tab.tsx
@@ -30,7 +30,7 @@ export interface TabProps extends VibeComponentProps {
   /**
    * Tab link-name
    */
-  children?: string | ReactElement[];
+  children?: string | ReactElement | ReactElement[];
 }
 
 const Tab: FC<TabProps> = forwardRef(

--- a/packages/core/src/components/Tabs/Tab/Tab.tsx
+++ b/packages/core/src/components/Tabs/Tab/Tab.tsx
@@ -70,11 +70,13 @@ const Tab: FC<TabProps> = forwardRef(
         />
       );
 
+      const childrenArray = React.Children.toArray(children);
+
       if (iconSide === "left") {
-        return [iconElement, ...children];
+        return [iconElement, ...childrenArray];
       }
 
-      return [...children, iconElement];
+      return [...childrenArray, iconElement];
     }
     return (
       <li

--- a/packages/core/src/components/Tabs/Tab/__tests__/__snapshots__/tab-snapshot-tests.jest.js.snap
+++ b/packages/core/src/components/Tabs/Tab/__tests__/__snapshots__/tab-snapshot-tests.jest.js.snap
@@ -121,9 +121,7 @@ exports[`Tab renders correctly with icon on left 1`] = `
         fillRule="evenodd"
       />
     </svg>
-    T
-    a
-    b
+    Tab
   </a>
 </li>
 `;
@@ -140,9 +138,7 @@ exports[`Tab renders correctly with icon on right 1`] = `
     className="tabInner"
     onClick={[Function]}
   >
-    T
-    a
-    b
+    Tab
     <svg
       aria-hidden={true}
       className="icon tabIcon right noFocusStyle"


### PR DESCRIPTION
https://monday.monday.com/boards/3532714909/pulses/6391046217

Was requested in support channel, doesn't seem like it makes sense not to accept a single `ReactElement` here