### PR TITLE
fix(DatePicker): added min width to buttons inside year picker

### DIFF
--- a/packages/core/src/components/DatePicker/YearPicker/YearPicker.module.scss
+++ b/packages/core/src/components/DatePicker/YearPicker/YearPicker.module.scss
@@ -38,6 +38,10 @@
     position: absolute;
     top: 55px;
     pointer-events: all;
+
+    Button {
+      min-width: 66px;
+    }
   }
 
   :global(.CalendarYear--blocked) {

--- a/packages/core/src/components/DatePicker/YearPicker/YearPicker.module.scss
+++ b/packages/core/src/components/DatePicker/YearPicker/YearPicker.module.scss
@@ -39,7 +39,7 @@
     top: 55px;
     pointer-events: all;
 
-    Button {
+    .pickerOption {
       min-width: 66px;
     }
   }

--- a/packages/core/src/components/DatePicker/YearPicker/YearsList.tsx
+++ b/packages/core/src/components/DatePicker/YearPicker/YearsList.tsx
@@ -1,4 +1,5 @@
 import Button from "../../Button/Button";
+import styles from "./YearPicker.module.scss";
 
 // eslint-disable-next-line @typescript-eslint/no-empty-function
 const NOOP = () => {};
@@ -19,7 +20,15 @@ const YearsList = ({ yearsItems, isYearBlocked, onSelect, selectedYear }: YearsL
         const kind = parseInt(selectedYear, 10) === currYear ? Button?.kinds?.PRIMARY : Button?.kinds?.TERTIARY;
 
         return (
-          <Button key={currYear} kind={kind} onClick={onClick} disabled={shouldBlockYear} marginLeft marginRight>
+          <Button
+            className={styles.pickerOption}
+            key={currYear}
+            kind={kind}
+            onClick={onClick}
+            disabled={shouldBlockYear}
+            marginLeft
+            marginRight
+          >
             {currYear.toString()}
           </Button>
         );


### PR DESCRIPTION
This bug happened since some of the years' widths are shorter than others (mostly years that start with 1), so the fix is to set a min width to the years' button

https://monday.monday.com/boards/3532714909/pulses/6234283969